### PR TITLE
chore: remove Google Sheets references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,3 @@
 # Required in production/preview deployments.
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
-# Google Sheets spreadsheet ID (future — not yet wired).
-# The dashboard currently uses lib/mock-data.ts.
-# SPREADSHEET_ID=your_spreadsheet_id_here

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Open [http://localhost:3000](http://localhost:3000) (or whichever port Next.js a
 
 | Variable | Required | Description | Example |
 |----------|----------|-------------|---------|
-| `SPREADSHEET_ID` | No | Google Sheets ID for the live data source (not yet wired — mock data used by default) | `1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms` |
+| `NEXT_PUBLIC_BASE_URL` | No | Base URL for internal `/api/*` fetches. Required in production/preview deployments. | `https://your-app.vercel.app` |
+| `BACKEND_URL` | No | URL of the Rust/SurrealDB backend. Defaults to `http://localhost:8080` in development. | `http://localhost:8080` |
 <!-- /AUTO-GENERATED -->
 
 ---
@@ -87,7 +88,7 @@ circle-dashboard/
 
 All monetary amounts are stored in **kobo** (NGN × 100) as integers to avoid floating-point errors. Use `formatNgn(kobo)` to display as `₦10,000`.
 
-The dashboard is **read-only**. The API routes currently serve `lib/mock-data.ts`. Swap to a real data source (Google Sheets, Supabase, etc.) by updating `app/api/*/route.ts` — the component layer requires no changes.
+The dashboard is **read-only**. The API routes proxy to the Rust/SurrealDB backend via `BACKEND_URL`. The component layer is decoupled from the data source — swap backends by updating `lib/data.ts` only.
 
 ---
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -26,17 +26,17 @@ The app is healthy if `GET /` returns HTTP 200. No dedicated health endpoint yet
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
 | `NEXT_PUBLIC_BASE_URL` | No | `http://localhost:3000` | Base URL for internal `/api/*` fetches |
-| `SPREADSHEET_ID` | No | — | Google Sheets ID (future data source) |
+| `BACKEND_URL` | No | `http://localhost:8080` | URL of the Rust/SurrealDB backend |
 
 ## Data Source
 
-The dashboard reads from `lib/data.ts`, which directly imports mock data from `lib/mock-data.ts`:
+The dashboard reads from `lib/data.ts`, which proxies to the Rust/SurrealDB backend via `BACKEND_URL`:
 
-- `fetchMembers()` → returns `Member[]` from `MOCK_MEMBERS`
-- `fetchCycles()` → returns `Cycle[]` from `MOCK_CYCLES`
-- `fetchPayments()` → returns `Payment[]` from store via `getPayments()`
+- `fetchMembers()` → `GET {BACKEND_URL}/api/members` → `Member[]`
+- `fetchCycles()` → `GET {BACKEND_URL}/api/cycles` → `Cycle[]`
+- `fetchPayments()` → `GET {BACKEND_URL}/api/payments` → `Payment[]`
 
-No HTTP fetch or port dependency. To wire a real data source, update `lib/data.ts` to fetch from an API or database instead of importing mock data. The component layer requires no changes.
+Ensure the Rust backend is running before starting the Next.js dev server. The component layer requires no changes if the backend URL is updated.
 
 ## Common Issues
 


### PR DESCRIPTION
## Summary

- Remove `SPREADSHEET_ID` env var from `.env.example`, `README.md`, and `docs/RUNBOOK.md` — Google Sheets was never wired in and is superseded by the Rust/SurrealDB backend
- Update env var docs to reflect actual variables in use (`NEXT_PUBLIC_BASE_URL`, `BACKEND_URL`)
- Update Data Source sections in README and RUNBOOK to describe the live Rust backend proxy flow instead of mock data