### PR TITLE
chore: fix .gitignore accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,6 @@
 
 # dependencies
 /node_modules
-/.pnp
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/versions
 
 # testing
 /coverage
@@ -26,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+.playwright-mcp/
 
 # debug
 npm-debug.log*
@@ -33,8 +27,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
+# env files — allow .env.example to be committed
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary

- Remove Yarn Berry patterns (`.pnp`, `.pnp.*`, `.yarn/*`) — project uses Yarn Classic v1, these are template noise
- Add `!.env.example` — `.env*` glob was too broad and would block `git add .env.example` on a fresh clone
- Add `.playwright-mcp/` — local MCP config dir was untracked and leaking into git status