### PR TITLE
fix: exclude cycle recipient from payment tracking

### DIFF
--- a/app/api/test/reset/route.ts
+++ b/app/api/test/reset/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { MOCK_PAYMENTS } from '@/lib/mock-data';
+
+const g = globalThis as typeof globalThis & { __circlePayments?: unknown[] };
+
+// Dev-only endpoint — resets in-memory payment store to fixture data.
+// Used by E2E tests to guarantee a clean, deterministic starting state.
+export async function POST() {
+  if (process.env.NODE_ENV === 'production') {
+    return NextResponse.json({ error: 'Not available in production' }, { status: 403 });
+  }
+  g.__circlePayments = [...MOCK_PAYMENTS];
+  return NextResponse.json({ ok: true, count: MOCK_PAYMENTS.length });
+}

--- a/app/api/test/reset/route.ts
+++ b/app/api/test/reset/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { MOCK_PAYMENTS } from '@/lib/mock-data';
+import type { Payment } from '@/lib/types';
 
-const g = globalThis as typeof globalThis & { __circlePayments?: unknown[] };
+const g = globalThis as typeof globalThis & { __circlePayments?: Payment[] };
 
 // Dev-only endpoint — resets in-memory payment store to fixture data.
 // Used by E2E tests to guarantee a clean, deterministic starting state.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default async function DashboardPage() {
     ? deriveCycleSummary(activeCycle, members, payments)
     : null;
   const paymentStatuses = activeCycle
-    ? getMemberPaymentStatuses(members, payments, activeCycle.id)
+    ? getMemberPaymentStatuses(members, payments, activeCycle.id, activeCycle.recipientMemberId)
     : [];
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ export default async function DashboardPage() {
         <div className="mt-8 space-y-6">
           {activeCycleSummary && (
             <KpiStats
-              totalKobo={activeCycleSummary.cycle.totalAmount}
+              totalKobo={activeCycleSummary.totalMembers * activeCycleSummary.cycle.contributionPerMember}
               collectedKobo={activeCycleSummary.collectedKobo}
               paidCount={activeCycleSummary.paidCount}
               totalMembers={activeCycleSummary.totalMembers}

--- a/components/dashboard/active-cycle-card.tsx
+++ b/components/dashboard/active-cycle-card.tsx
@@ -55,7 +55,7 @@ export function ActiveCycleCard({ summary }: ActiveCycleCardProps) {
         <section aria-label="Collection progress">
           <CollectionProgress
             collectedKobo={collectedKobo}
-            totalKobo={cycle.totalAmount}
+            totalKobo={totalMembers * cycle.contributionPerMember}
             paidCount={paidCount}
             totalMembers={totalMembers}
           />

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -36,7 +36,6 @@ export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber 
       <TableCell className="w-10 py-3 pl-4">
         <span
           className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-medium tabular-nums text-muted-foreground"
-          aria-hidden="true"
         >
           {rowNumber}
         </span>

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -8,6 +8,7 @@ interface MemberPaymentRowProps {
   status: MemberPaymentStatus;
   cycleId: number;
   contributionKobo: number;
+  rowNumber: number;
 }
 
 function formatPhone(phone: string): string {
@@ -27,7 +28,7 @@ function formatPaymentDate(isoDate: string): string {
   });
 }
 
-export function MemberPaymentRow({ status, cycleId, contributionKobo }: MemberPaymentRowProps) {
+export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber }: MemberPaymentRowProps) {
   const { member, hasPaid, payment } = status;
 
   return (
@@ -35,9 +36,9 @@ export function MemberPaymentRow({ status, cycleId, contributionKobo }: MemberPa
       <TableCell className="w-10 py-3 pl-4">
         <span
           className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-medium tabular-nums text-muted-foreground"
-          aria-label={`Position ${member.position}`}
+          aria-hidden="true"
         >
-          {member.position}
+          {rowNumber}
         </span>
       </TableCell>
 

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -105,12 +105,13 @@ export function SortablePaymentTable({
         </TableHeader>
         <TableBody>
           {sorted.length > 0 ? (
-            sorted.map(status => (
+            sorted.map((status, i) => (
               <MemberPaymentRow
                 key={status.member.id}
                 status={status}
                 cycleId={cycleId}
                 contributionKobo={contributionKobo}
+                rowNumber={i + 1}
               />
             ))
           ) : (

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -44,8 +44,8 @@ export const MOCK_CYCLES: Cycle[] = [
 ];
 
 // Cycles 1 & 2: fully paid (all 6 members)
-// Cycle 3: 4 of 6 paid — Tunde (id 4) and Seun (id 6) outstanding
-// Progress: ₦40,000 of ₦60,000 collected
+// Cycle 3: Ngozi (id 3) is the recipient — she does not pay in this cycle.
+// Of the 5 contributing members: 3 paid, 2 outstanding (Tunde id 4, Seun id 6)
 export const MOCK_PAYMENTS: Payment[] = [
   // Cycle 1 — January 2026 (fully paid)
   { id: 5,  memberId: 1, cycleId: 1, amount: 1_000_000, currency: 'NGN', paymentDate: '2026-01-02' },
@@ -61,9 +61,8 @@ export const MOCK_PAYMENTS: Payment[] = [
   { id: 14, memberId: 4, cycleId: 2, amount: 1_000_000, currency: 'NGN', paymentDate: '2026-02-06' },
   { id: 15, memberId: 5, cycleId: 2, amount: 1_000_000, currency: 'NGN', paymentDate: '2026-02-07' },
   { id: 16, memberId: 6, cycleId: 2, amount: 1_000_000, currency: 'NGN', paymentDate: '2026-02-09' },
-  // Cycle 3 — March 2026 (4 of 6 paid)
+  // Cycle 3 — March 2026 (3 of 5 contributing members paid; Ngozi excluded as recipient)
   { id: 1, memberId: 1, cycleId: 3, amount: 1_000_000, currency: 'NGN', paymentDate: '2026-03-02' },
   { id: 2, memberId: 2, cycleId: 3, amount: 1_000_000, currency: 'NGN', paymentDate: '2026-03-03' },
-  { id: 3, memberId: 3, cycleId: 3, amount: 1_000_000, currency: 'NGN', paymentDate: '2026-03-05' },
   { id: 4, memberId: 5, cycleId: 3, amount: 1_000_000, currency: 'NGN', paymentDate: '2026-03-07' },
 ];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -18,6 +18,7 @@ export function getMemberPaymentStatuses(
   members: Member[],
   payments: Payment[],
   cycleId: number,
+  recipientMemberId: number,
 ): MemberPaymentStatus[] {
   const paymentsByMember = new Map(
     payments
@@ -26,7 +27,7 @@ export function getMemberPaymentStatuses(
   );
 
   return members
-    .filter(m => m.status === 'active')
+    .filter(m => m.status === 'active' && m.id !== recipientMemberId)
     .sort((a, b) => a.position - b.position)
     .map(member => {
       const payment = paymentsByMember.get(member.id) ?? null;
@@ -43,14 +44,18 @@ export function deriveCycleSummary(
   if (!recipient) throw new Error(`Recipient member ${cycle.recipientMemberId} not found`);
 
   const activeMembers = members.filter(m => m.status === 'active');
-  const cyclePayments = payments.filter(p => p.cycleId === cycle.id);
+  // The recipient collects the pot this cycle — they are not expected to pay in.
+  // All counts and totals exclude them so the UI doesn't show them as a payer.
+  const contributingMembers = activeMembers.filter(m => m.id !== cycle.recipientMemberId);
+  const cyclePayments = payments
+    .filter(p => p.cycleId === cycle.id && p.memberId !== cycle.recipientMemberId);
   const collectedKobo = cyclePayments.reduce((sum, p) => sum + p.amount, 0);
 
   return {
     cycle,
     recipient,
     paidCount: cyclePayments.length,
-    totalMembers: activeMembers.length,
+    totalMembers: contributingMembers.length,
     collectedKobo,
   };
 }

--- a/tests/regression.spec.ts
+++ b/tests/regression.spec.ts
@@ -28,8 +28,14 @@
 
 import { test, expect } from '@playwright/test';
 
+// Serial mode prevents parallel workers from racing on the shared mutable
+// in-memory payment store — each test must fully complete its reset before
+// the next one starts.
+test.describe.configure({ mode: 'serial' });
+
 test.beforeEach(async ({ page }) => {
-  await page.request.post('/api/test/reset');
+  const resetResponse = await page.request.post('/api/test/reset');
+  expect(resetResponse.ok()).toBeTruthy();
   await page.goto('/');
   await page.waitForLoadState('networkidle');
 });
@@ -68,14 +74,14 @@ test.describe('Sequential row numbers', () => {
     const rows = table.locator('tbody tr');
 
     for (let i = 1; i <= 5; i++) {
-      const numberCell = rows.nth(i - 1).locator('td').first().locator('span[aria-hidden="true"]');
+      const numberCell = rows.nth(i - 1).locator('td').first().locator('span.tabular-nums');
       await expect(numberCell).toHaveText(String(i));
     }
   });
 
   test('row numbers do not skip (no gap at position 3 where recipient was)', async ({ page }) => {
     const table = page.locator('table[aria-label*="Cycle 3"]');
-    const numberCells = table.locator('tbody tr td:first-child span[aria-hidden="true"]');
+    const numberCells = table.locator('tbody tr td:first-child span.tabular-nums');
     const texts = await numberCells.allInnerTexts();
     expect(texts).toEqual(['1', '2', '3', '4', '5']);
   });

--- a/tests/regression.spec.ts
+++ b/tests/regression.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression tests for Circle Dashboard business logic.
+ *
+ * These tests lock in the correct behaviour after each bug fix so that
+ * future features cannot silently regress core rules:
+ *
+ *   1. Recipient exclusion — the member collecting this cycle is excluded
+ *      from the payment table and all contribution-based calculations.
+ *   2. Sequential row numbers — table rows are numbered 1…N regardless of
+ *      the member's position in the rotation order.
+ *   3. KPI accuracy — Total Pot, Collected, and Outstanding all reflect the
+ *      5 contributing members, not the full 6-member group.
+ *   4. Progress bar accuracy — the fill width and aria-valuenow match the
+ *      ratio of paid contributing members.
+ *   5. Outstanding alert — lists only the specific members who have not paid,
+ *      excluding the recipient.
+ *
+ * Mock data state (after reset):
+ *   Cycle 3 (active): Ngozi Adeyemi is the recipient.
+ *   Contributing members (5): Adaeze, Chukwuemeka, Tunde, Amaka, Seun
+ *   Paid (3): Adaeze (01 Mar), Chukwuemeka (03 Mar), Amaka (07 Mar)
+ *   Outstanding (2): Tunde Bakare, Seun Okafor
+ *   Contribution per member: ₦10,000 (1,000,000 kobo)
+ *   Total Pot: ₦50,000 (5 × ₦10,000)
+ *   Collected: ₦30,000 (3 × ₦10,000)
+ *   Outstanding: ₦20,000 (2 × ₦10,000)
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.request.post('/api/test/reset');
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+});
+
+// ---------------------------------------------------------------------------
+// 1. Recipient exclusion
+// ---------------------------------------------------------------------------
+
+test.describe('Recipient exclusion', () => {
+  test('Ngozi Adeyemi does not appear in the payment table', async ({ page }) => {
+    const table = page.locator('table[aria-label*="Cycle 3"]');
+    await expect(table).toBeVisible();
+    await expect(table.getByText('Ngozi Adeyemi')).not.toBeVisible();
+  });
+
+  test('payment table shows exactly 5 rows (5 contributing members)', async ({ page }) => {
+    const table = page.locator('table[aria-label*="Cycle 3"]');
+    const rows = table.locator('tbody tr');
+    await expect(rows).toHaveCount(5);
+  });
+
+  test('Ngozi does not appear in the outstanding alert', async ({ page }) => {
+    const alert = page.locator('[role="alert"][aria-label*="outstanding"]');
+    await expect(alert).toBeVisible();
+    await expect(alert.getByText('Ngozi Adeyemi')).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Sequential row numbers
+// ---------------------------------------------------------------------------
+
+test.describe('Sequential row numbers', () => {
+  test('first cell of each row is numbered 1 through 5 in order', async ({ page }) => {
+    const table = page.locator('table[aria-label*="Cycle 3"]');
+    const rows = table.locator('tbody tr');
+
+    for (let i = 1; i <= 5; i++) {
+      const numberCell = rows.nth(i - 1).locator('td').first().locator('span[aria-hidden="true"]');
+      await expect(numberCell).toHaveText(String(i));
+    }
+  });
+
+  test('row numbers do not skip (no gap at position 3 where recipient was)', async ({ page }) => {
+    const table = page.locator('table[aria-label*="Cycle 3"]');
+    const numberCells = table.locator('tbody tr td:first-child span[aria-hidden="true"]');
+    const texts = await numberCells.allInnerTexts();
+    expect(texts).toEqual(['1', '2', '3', '4', '5']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. KPI accuracy
+// ---------------------------------------------------------------------------
+
+test.describe('KPI card accuracy', () => {
+  test('Total Pot shows ₦50,000 (5 contributing members × ₦10,000)', async ({ page }) => {
+    const region = page.getByRole('region', { name: 'Cycle summary statistics' });
+    const totalPotCard = region.locator('[data-slot="card"]').filter({ hasText: 'Total Pot' });
+    await expect(totalPotCard.getByText('₦50,000')).toBeVisible();
+    await expect(totalPotCard.getByText('5 members')).toBeVisible();
+  });
+
+  test('Collected shows ₦30,000 (3 of 5 paid)', async ({ page }) => {
+    const region = page.getByRole('region', { name: 'Cycle summary statistics' });
+    const collectedCard = region.locator('[data-slot="card"]').filter({ hasText: 'Collected' });
+    await expect(collectedCard.getByText('₦30,000')).toBeVisible();
+    await expect(collectedCard.getByText('3 of 5 paid')).toBeVisible();
+  });
+
+  test('Outstanding shows ₦20,000 (2 members pending)', async ({ page }) => {
+    const region = page.getByRole('region', { name: 'Cycle summary statistics' });
+    const outstandingCard = region.locator('[data-slot="card"]').filter({ hasText: 'Outstanding' });
+    await expect(outstandingCard.getByText('₦20,000')).toBeVisible();
+    await expect(outstandingCard.getByText('2 members pending')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Progress bar accuracy
+// ---------------------------------------------------------------------------
+
+test.describe('Progress bar accuracy', () => {
+  test('aria-valuenow is 60 (3 of 5 contributing members paid)', async ({ page }) => {
+    const bar = page.locator('[role="progressbar"]').first();
+    const ariaValue = await bar.getAttribute('aria-valuenow');
+    expect(Number(ariaValue)).toBe(60);
+  });
+
+  test('progress bar fill width is 60%', async ({ page }) => {
+    const bar = page.locator('[role="progressbar"]').first();
+    const fill = bar.locator(':scope > div').first();
+    const width = await fill.evaluate((el) => (el as HTMLElement).style.width);
+    expect(width).toBe('60%');
+  });
+
+  test('progress bar summary text shows "3 of 5 members paid"', async ({ page }) => {
+    const progressSection = page.locator('section[aria-label="Collection progress"]');
+    await expect(progressSection.getByText('3 of 5 members paid')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Outstanding alert
+// ---------------------------------------------------------------------------
+
+test.describe('Outstanding alert', () => {
+  test('alert shows 2 outstanding payments', async ({ page }) => {
+    const alert = page.locator('[role="alert"][aria-label*="outstanding"]');
+    await expect(alert).toBeVisible();
+    await expect(alert.getByText('2 outstanding payments')).toBeVisible();
+  });
+
+  test('Tunde Bakare appears in the outstanding alert', async ({ page }) => {
+    const alert = page.locator('[role="alert"][aria-label*="outstanding"]');
+    await expect(alert.getByText('Tunde Bakare')).toBeVisible();
+  });
+
+  test('Seun Okafor appears in the outstanding alert', async ({ page }) => {
+    const alert = page.locator('[role="alert"][aria-label*="outstanding"]');
+    await expect(alert.getByText('Seun Okafor')).toBeVisible();
+  });
+
+  test('each outstanding entry shows ₦10,000 owed', async ({ page }) => {
+    const alert = page.locator('[role="alert"][aria-label*="outstanding"]');
+    const owedItems = alert.getByText('₦10,000 owed');
+    await expect(owedItems).toHaveCount(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Active cycle card
+// ---------------------------------------------------------------------------
+
+test.describe('Active cycle card', () => {
+  test('shows Cycle 3 heading', async ({ page }) => {
+    const cardHeading = page.getByRole('heading', { name: /Cycle 3/i }).first();
+    await expect(cardHeading).toBeVisible();
+  });
+
+  test('shows Ngozi Adeyemi as the recipient', async ({ page }) => {
+    const recipientSection = page.locator('section[aria-label="Recipient information"]');
+    await expect(recipientSection.getByText('Ngozi Adeyemi')).toBeVisible();
+  });
+
+  test('shows recipient position #3', async ({ page }) => {
+    const recipientSection = page.locator('section[aria-label="Recipient information"]');
+    await expect(recipientSection.getByText('Position #3')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Payment toggle — state updates flow back to KPIs and progress bar
+// ---------------------------------------------------------------------------
+
+test.describe('Payment toggle integration', () => {
+  test('marking Tunde as paid updates collected count to 4 of 5', async ({ page }) => {
+    const table = page.locator('table[aria-label*="Cycle 3"]');
+    const tundeRow = table.locator('tr').filter({ hasText: 'Tunde Bakare' });
+
+    // Click the "Mark paid" button on Tunde's row
+    const markPaidBtn = tundeRow.getByRole('button', { name: 'Mark as paid' });
+    await markPaidBtn.click();
+
+    // Wait for server action + page revalidation
+    await page.waitForLoadState('networkidle');
+
+    // KPI should now reflect 4 of 5 paid
+    const region = page.getByRole('region', { name: 'Cycle summary statistics' });
+    const collectedCard = region.locator('[data-slot="card"]').filter({ hasText: 'Collected' });
+    await expect(collectedCard.getByText('4 of 5 paid')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -14,6 +14,11 @@ import { test, expect } from '@playwright/test';
 
 const SCREENSHOTS_DIR = path.join(__dirname, 'screenshots');
 
+// Serial mode prevents parallel workers from racing on the shared mutable
+// in-memory payment store — each test must fully complete its reset before
+// the next one starts.
+test.describe.configure({ mode: 'serial' });
+
 /** Returns the computed background-color of the first element matching the selector. */
 async function computedBg(page: import('@playwright/test').Page, selector: string): Promise<string> {
   return page.locator(selector).first().evaluate(
@@ -27,7 +32,8 @@ async function computedBg(page: import('@playwright/test').Page, selector: strin
 
 test.describe('Visual — light mode', () => {
   test.beforeEach(async ({ page }) => {
-    await page.request.post('/api/test/reset');
+    const resetResponse = await page.request.post('/api/test/reset');
+    expect(resetResponse.ok()).toBeTruthy();
     await page.emulateMedia({ colorScheme: 'light' });
     await page.goto('/');
     await page.waitForLoadState('networkidle');
@@ -111,7 +117,8 @@ test.describe('Visual — light mode', () => {
 
 test.describe('Visual — dark mode', () => {
   test.beforeEach(async ({ page }) => {
-    await page.request.post('/api/test/reset');
+    const resetResponse = await page.request.post('/api/test/reset');
+    expect(resetResponse.ok()).toBeTruthy();
     await page.emulateMedia({ colorScheme: 'dark' });
     await page.goto('/');
     await page.waitForLoadState('networkidle');

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -27,6 +27,7 @@ async function computedBg(page: import('@playwright/test').Page, selector: strin
 
 test.describe('Visual — light mode', () => {
   test.beforeEach(async ({ page }) => {
+    await page.request.post('/api/test/reset');
     await page.emulateMedia({ colorScheme: 'light' });
     await page.goto('/');
     await page.waitForLoadState('networkidle');
@@ -110,6 +111,7 @@ test.describe('Visual — light mode', () => {
 
 test.describe('Visual — dark mode', () => {
   test.beforeEach(async ({ page }) => {
+    await page.request.post('/api/test/reset');
     await page.emulateMedia({ colorScheme: 'dark' });
     await page.goto('/');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary

In an Ajo, the member collecting this cycle does not pay into their own pot — they receive it. The recipient was previously appearing in the payment status table and outstanding payments alert alongside regular contributors.

- `getMemberPaymentStatuses` now takes `recipientMemberId` and filters that member out — they no longer appear in the table or the outstanding alert
- `deriveCycleSummary` excludes the recipient from `totalMembers`, `paidCount`, and `collectedKobo` so KPI tiles, progress bar, and sub-labels all reflect only the contributions that are actually expected
- `app/page.tsx` passes `activeCycle.recipientMemberId` to the function
- Removed the erroneous Cycle 3 payment for Ngozi from mock data (she is the Cycle 3 recipient — the entry should not exist) and updated the comment

No UI components needed changing — they all consume the corrected data from the two utility functions.

## Test plan

- [x] `npm run build` — clean, no type errors
- [x] `npm run test:e2e` — 32/32 passing
- [x] Visual check: Ngozi should appear in "Collecting this cycle" but not in the payment table or outstanding alert