### PR TITLE
feat: table redesign — card layout with inline overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ circle-dashboard/
 ├── app/
 │   ├── layout.tsx              # Root layout — Geist font, dark mode, metadata
 │   ├── page.tsx                # Dashboard page — server component, fetches + composes
+│   ├── loading.tsx             # Loading skeleton with card layout
+│   ├── error.tsx               # Error boundary for dashboard
 │   ├── globals.css             # Tailwind v4 + shadcn tokens + Ajo accent colours
 │   └── api/
 │       ├── members/route.ts    # GET /api/members  → Member[]
@@ -66,20 +68,27 @@ circle-dashboard/
 │   │   ├── payment-status-grid.tsx       # Table/chart toggle card
 │   │   ├── cycle-performance-chart.tsx   # Per-cycle + cumulative chart toggle
 │   │   ├── sortable-payment-table.tsx    # Sortable table with member search
+│   │   ├── member-payment-row.tsx        # Card-based layout with phone formatting + date display
 │   │   ├── kpi-stats.tsx                 # KPI stat tiles
 │   │   ├── payment-toggle-button.tsx     # Server action toggle for payment status
-│   │   └── outstanding-alert.tsx         # role=alert listing unpaid members
+│   │   ├── outstanding-alert.tsx         # role=alert listing unpaid members
+│   │   └── theme-toggle.tsx              # Light/dark mode toggle
+│   ├── theme-provider.tsx                # next-themes wrapper
 │   └── ui/                               # shadcn/ui primitives (auto-generated)
 │
 ├── lib/
 │   ├── types.ts        # Domain types: Member, Payment, Cycle, derived view types
 │   ├── mock-data.ts    # 6-member demo dataset (cycle 3 active, 4/6 paid)
-│   ├── utils.ts        # koboToNgn, formatNgn, getMemberPaymentStatuses, deriveCycleSummary
-│   └── data.ts         # Direct data access helpers (imports from store/mock-data)
+│   ├── utils.ts        # Formatting (formatNgn, formatPhone, formatPaymentDate, padZero) + data derivation
+│   ├── config.ts       # Configuration (BACKEND_URL, NEXT_PUBLIC_BASE_URL)
+│   ├── data.ts         # Data fetching layer (proxies to Rust/SurrealDB backend)
+│   ├── store.ts        # In-memory store (mock/test mode)
+│   └── actions.ts      # Server actions (payment toggle)
 │
 └── tests/
-    ├── pages/dashboard.page.ts  # Page Object Model for dashboard
-    └── dashboard.spec.ts        # E2E tests — toggle flows, chart rendering, tooltips
+    ├── dashboard.spec.ts       # E2E tests — toggle flows, chart rendering, tooltips
+    ├── pages/dashboard.page.ts # Page Object Model for dashboard
+    └── screenshots/            # Visual regression baselines (gitignored)
 ```
 
 ---
@@ -100,4 +109,4 @@ All components meet **WCAG 2.2 AA**. Tested with Playwright E2E tests:
 yarn test:e2e
 ```
 
-Key requirements met: semantic `<table>`, `role="progressbar"` with aria attrs, `role="alert"` on outstanding banner, status badges use text (not colour alone), visible focus rings, full keyboard navigation.
+Key requirements met: semantic `<table>`, `role="progressbar"` with aria attrs, `role="alert"` on outstanding banner, status badges use text (not colour alone), visible focus rings, full keyboard navigation, proper dark mode contrast in all states.

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,19 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
+@keyframes row-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-20px) scale(0.96);
+    filter: blur(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+    filter: blur(0);
+  }
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -50,23 +50,77 @@ function CycleCardSkeleton() {
   );
 }
 
+function OutstandingAlertSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-4 w-4 rounded shrink-0" />
+        <Skeleton className="h-4 w-36" />
+      </div>
+      <div className="space-y-2 pl-6">
+        {[0, 1].map(i => (
+          <div key={i} className="flex items-center justify-between gap-4">
+            <Skeleton className="h-3.5 w-28" />
+            <Skeleton className="h-3.5 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function PaymentGridSkeleton() {
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">
-      <div className="p-5 pb-3 space-y-1">
-        <Skeleton className="h-4 w-32" />
-        <Skeleton className="h-3 w-16" />
+      {/* Card header — title + subtitle + toggle */}
+      <div className="px-5 pt-5 pb-3 flex items-start justify-between">
+        <div className="space-y-1.5">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-14" />
+        </div>
+        <Skeleton className="h-7 w-16 rounded-md" />
       </div>
 
-      <div className="px-4 pb-2 space-y-px">
-        {[0, 1, 2, 3, 4, 5].map(i => (
-          <div key={i} className="flex items-center justify-between py-3 gap-3">
-            <Skeleton className="h-6 w-6 rounded-full shrink-0" />
-            <div className="flex-1 space-y-1.5">
+      {/* Search bar */}
+      <div className="px-4 pt-1 pb-2">
+        <Skeleton className="h-8 w-full rounded-md" />
+      </div>
+
+      {/* Column headers */}
+      <div className="grid gap-x-4 px-8 py-2 [grid-template-columns:2rem_1fr_8rem] sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]">
+        <Skeleton className="h-2.5 w-5" />
+        <Skeleton className="h-2.5 w-14" />
+        <Skeleton className="hidden sm:block h-2.5 w-10" />
+        <Skeleton className="hidden sm:block h-2.5 w-8" />
+        <Skeleton className="h-2.5 w-10 ml-auto" />
+      </div>
+
+      {/* Card rows */}
+      <div className="px-4 pb-4 space-y-2">
+        {[0, 1, 2, 3, 4].map(i => (
+          <div
+            key={i}
+            className="rounded-xl border border-border/50 bg-muted/50 grid items-center gap-x-4 px-4 py-3.5
+              [grid-template-columns:2rem_1fr_8rem]
+              sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]"
+          >
+            {/* Row number */}
+            <Skeleton className="h-6 w-6" />
+
+            {/* Name + stacked phone (mobile) */}
+            <div className="min-w-0 space-y-1.5">
               <Skeleton className="h-3.5 w-28" />
-              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-3 w-20 sm:hidden" />
             </div>
-            <Skeleton className="h-5 w-16 rounded-full shrink-0" />
+
+            {/* Phone — sm+ only */}
+            <Skeleton className="hidden sm:block h-3 w-24" />
+
+            {/* Date — sm+ only */}
+            <Skeleton className="hidden sm:block h-3 w-12" />
+
+            {/* Status badge */}
+            <Skeleton className="h-7 w-20 rounded-lg ml-auto" />
           </div>
         ))}
       </div>
@@ -78,7 +132,7 @@ export default function DashboardLoading() {
   return (
     <div className="min-h-screen bg-background">
       <main className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8" aria-busy="true" aria-label="Loading dashboard">
-        {/* Header skeleton */}
+        {/* Header */}
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-2">
             <div className="flex items-center gap-2">
@@ -95,10 +149,14 @@ export default function DashboardLoading() {
         <div className="mt-8 space-y-6">
           <KpiSkeleton />
 
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_1.4fr]">
+          {/* CycleCard + OutstandingAlert — mirrors the sm:grid-cols-2 layout in page.tsx */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <CycleCardSkeleton />
-            <PaymentGridSkeleton />
+            <OutstandingAlertSkeleton />
           </div>
+
+          {/* Full-width payment table */}
+          <PaymentGridSkeleton />
         </div>
       </main>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,30 +40,28 @@ export default async function DashboardPage() {
             />
           )}
 
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_1.4fr]">
-            <div className="space-y-4">
-              {activeCycleSummary && (
-                <ActiveCycleCard summary={activeCycleSummary} />
-              )}
-              {activeCycle && (
-                <OutstandingAlert
-                  statuses={paymentStatuses}
-                  contributionPerMemberKobo={activeCycle.contributionPerMember}
-                />
-              )}
-            </div>
-
-            {paymentStatuses.length > 0 && activeCycle && (
-              <PaymentStatusGrid
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {activeCycleSummary && (
+              <ActiveCycleCard summary={activeCycleSummary} />
+            )}
+            {activeCycle && (
+              <OutstandingAlert
                 statuses={paymentStatuses}
-                cycleId={activeCycle.id}
-                cycleNumber={activeCycle.cycleNumber}
-                contributionKobo={activeCycle.contributionPerMember}
-                cycles={cycles}
-                payments={payments}
+                contributionPerMemberKobo={activeCycle.contributionPerMember}
               />
             )}
           </div>
+
+          {paymentStatuses.length > 0 && activeCycle && (
+            <PaymentStatusGrid
+              statuses={paymentStatuses}
+              cycleId={activeCycle.id}
+              cycleNumber={activeCycle.cycleNumber}
+              contributionKobo={activeCycle.contributionPerMember}
+              cycles={cycles}
+              payments={payments}
+            />
+          )}
         </div>
       </main>
     </div>

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { CheckCircle2 } from 'lucide-react';
-import { formatPhone, formatPaymentDate } from '@/lib/utils';
+import { memo } from 'react';
+import { formatPhone, formatPaymentDate, padZero } from '@/lib/utils';
+import { PaymentStatusBadge } from '@/components/dashboard/payment-status-badge';
 import type { MemberPaymentStatus } from '@/lib/types';
 
 interface MemberPaymentRowProps {
@@ -21,7 +22,7 @@ interface MemberPaymentRowProps {
 */
 export const GRID = '[grid-template-columns:2rem_1fr_8rem] sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]';
 
-export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentRowProps) {
+export const MemberPaymentRow = memo(function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentRowProps) {
   const { member, hasPaid, payment } = status;
 
   return (
@@ -30,7 +31,12 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
       tabIndex={0}
       aria-label={`View details for ${member.name}`}
       onClick={onSelect}
-      onKeyDown={e => e.key === 'Enter' && onSelect()}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
       style={{ animationDelay: `${(rowNumber - 1) * 80}ms` }}
       className={`relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden
         cursor-pointer hover:brightness-95
@@ -49,7 +55,7 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
       <div className={`relative grid items-center gap-x-4 px-4 py-3.5 ${GRID}`}>
 
         <span className="text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
-          {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
+          {padZero(rowNumber)}
         </span>
 
         <div className="min-w-0">
@@ -66,18 +72,9 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
         </span>
 
         <div className="flex justify-end">
-          {hasPaid ? (
-            <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
-              <span className="text-ajo-paid text-sm font-medium">Paid</span>
-              <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
-            </div>
-          ) : (
-            <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
-              <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
-            </div>
-          )}
+          <PaymentStatusBadge hasPaid={hasPaid} variant="row" />
         </div>
       </div>
     </div>
   );
-}
+});

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -56,13 +56,18 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
             {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
           </span>
 
-          {/* Member info — name and phone are separate lines; more fields can be added here */}
+          {/* Name — on mobile also shows phone stacked below */}
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
-            <p className="text-xs text-muted-foreground">{formatPhone(member.phone)}</p>
+            <p className="text-xs text-muted-foreground sm:hidden">{formatPhone(member.phone)}</p>
           </div>
 
-          {/* Date + status badge only */}
+          {/* Phone — own column on sm+, hidden on mobile (shown stacked above) */}
+          <p className="hidden sm:block w-36 shrink-0 text-xs text-muted-foreground tabular-nums">
+            {formatPhone(member.phone)}
+          </p>
+
+          {/* Date + status badge */}
           <div className="flex items-center gap-3 ml-auto shrink-0">
             {hasPaid && payment?.paymentDate && (
               <span className="hidden sm:inline text-xs text-muted-foreground tabular-nums">

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -51,37 +51,41 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
         />
 
         {/*
-          Grid columns:
-            mobile  — [number | name+phone | badge]
-            sm+     — [number | name | phone | date | badge]
-          Hidden elements are display:none so they don't consume grid tracks on mobile.
+          Outer 3 columns: [number] [middle: member/phone/date] [badge]
+          Middle sub-grid on sm+: [name (capped)] [phone] [date]
+          On mobile, middle shows name with phone stacked below.
         */}
         <div className="relative grid items-center gap-x-3 px-4 py-3.5
-          [grid-template-columns:2rem_minmax(0,1fr)_auto]
-          sm:[grid-template-columns:2rem_minmax(0,1fr)_9rem_5rem_auto]">
+          [grid-template-columns:2rem_1fr_auto]">
 
-          {/* Number */}
+          {/* Col 1 — number */}
           <span className="text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
             {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
           </span>
 
-          {/* Name — phone stacked below on mobile only */}
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
-            <p className="text-xs text-muted-foreground sm:hidden">{formatPhone(member.phone)}</p>
+          {/* Col 2 — member / phone / date */}
+          <div className="grid min-w-0 gap-x-3
+            [grid-template-columns:1fr]
+            sm:[grid-template-columns:minmax(0,9rem)_9rem_5rem]">
+
+            {/* Name — phone stacked below on mobile */}
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
+              <p className="text-xs text-muted-foreground sm:hidden">{formatPhone(member.phone)}</p>
+            </div>
+
+            {/* Phone (sm+) */}
+            <p className="hidden sm:block text-xs text-muted-foreground tabular-nums self-center truncate">
+              {formatPhone(member.phone)}
+            </p>
+
+            {/* Date (sm+) — always rendered to hold the grid track */}
+            <span className="hidden sm:block text-xs text-muted-foreground tabular-nums self-center">
+              {hasPaid && payment?.paymentDate ? formatPaymentDate(payment.paymentDate) : ''}
+            </span>
           </div>
 
-          {/* Phone — own column on sm+; hidden on mobile */}
-          <p className="hidden sm:block text-xs text-muted-foreground tabular-nums truncate">
-            {formatPhone(member.phone)}
-          </p>
-
-          {/* Date — own column on sm+; always rendered to keep grid alignment */}
-          <span className="hidden sm:block text-xs text-muted-foreground tabular-nums">
-            {hasPaid && payment?.paymentDate ? formatPaymentDate(payment.paymentDate) : ''}
-          </span>
-
-          {/* Status badge — sole element at the far right */}
+          {/* Col 3 — status badge at far right */}
           {hasPaid ? (
             <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
               <span className="text-ajo-paid text-sm font-medium">Paid</span>

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -1,29 +1,13 @@
 'use client';
 
 import { CheckCircle2 } from 'lucide-react';
+import { formatPhone, formatPaymentDate } from '@/lib/utils';
 import type { MemberPaymentStatus } from '@/lib/types';
 
 interface MemberPaymentRowProps {
   status: MemberPaymentStatus;
   rowNumber: number;
   onSelect: () => void;
-}
-
-function formatPhone(phone: string): string {
-  // "2348101234567" → "+234 810 123 4567"
-  const digits = phone.replace(/\D/g, '');
-  if (digits.length === 13 && digits.startsWith('234')) {
-    return `+234 ${digits.slice(3, 6)} ${digits.slice(6, 9)} ${digits.slice(9)}`;
-  }
-  return `+${digits}`;
-}
-
-function formatPaymentDate(isoDate: string): string {
-  const [year, month, day] = isoDate.split('-').map(Number);
-  return new Date(year, month - 1, day).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-  });
 }
 
 /*
@@ -35,72 +19,65 @@ function formatPaymentDate(isoDate: string): string {
   Hidden items (phone/date on mobile) don't consume grid tracks, so
   the mobile 3-col template always sees exactly 3 items.
 */
-const GRID = '[grid-template-columns:2rem_1fr_8rem] sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]';
+export const GRID = '[grid-template-columns:2rem_1fr_8rem] sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]';
 
 export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentRowProps) {
   const { member, hasPaid, payment } = status;
 
   return (
-    <>
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`View details for ${member.name}`}
+      onClick={onSelect}
+      onKeyDown={e => e.key === 'Enter' && onSelect()}
+      style={{ animationDelay: `${(rowNumber - 1) * 80}ms` }}
+      className={`relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden
+        cursor-pointer hover:brightness-95
+        animate-[row-slide-in_0.4s_ease-out_both]`}
+    >
+      {/* Right-anchored status gradient */}
       <div
-        role="button"
-        tabIndex={0}
-        aria-label={`View details for ${member.name}`}
-        onClick={() => onSelect()}
-        onKeyDown={e => e.key === 'Enter' && onSelect()}
-        style={{ animationDelay: `${(rowNumber - 1) * 80}ms` }}
-        className={`relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden
-          cursor-pointer hover:brightness-95
-          animate-[row-slide-in_0.4s_ease-out_both]`}
-      >
-        {/* Status gradient — right-anchored */}
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            background: hasPaid
-              ? 'linear-gradient(to left, oklch(0.696 0.17 162.48 / 0.10) 0%, transparent 40%)'
-              : 'linear-gradient(to left, oklch(0.769 0.188 70.08 / 0.10) 0%, transparent 40%)',
-          }}
-        />
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background: hasPaid
+            ? 'linear-gradient(to left, oklch(0.696 0.17 162.48 / 0.10) 0%, transparent 40%)'
+            : 'linear-gradient(to left, oklch(0.769 0.188 70.08 / 0.10) 0%, transparent 40%)',
+        }}
+      />
 
-        <div className={`relative grid items-center gap-x-4 px-4 py-3.5 ${GRID}`}>
+      <div className={`relative grid items-center gap-x-4 px-4 py-3.5 ${GRID}`}>
 
-          {/* NO */}
-          <span className="text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
-            {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
-          </span>
+        <span className="text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
+          {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
+        </span>
 
-          {/* MEMBER — phone stacked below on mobile */}
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
-            <p className="text-xs text-muted-foreground sm:hidden">{formatPhone(member.phone)}</p>
-          </div>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
+          <p className="text-xs text-muted-foreground sm:hidden">{formatPhone(member.phone)}</p>
+        </div>
 
-          {/* PHONE — sm+ only */}
-          <p className="hidden sm:block text-xs text-muted-foreground tabular-nums truncate">
-            {formatPhone(member.phone)}
-          </p>
+        <p className="hidden sm:block text-xs text-muted-foreground tabular-nums truncate">
+          {formatPhone(member.phone)}
+        </p>
 
-          {/* DATE — sm+ only; always rendered to hold the grid track */}
-          <span className="hidden sm:block text-xs text-muted-foreground tabular-nums">
-            {hasPaid && payment?.paymentDate ? formatPaymentDate(payment.paymentDate) : ''}
-          </span>
+        <span className="hidden sm:block text-xs text-muted-foreground tabular-nums">
+          {hasPaid && payment?.paymentDate ? formatPaymentDate(payment.paymentDate) : ''}
+        </span>
 
-          {/* STATUS — right-aligned at far end */}
-          <div className="flex justify-end">
-            {hasPaid ? (
-              <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
-                <span className="text-ajo-paid text-sm font-medium">Paid</span>
-                <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
-              </div>
-            ) : (
-              <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
-                <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
-              </div>
-            )}
-          </div>
+        <div className="flex justify-end">
+          {hasPaid ? (
+            <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
+              <span className="text-ajo-paid text-sm font-medium">Paid</span>
+              <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
+            </div>
+          ) : (
+            <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
+              <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
+            </div>
+          )}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -56,7 +56,7 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
           On mobile, middle shows name with phone stacked below.
         */}
         <div className="relative grid items-center gap-x-3 px-4 py-3.5
-          [grid-template-columns:2rem_1fr_auto]">
+          [grid-template-columns:2rem_1fr_8rem]">
 
           {/* Col 1 — number */}
           <span className="text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
@@ -85,17 +85,19 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
             </span>
           </div>
 
-          {/* Col 3 — status badge at far right */}
-          {hasPaid ? (
-            <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
-              <span className="text-ajo-paid text-sm font-medium">Paid</span>
-              <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
-            </div>
-          ) : (
-            <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
-              <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
-            </div>
-          )}
+          {/* Col 3 — status badge, right-aligned in fixed column */}
+          <div className="flex justify-end">
+            {hasPaid ? (
+              <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
+                <span className="text-ajo-paid text-sm font-medium">Paid</span>
+                <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
+              </div>
+            ) : (
+              <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
+                <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -1,5 +1,4 @@
 import { CheckCircle2 } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { TableCell, TableRow } from '@/components/ui/table';
 import { PaymentToggleButton } from '@/components/dashboard/payment-toggle-button';
 import type { MemberPaymentStatus } from '@/lib/types';
@@ -32,12 +31,17 @@ export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber 
   const { member, hasPaid, payment } = status;
 
   return (
-    <TableRow className="border-border hover:bg-muted/40 transition-colors">
+    <TableRow
+      className="border-border transition-colors hover:brightness-95"
+      style={{
+        background: hasPaid
+          ? 'linear-gradient(to left, oklch(0.696 0.17 162.48 / 0.08) 0%, transparent 38%)'
+          : 'linear-gradient(to left, oklch(0.769 0.188 70.08 / 0.08) 0%, transparent 38%)',
+      }}
+    >
       <TableCell className="w-10 py-3 pl-4">
-        <span
-          className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-medium tabular-nums text-muted-foreground"
-        >
-          {rowNumber}
+        <span className="text-2xl font-bold tabular-nums text-muted-foreground/60 leading-none">
+          {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
         </span>
       </TableCell>
 
@@ -54,14 +58,14 @@ export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber 
             </span>
           )}
           {hasPaid ? (
-            <Badge className="inline-flex items-center gap-1 bg-ajo-paid-subtle text-ajo-paid border-transparent text-xs font-medium">
-              Paid
-              <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
-            </Badge>
+            <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
+              <span className="text-ajo-paid text-sm font-medium">Paid</span>
+              <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
+            </div>
           ) : (
-            <Badge className="bg-ajo-outstanding-subtle text-ajo-outstanding border-transparent text-xs font-medium">
-              Outstanding
-            </Badge>
+            <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
+              <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
+            </div>
           )}
           <PaymentToggleButton
             memberId={member.id}

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -26,21 +26,34 @@ function formatPaymentDate(isoDate: string): string {
   });
 }
 
+/*
+  Grid columns — same template used in the header so every column aligns:
+    mobile:  [2rem | 1fr        | 8rem  ]
+    sm+:     [2rem | 2fr | 2fr  | 1.5fr | 1.5fr]
+             NO     NAME  PHONE   DATE    STATUS
+
+  Hidden items (phone/date on mobile) don't consume grid tracks, so
+  the mobile 3-col template always sees exactly 3 items.
+*/
+const GRID = '[grid-template-columns:2rem_1fr_8rem] sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]';
+
 export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentRowProps) {
   const { member, hasPaid, payment } = status;
 
   return (
     <>
-      {/* Card — click opens inline overlay; toggle button stops propagation for quick inline action */}
       <div
         role="button"
         tabIndex={0}
         aria-label={`View details for ${member.name}`}
         onClick={() => onSelect()}
         onKeyDown={e => e.key === 'Enter' && onSelect()}
-        className="relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden transition-all hover:brightness-95 cursor-pointer"
+        style={{ animationDelay: `${(rowNumber - 1) * 80}ms` }}
+        className={`relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden
+          cursor-pointer hover:brightness-95
+          animate-[row-slide-in_0.4s_ease-out_both]`}
       >
-        {/* Persistent status gradient — right-anchored */}
+        {/* Status gradient — right-anchored */}
         <div
           className="absolute inset-0 pointer-events-none"
           style={{
@@ -50,42 +63,30 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
           }}
         />
 
-        {/*
-          Outer 3 columns: [number] [middle: member/phone/date] [badge]
-          Middle sub-grid on sm+: [name (capped)] [phone] [date]
-          On mobile, middle shows name with phone stacked below.
-        */}
-        <div className="relative grid items-center gap-x-3 px-4 py-3.5
-          [grid-template-columns:2rem_1fr_8rem]">
+        <div className={`relative grid items-center gap-x-4 px-4 py-3.5 ${GRID}`}>
 
-          {/* Col 1 — number */}
+          {/* NO */}
           <span className="text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
             {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
           </span>
 
-          {/* Col 2 — member / phone / date */}
-          <div className="grid min-w-0 gap-x-3
-            [grid-template-columns:1fr]
-            sm:[grid-template-columns:minmax(0,9rem)_9rem_5rem]">
-
-            {/* Name — phone stacked below on mobile */}
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
-              <p className="text-xs text-muted-foreground sm:hidden">{formatPhone(member.phone)}</p>
-            </div>
-
-            {/* Phone (sm+) */}
-            <p className="hidden sm:block text-xs text-muted-foreground tabular-nums self-center truncate">
-              {formatPhone(member.phone)}
-            </p>
-
-            {/* Date (sm+) — always rendered to hold the grid track */}
-            <span className="hidden sm:block text-xs text-muted-foreground tabular-nums self-center">
-              {hasPaid && payment?.paymentDate ? formatPaymentDate(payment.paymentDate) : ''}
-            </span>
+          {/* MEMBER — phone stacked below on mobile */}
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
+            <p className="text-xs text-muted-foreground sm:hidden">{formatPhone(member.phone)}</p>
           </div>
 
-          {/* Col 3 — status badge, right-aligned in fixed column */}
+          {/* PHONE — sm+ only */}
+          <p className="hidden sm:block text-xs text-muted-foreground tabular-nums truncate">
+            {formatPhone(member.phone)}
+          </p>
+
+          {/* DATE — sm+ only; always rendered to hold the grid track */}
+          <span className="hidden sm:block text-xs text-muted-foreground tabular-nums">
+            {hasPaid && payment?.paymentDate ? formatPaymentDate(payment.paymentDate) : ''}
+          </span>
+
+          {/* STATUS — right-aligned at far end */}
           <div className="flex justify-end">
             {hasPaid ? (
               <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -51,11 +51,13 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
         />
 
         <div className="relative flex items-center gap-4 px-4 py-3.5">
-          {/* Row number stacked above name */}
+          {/* Row number */}
+          <span className="w-8 shrink-0 text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
+            {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
+          </span>
+
+          {/* Member info — name and phone are separate lines; more fields can be added here */}
           <div className="flex-1 min-w-0">
-            <span className="block text-xl font-bold tabular-nums text-muted-foreground/40 leading-none mb-1">
-              {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
-            </span>
             <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
             <p className="text-xs text-muted-foreground">{formatPhone(member.phone)}</p>
           </div>

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -50,41 +50,48 @@ export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentR
           }}
         />
 
-        <div className="relative flex items-center gap-4 px-4 py-3.5">
-          {/* Row number */}
-          <span className="w-8 shrink-0 text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
+        {/*
+          Grid columns:
+            mobile  — [number | name+phone | badge]
+            sm+     — [number | name | phone | date | badge]
+          Hidden elements are display:none so they don't consume grid tracks on mobile.
+        */}
+        <div className="relative grid items-center gap-x-3 px-4 py-3.5
+          [grid-template-columns:2rem_minmax(0,1fr)_auto]
+          sm:[grid-template-columns:2rem_minmax(0,1fr)_9rem_5rem_auto]">
+
+          {/* Number */}
+          <span className="text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
             {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
           </span>
 
-          {/* Name — on mobile also shows phone stacked below */}
-          <div className="flex-1 min-w-0">
+          {/* Name — phone stacked below on mobile only */}
+          <div className="min-w-0">
             <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
             <p className="text-xs text-muted-foreground sm:hidden">{formatPhone(member.phone)}</p>
           </div>
 
-          {/* Phone — own column on sm+, hidden on mobile (shown stacked above) */}
-          <p className="hidden sm:block w-36 shrink-0 text-xs text-muted-foreground tabular-nums">
+          {/* Phone — own column on sm+; hidden on mobile */}
+          <p className="hidden sm:block text-xs text-muted-foreground tabular-nums truncate">
             {formatPhone(member.phone)}
           </p>
 
-          {/* Date + status badge */}
-          <div className="flex items-center gap-3 ml-auto shrink-0">
-            {hasPaid && payment?.paymentDate && (
-              <span className="hidden sm:inline text-xs text-muted-foreground tabular-nums">
-                {formatPaymentDate(payment.paymentDate)}
-              </span>
-            )}
-            {hasPaid ? (
-              <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
-                <span className="text-ajo-paid text-sm font-medium">Paid</span>
-                <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
-              </div>
-            ) : (
-              <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
-                <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
-              </div>
-            )}
-          </div>
+          {/* Date — own column on sm+; always rendered to keep grid alignment */}
+          <span className="hidden sm:block text-xs text-muted-foreground tabular-nums">
+            {hasPaid && payment?.paymentDate ? formatPaymentDate(payment.paymentDate) : ''}
+          </span>
+
+          {/* Status badge — sole element at the far right */}
+          {hasPaid ? (
+            <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
+              <span className="text-ajo-paid text-sm font-medium">Paid</span>
+              <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
+            </div>
+          ) : (
+            <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
+              <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -1,22 +1,12 @@
 'use client';
 
-import { useState } from 'react';
 import { CheckCircle2 } from 'lucide-react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog';
-import { PaymentToggleButton } from '@/components/dashboard/payment-toggle-button';
 import type { MemberPaymentStatus } from '@/lib/types';
 
 interface MemberPaymentRowProps {
   status: MemberPaymentStatus;
-  cycleId: number;
-  contributionKobo: number;
   rowNumber: number;
+  onSelect: () => void;
 }
 
 function formatPhone(phone: string): string {
@@ -36,19 +26,18 @@ function formatPaymentDate(isoDate: string): string {
   });
 }
 
-export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber }: MemberPaymentRowProps) {
+export function MemberPaymentRow({ status, rowNumber, onSelect }: MemberPaymentRowProps) {
   const { member, hasPaid, payment } = status;
-  const [open, setOpen] = useState(false);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      {/* Card — click opens dialog; toggle button stops propagation for quick inline action */}
+    <>
+      {/* Card — click opens inline overlay; toggle button stops propagation for quick inline action */}
       <div
         role="button"
         tabIndex={0}
         aria-label={`View details for ${member.name}`}
-        onClick={() => setOpen(true)}
-        onKeyDown={e => e.key === 'Enter' && setOpen(true)}
+        onClick={() => onSelect()}
+        onKeyDown={e => e.key === 'Enter' && onSelect()}
         className="relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden transition-all hover:brightness-95 cursor-pointer"
       >
         {/* Persistent status gradient — right-anchored */}
@@ -62,23 +51,17 @@ export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber 
         />
 
         <div className="relative flex items-center gap-4 px-4 py-3.5">
-          {/* Row number */}
-          <span className="w-8 shrink-0 text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
-            {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
-          </span>
-
-          {/* Member info */}
+          {/* Row number stacked above name */}
           <div className="flex-1 min-w-0">
+            <span className="block text-xl font-bold tabular-nums text-muted-foreground/40 leading-none mb-1">
+              {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
+            </span>
             <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
             <p className="text-xs text-muted-foreground">{formatPhone(member.phone)}</p>
           </div>
 
-          {/* Date + status badge + quick action — stop propagation so clicks here don't open dialog */}
-          <div
-            className="flex items-center gap-3 ml-auto shrink-0"
-            onClick={e => e.stopPropagation()}
-            onKeyDown={e => e.stopPropagation()}
-          >
+          {/* Date + status badge only */}
+          <div className="flex items-center gap-3 ml-auto shrink-0">
             {hasPaid && payment?.paymentDate && (
               <span className="hidden sm:inline text-xs text-muted-foreground tabular-nums">
                 {formatPaymentDate(payment.paymentDate)}
@@ -94,45 +77,9 @@ export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber 
                 <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
               </div>
             )}
-            <PaymentToggleButton
-              memberId={member.id}
-              cycleId={cycleId}
-              hasPaid={hasPaid}
-              contributionKobo={contributionKobo}
-            />
           </div>
         </div>
       </div>
-
-      {/* Member detail dialog — dumb UI shell; more actions to be added in Plan 1 */}
-      <DialogContent className="sm:max-w-xs">
-        <DialogHeader>
-          <DialogTitle>{member.name}</DialogTitle>
-        </DialogHeader>
-
-        {/* Status */}
-        <div className="flex items-center justify-center py-4">
-          {hasPaid ? (
-            <div className="px-5 py-2.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-2">
-              <span className="text-ajo-paid text-base font-medium">Paid</span>
-              <CheckCircle2 className="h-4 w-4 text-ajo-paid" aria-hidden="true" />
-            </div>
-          ) : (
-            <div className="px-5 py-2.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
-              <span className="text-ajo-outstanding text-base font-medium">Outstanding</span>
-            </div>
-          )}
-        </div>
-
-        <DialogFooter showCloseButton>
-          <PaymentToggleButton
-            memberId={member.id}
-            cycleId={cycleId}
-            hasPaid={hasPaid}
-            contributionKobo={contributionKobo}
-          />
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    </>
   );
 }

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -1,4 +1,14 @@
+'use client';
+
+import { useState } from 'react';
 import { CheckCircle2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
 import { PaymentToggleButton } from '@/components/dashboard/payment-toggle-button';
 import type { MemberPaymentStatus } from '@/lib/types';
 
@@ -28,56 +38,101 @@ function formatPaymentDate(isoDate: string): string {
 
 export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber }: MemberPaymentRowProps) {
   const { member, hasPaid, payment } = status;
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden transition-all hover:brightness-95">
-      {/* Persistent status gradient — right-anchored */}
+    <Dialog open={open} onOpenChange={setOpen}>
+      {/* Card — click opens dialog; toggle button stops propagation for quick inline action */}
       <div
-        className="absolute inset-0 pointer-events-none"
-        style={{
-          background: hasPaid
-            ? 'linear-gradient(to left, oklch(0.696 0.17 162.48 / 0.10) 0%, transparent 40%)'
-            : 'linear-gradient(to left, oklch(0.769 0.188 70.08 / 0.10) 0%, transparent 40%)',
-        }}
-      />
+        role="button"
+        tabIndex={0}
+        aria-label={`View details for ${member.name}`}
+        onClick={() => setOpen(true)}
+        onKeyDown={e => e.key === 'Enter' && setOpen(true)}
+        className="relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden transition-all hover:brightness-95 cursor-pointer"
+      >
+        {/* Persistent status gradient — right-anchored */}
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            background: hasPaid
+              ? 'linear-gradient(to left, oklch(0.696 0.17 162.48 / 0.10) 0%, transparent 40%)'
+              : 'linear-gradient(to left, oklch(0.769 0.188 70.08 / 0.10) 0%, transparent 40%)',
+          }}
+        />
 
-      <div className="relative flex items-center gap-4 px-4 py-3.5">
-        {/* Row number */}
-        <span className="w-8 shrink-0 text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
-          {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
-        </span>
+        <div className="relative flex items-center gap-4 px-4 py-3.5">
+          {/* Row number */}
+          <span className="w-8 shrink-0 text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
+            {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
+          </span>
 
-        {/* Member info */}
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
-          <p className="text-xs text-muted-foreground">{formatPhone(member.phone)}</p>
+          {/* Member info */}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
+            <p className="text-xs text-muted-foreground">{formatPhone(member.phone)}</p>
+          </div>
+
+          {/* Date + status badge + quick action — stop propagation so clicks here don't open dialog */}
+          <div
+            className="flex items-center gap-3 ml-auto shrink-0"
+            onClick={e => e.stopPropagation()}
+            onKeyDown={e => e.stopPropagation()}
+          >
+            {hasPaid && payment?.paymentDate && (
+              <span className="hidden sm:inline text-xs text-muted-foreground tabular-nums">
+                {formatPaymentDate(payment.paymentDate)}
+              </span>
+            )}
+            {hasPaid ? (
+              <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
+                <span className="text-ajo-paid text-sm font-medium">Paid</span>
+                <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
+              </div>
+            ) : (
+              <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
+                <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
+              </div>
+            )}
+            <PaymentToggleButton
+              memberId={member.id}
+              cycleId={cycleId}
+              hasPaid={hasPaid}
+              contributionKobo={contributionKobo}
+            />
+          </div>
         </div>
+      </div>
 
-        {/* Date + status badge + action */}
-        <div className="flex items-center gap-3 ml-auto shrink-0">
-          {hasPaid && payment?.paymentDate && (
-            <span className="hidden sm:inline text-xs text-muted-foreground tabular-nums">
-              {formatPaymentDate(payment.paymentDate)}
-            </span>
-          )}
+      {/* Member detail dialog — dumb UI shell; more actions to be added in Plan 1 */}
+      <DialogContent className="sm:max-w-xs">
+        <DialogHeader>
+          <DialogTitle>{member.name}</DialogTitle>
+        </DialogHeader>
+
+        {/* Status */}
+        <div className="flex items-center justify-center py-4">
           {hasPaid ? (
-            <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
-              <span className="text-ajo-paid text-sm font-medium">Paid</span>
-              <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
+            <div className="px-5 py-2.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-2">
+              <span className="text-ajo-paid text-base font-medium">Paid</span>
+              <CheckCircle2 className="h-4 w-4 text-ajo-paid" aria-hidden="true" />
             </div>
           ) : (
-            <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
-              <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
+            <div className="px-5 py-2.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
+              <span className="text-ajo-outstanding text-base font-medium">Outstanding</span>
             </div>
           )}
+        </div>
+
+        <DialogFooter showCloseButton>
           <PaymentToggleButton
             memberId={member.id}
             cycleId={cycleId}
             hasPaid={hasPaid}
             contributionKobo={contributionKobo}
           />
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -40,6 +40,7 @@ export const MemberPaymentRow = memo(function MemberPaymentRow({ status, rowNumb
       style={{ animationDelay: `${(rowNumber - 1) * 80}ms` }}
       className={`relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden
         cursor-pointer hover:brightness-95
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background
         animate-[row-slide-in_0.4s_ease-out_both]`}
     >
       {/* Right-anchored status gradient */}

--- a/components/dashboard/member-payment-row.tsx
+++ b/components/dashboard/member-payment-row.tsx
@@ -1,5 +1,4 @@
 import { CheckCircle2 } from 'lucide-react';
-import { TableCell, TableRow } from '@/components/ui/table';
 import { PaymentToggleButton } from '@/components/dashboard/payment-toggle-button';
 import type { MemberPaymentStatus } from '@/lib/types';
 
@@ -31,27 +30,31 @@ export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber 
   const { member, hasPaid, payment } = status;
 
   return (
-    <TableRow
-      className="border-border transition-colors hover:brightness-95"
-      style={{
-        background: hasPaid
-          ? 'linear-gradient(to left, oklch(0.696 0.17 162.48 / 0.08) 0%, transparent 38%)'
-          : 'linear-gradient(to left, oklch(0.769 0.188 70.08 / 0.08) 0%, transparent 38%)',
-      }}
-    >
-      <TableCell className="w-10 py-3 pl-4">
-        <span className="text-2xl font-bold tabular-nums text-muted-foreground/60 leading-none">
+    <div className="relative bg-muted/50 border border-border/50 rounded-xl overflow-hidden transition-all hover:brightness-95">
+      {/* Persistent status gradient — right-anchored */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background: hasPaid
+            ? 'linear-gradient(to left, oklch(0.696 0.17 162.48 / 0.10) 0%, transparent 40%)'
+            : 'linear-gradient(to left, oklch(0.769 0.188 70.08 / 0.10) 0%, transparent 40%)',
+        }}
+      />
+
+      <div className="relative flex items-center gap-4 px-4 py-3.5">
+        {/* Row number */}
+        <span className="w-8 shrink-0 text-2xl font-bold tabular-nums text-muted-foreground/50 leading-none">
           {rowNumber < 10 ? `0${rowNumber}` : rowNumber}
         </span>
-      </TableCell>
 
-      <TableCell className="py-3">
-        <p className="text-sm font-medium text-foreground">{member.name}</p>
-        <p className="text-xs text-muted-foreground">{formatPhone(member.phone)}</p>
-      </TableCell>
+        {/* Member info */}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">{member.name}</p>
+          <p className="text-xs text-muted-foreground">{formatPhone(member.phone)}</p>
+        </div>
 
-      <TableCell className="py-3 pr-4">
-        <div className="flex items-center justify-end gap-3">
+        {/* Date + status badge + action */}
+        <div className="flex items-center gap-3 ml-auto shrink-0">
           {hasPaid && payment?.paymentDate && (
             <span className="hidden sm:inline text-xs text-muted-foreground tabular-nums">
               {formatPaymentDate(payment.paymentDate)}
@@ -74,7 +77,7 @@ export function MemberPaymentRow({ status, cycleId, contributionKobo, rowNumber 
             contributionKobo={contributionKobo}
           />
         </div>
-      </TableCell>
-    </TableRow>
+      </div>
+    </div>
   );
 }

--- a/components/dashboard/payment-status-badge.tsx
+++ b/components/dashboard/payment-status-badge.tsx
@@ -1,0 +1,35 @@
+import { CheckCircle2 } from 'lucide-react';
+
+interface PaymentStatusBadgeProps {
+  hasPaid: boolean;
+  /**
+   * 'row'  — compact inline badge used inside table card rows (with paid icon)
+   * 'tile' — full-height badge used inside the detail overlay status tile
+   */
+  variant?: 'row' | 'tile';
+}
+
+export function PaymentStatusBadge({ hasPaid, variant = 'row' }: PaymentStatusBadgeProps) {
+  if (variant === 'tile') {
+    return hasPaid ? (
+      <div className="flex-1 flex items-center justify-center rounded-md bg-ajo-paid/15 border border-ajo-paid/30 px-2 py-1">
+        <span className="text-xs font-semibold text-ajo-paid">Paid</span>
+      </div>
+    ) : (
+      <div className="flex-1 flex items-center justify-center rounded-md bg-ajo-outstanding/15 border border-ajo-outstanding/30 px-2 py-1">
+        <span className="text-xs font-semibold text-ajo-outstanding">Outstanding</span>
+      </div>
+    );
+  }
+
+  return hasPaid ? (
+    <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
+      <span className="text-ajo-paid text-sm font-medium">Paid</span>
+      <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
+    </div>
+  ) : (
+    <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
+      <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
+    </div>
+  );
+}

--- a/components/dashboard/payment-status-grid.tsx
+++ b/components/dashboard/payment-status-grid.tsx
@@ -6,7 +6,8 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { SortablePaymentTable } from '@/components/dashboard/sortable-payment-table';
 import { CyclePerformanceChart } from '@/components/dashboard/cycle-performance-chart';
 import { PaymentToggleButton } from '@/components/dashboard/payment-toggle-button';
-import { formatPhone, formatPaymentDate, formatNgn } from '@/lib/utils';
+import { PaymentStatusBadge } from '@/components/dashboard/payment-status-badge';
+import { formatPhone, formatPaymentDate, formatNgn, padZero } from '@/lib/utils';
 import type { MemberPaymentStatus, Cycle, Payment } from '@/lib/types';
 
 type ViewMode = 'table' | 'chart';
@@ -90,15 +91,13 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
         )}
       </CardContent>
 
-      {/* Inline detail overlay — covers card content, matches reference panel layout */}
       {selectedMember && (
         <div className="absolute inset-0 bg-card flex flex-col rounded-xl z-10 overflow-hidden border border-border">
 
-          {/* ── Header ── */}
           <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-border/60">
             <div className="flex items-center gap-3 min-w-0">
               <span className="text-2xl font-bold tabular-nums text-muted-foreground/30 leading-none shrink-0 w-9">
-                {String(selectedMember.member.position).padStart(2, '0')}
+                {padZero(selectedMember.member.position)}
               </span>
               <div className="min-w-0">
                 <p className="text-base font-semibold text-foreground truncate leading-tight">
@@ -127,9 +126,7 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
             </div>
           </div>
 
-          {/* ── Info tiles ── */}
           <div className="grid grid-cols-3 gap-2 px-5 py-4 border-b border-border/60">
-            {/* PAID DATE */}
             <div className="bg-muted/40 rounded-lg px-3 py-2.5 border border-border/40">
               <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
                 Paid Date
@@ -141,7 +138,6 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
               </p>
             </div>
 
-            {/* DUE DATE — cycle end date (placeholder if unavailable) */}
             <div className="bg-muted/40 rounded-lg px-3 py-2.5 border border-border/40">
               <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
                 Due Date
@@ -151,24 +147,14 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
               </p>
             </div>
 
-            {/* STATUS */}
             <div className="bg-muted/40 rounded-lg px-3 py-2.5 border border-border/40 flex flex-col">
               <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
                 Status
               </p>
-              {selectedMember.hasPaid ? (
-                <div className="flex-1 flex items-center justify-center rounded-md bg-ajo-paid/15 border border-ajo-paid/30 px-2 py-1">
-                  <span className="text-xs font-semibold text-ajo-paid">Paid</span>
-                </div>
-              ) : (
-                <div className="flex-1 flex items-center justify-center rounded-md bg-ajo-outstanding/15 border border-ajo-outstanding/30 px-2 py-1">
-                  <span className="text-xs font-semibold text-ajo-outstanding">Outstanding</span>
-                </div>
-              )}
+              <PaymentStatusBadge hasPaid={selectedMember.hasPaid} variant="tile" />
             </div>
           </div>
 
-          {/* ── Contribution ── */}
           <div className="px-5 py-4 border-b border-border/60">
             <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-2">
               Contribution
@@ -183,7 +169,6 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
             </div>
           </div>
 
-          {/* ── Payment History (placeholder) ── */}
           <div className="flex-1 px-5 py-4 overflow-hidden">
             <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-3">
               Payment History

--- a/components/dashboard/payment-status-grid.tsx
+++ b/components/dashboard/payment-status-grid.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
-import { BarChart2, TableIcon } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { BarChart2, TableIcon, X, CheckCircle2 } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { SortablePaymentTable } from '@/components/dashboard/sortable-payment-table';
 import { CyclePerformanceChart } from '@/components/dashboard/cycle-performance-chart';
+import { PaymentToggleButton } from '@/components/dashboard/payment-toggle-button';
 import type { MemberPaymentStatus, Cycle, Payment } from '@/lib/types';
 
 type ViewMode = 'table' | 'chart';
@@ -18,11 +19,36 @@ interface PaymentStatusGridProps {
   payments: Payment[];
 }
 
+function formatPhone(phone: string): string {
+  const digits = phone.replace(/\D/g, '');
+  if (digits.length === 13 && digits.startsWith('234')) {
+    return `+234 ${digits.slice(3, 6)} ${digits.slice(6, 9)} ${digits.slice(9)}`;
+  }
+  return `+${digits}`;
+}
+
+function formatPaymentDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
 export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contributionKobo, cycles, payments }: PaymentStatusGridProps) {
   const [view, setView] = useState<ViewMode>('table');
+  const [selectedMember, setSelectedMember] = useState<MemberPaymentStatus | null>(null);
+
+  // Sync overlay with server re-renders after payment toggle
+  useEffect(() => {
+    if (!selectedMember) return;
+    const updated = statuses.find(s => s.member.id === selectedMember.member.id);
+    if (updated) setSelectedMember(updated);
+  }, [statuses, selectedMember]);
 
   return (
-    <Card className="border-border bg-card shadow-sm">
+    <Card className="relative overflow-hidden border-border bg-card shadow-sm">
       <CardHeader className="pb-2">
         <div className="flex items-start justify-between">
           <div>
@@ -67,9 +93,8 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
         {view === 'table' ? (
           <SortablePaymentTable
             statuses={statuses}
-            cycleId={cycleId}
             cycleNumber={cycleNumber}
-            contributionKobo={contributionKobo}
+            onSelectMember={setSelectedMember}
           />
         ) : (
           <CyclePerformanceChart
@@ -78,6 +103,66 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
           />
         )}
       </CardContent>
+
+      {/* Inline overlay — sits inside the card, not full-screen */}
+      {selectedMember && (
+        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex flex-col rounded-xl z-10 overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center justify-between gap-4 px-4 py-3 border-b border-border/40 bg-muted/30">
+            <div className="min-w-0">
+              <p className="text-base font-semibold text-foreground truncate">{selectedMember.member.name}</p>
+              <p className="text-xs text-muted-foreground">{formatPhone(selectedMember.member.phone)}</p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <div
+                onClick={e => e.stopPropagation()}
+                onKeyDown={e => e.stopPropagation()}
+              >
+                <PaymentToggleButton
+                  memberId={selectedMember.member.id}
+                  cycleId={cycleId}
+                  hasPaid={selectedMember.hasPaid}
+                  contributionKobo={contributionKobo}
+                />
+              </div>
+              <button
+                onClick={() => setSelectedMember(null)}
+                aria-label="Close member detail"
+                className="w-8 h-8 flex items-center justify-center rounded-full border border-border/50 bg-background/80 hover:bg-background text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+
+          {/* Body */}
+          <div className="flex-1 flex items-center justify-center p-6">
+            <div className="w-full max-w-xs space-y-4">
+              {/* Status */}
+              <div className="flex justify-center">
+                {selectedMember.hasPaid ? (
+                  <div className="px-5 py-2.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-2">
+                    <span className="text-ajo-paid text-base font-medium">Paid</span>
+                    <CheckCircle2 className="h-4 w-4 text-ajo-paid" aria-hidden="true" />
+                  </div>
+                ) : (
+                  <div className="px-5 py-2.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
+                    <span className="text-ajo-outstanding text-base font-medium">Outstanding</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Payment date if paid */}
+              {selectedMember.hasPaid && selectedMember.payment?.paymentDate && (
+                <div className="bg-muted/40 rounded-lg px-4 py-3 border border-border/30 text-center">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">Paid on</p>
+                  <p className="text-sm font-medium text-foreground">{formatPaymentDate(selectedMember.payment.paymentDate)}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </Card>
   );
 }

--- a/components/dashboard/payment-status-grid.tsx
+++ b/components/dashboard/payment-status-grid.tsx
@@ -24,6 +24,7 @@ interface PaymentStatusGridProps {
 export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contributionKobo, cycles, payments }: PaymentStatusGridProps) {
   const [view, setView] = useState<ViewMode>('table');
   const [selectedMember, setSelectedMember] = useState<MemberPaymentStatus | null>(null);
+  const [selectedRowNumber, setSelectedRowNumber] = useState<number | null>(null);
 
   const activeCycle = cycles.find(c => c.id === cycleId);
 
@@ -81,7 +82,7 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
           <SortablePaymentTable
             statuses={statuses}
             cycleNumber={cycleNumber}
-            onSelectMember={setSelectedMember}
+            onSelectMember={(status, rowNumber) => { setSelectedMember(status); setSelectedRowNumber(rowNumber); }}
           />
         ) : (
           <CyclePerformanceChart
@@ -97,7 +98,7 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
           <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-border/60">
             <div className="flex items-center gap-3 min-w-0">
               <span className="text-2xl font-bold tabular-nums text-muted-foreground/30 leading-none shrink-0 w-9">
-                {padZero(selectedMember.member.position)}
+                {padZero(selectedRowNumber ?? selectedMember.member.position)}
               </span>
               <div className="min-w-0">
                 <p className="text-base font-semibold text-foreground truncate leading-tight">
@@ -117,7 +118,7 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
                 contributionKobo={contributionKobo}
               />
               <button
-                onClick={() => setSelectedMember(null)}
+                onClick={() => { setSelectedMember(null); setSelectedRowNumber(null); }}
                 aria-label="Close member detail"
                 className="w-8 h-8 flex items-center justify-center rounded-full border border-border/60 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >

--- a/components/dashboard/payment-status-grid.tsx
+++ b/components/dashboard/payment-status-grid.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { SortablePaymentTable } from '@/components/dashboard/sortable-payment-table';
 import { CyclePerformanceChart } from '@/components/dashboard/cycle-performance-chart';
 import { PaymentToggleButton } from '@/components/dashboard/payment-toggle-button';
+import { formatPhone, formatPaymentDate } from '@/lib/utils';
 import type { MemberPaymentStatus, Cycle, Payment } from '@/lib/types';
 
 type ViewMode = 'table' | 'chart';
@@ -17,23 +18,6 @@ interface PaymentStatusGridProps {
   contributionKobo: number;
   cycles: Cycle[];
   payments: Payment[];
-}
-
-function formatPhone(phone: string): string {
-  const digits = phone.replace(/\D/g, '');
-  if (digits.length === 13 && digits.startsWith('234')) {
-    return `+234 ${digits.slice(3, 6)} ${digits.slice(6, 9)} ${digits.slice(9)}`;
-  }
-  return `+${digits}`;
-}
-
-function formatPaymentDate(isoDate: string): string {
-  const [year, month, day] = isoDate.split('-').map(Number);
-  return new Date(year, month - 1, day).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
 }
 
 export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contributionKobo, cycles, payments }: PaymentStatusGridProps) {
@@ -156,7 +140,7 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
               {selectedMember.hasPaid && selectedMember.payment?.paymentDate && (
                 <div className="bg-muted/40 rounded-lg px-4 py-3 border border-border/30 text-center">
                   <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">Paid on</p>
-                  <p className="text-sm font-medium text-foreground">{formatPaymentDate(selectedMember.payment.paymentDate)}</p>
+                  <p className="text-sm font-medium text-foreground">{formatPaymentDate(selectedMember.payment.paymentDate, true)}</p>
                 </div>
               )}
             </div>

--- a/components/dashboard/payment-status-grid.tsx
+++ b/components/dashboard/payment-status-grid.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { BarChart2, TableIcon, X, CheckCircle2 } from 'lucide-react';
+import { BarChart2, TableIcon, X } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { SortablePaymentTable } from '@/components/dashboard/sortable-payment-table';
 import { CyclePerformanceChart } from '@/components/dashboard/cycle-performance-chart';
 import { PaymentToggleButton } from '@/components/dashboard/payment-toggle-button';
-import { formatPhone, formatPaymentDate } from '@/lib/utils';
+import { formatPhone, formatPaymentDate, formatNgn } from '@/lib/utils';
 import type { MemberPaymentStatus, Cycle, Payment } from '@/lib/types';
 
 type ViewMode = 'table' | 'chart';
@@ -23,6 +23,8 @@ interface PaymentStatusGridProps {
 export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contributionKobo, cycles, payments }: PaymentStatusGridProps) {
   const [view, setView] = useState<ViewMode>('table');
   const [selectedMember, setSelectedMember] = useState<MemberPaymentStatus | null>(null);
+
+  const activeCycle = cycles.find(c => c.id === cycleId);
 
   // Sync overlay with server re-renders after payment toggle
   useEffect(() => {
@@ -88,15 +90,26 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
         )}
       </CardContent>
 
-      {/* Inline overlay — sits inside the card, not full-screen */}
+      {/* Inline detail overlay — covers card content, matches reference panel layout */}
       {selectedMember && (
-        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex flex-col rounded-xl z-10 overflow-hidden">
-          {/* Header */}
-          <div className="flex items-center justify-between gap-4 px-4 py-3 border-b border-border/40 bg-muted/30">
-            <div className="min-w-0">
-              <p className="text-base font-semibold text-foreground truncate">{selectedMember.member.name}</p>
-              <p className="text-xs text-muted-foreground">{formatPhone(selectedMember.member.phone)}</p>
+        <div className="absolute inset-0 bg-card flex flex-col rounded-xl z-10 overflow-hidden border border-border">
+
+          {/* ── Header ── */}
+          <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-border/60">
+            <div className="flex items-center gap-3 min-w-0">
+              <span className="text-2xl font-bold tabular-nums text-muted-foreground/30 leading-none shrink-0 w-9">
+                {String(selectedMember.member.position).padStart(2, '0')}
+              </span>
+              <div className="min-w-0">
+                <p className="text-base font-semibold text-foreground truncate leading-tight">
+                  {selectedMember.member.name}
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {formatPhone(selectedMember.member.phone)}
+                </p>
+              </div>
             </div>
+
             <div className="flex items-center gap-2 shrink-0">
               <PaymentToggleButton
                 memberId={selectedMember.member.id}
@@ -107,39 +120,79 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
               <button
                 onClick={() => setSelectedMember(null)}
                 aria-label="Close member detail"
-                className="w-8 h-8 flex items-center justify-center rounded-full border border-border/50 bg-background/80 hover:bg-background text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="w-8 h-8 flex items-center justify-center rounded-full border border-border/60 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <X className="h-4 w-4" aria-hidden="true" />
               </button>
             </div>
           </div>
 
-          {/* Body */}
-          <div className="flex-1 flex items-center justify-center p-6">
-            <div className="w-full max-w-xs space-y-4">
-              {/* Status */}
-              <div className="flex justify-center">
-                {selectedMember.hasPaid ? (
-                  <div className="px-5 py-2.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-2">
-                    <span className="text-ajo-paid text-base font-medium">Paid</span>
-                    <CheckCircle2 className="h-4 w-4 text-ajo-paid" aria-hidden="true" />
-                  </div>
-                ) : (
-                  <div className="px-5 py-2.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
-                    <span className="text-ajo-outstanding text-base font-medium">Outstanding</span>
-                  </div>
-                )}
-              </div>
+          {/* ── Info tiles ── */}
+          <div className="grid grid-cols-3 gap-2 px-5 py-4 border-b border-border/60">
+            {/* PAID DATE */}
+            <div className="bg-muted/40 rounded-lg px-3 py-2.5 border border-border/40">
+              <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
+                Paid Date
+              </p>
+              <p className="text-sm font-semibold text-foreground tabular-nums">
+                {selectedMember.hasPaid && selectedMember.payment?.paymentDate
+                  ? formatPaymentDate(selectedMember.payment.paymentDate)
+                  : '—'}
+              </p>
+            </div>
 
-              {/* Payment date if paid */}
-              {selectedMember.hasPaid && selectedMember.payment?.paymentDate && (
-                <div className="bg-muted/40 rounded-lg px-4 py-3 border border-border/30 text-center">
-                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">Paid on</p>
-                  <p className="text-sm font-medium text-foreground">{formatPaymentDate(selectedMember.payment.paymentDate, true)}</p>
+            {/* DUE DATE — cycle end date (placeholder if unavailable) */}
+            <div className="bg-muted/40 rounded-lg px-3 py-2.5 border border-border/40">
+              <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
+                Due Date
+              </p>
+              <p className="text-sm font-semibold text-foreground tabular-nums">
+                {activeCycle?.endDate ? formatPaymentDate(activeCycle.endDate) : '—'}
+              </p>
+            </div>
+
+            {/* STATUS */}
+            <div className="bg-muted/40 rounded-lg px-3 py-2.5 border border-border/40 flex flex-col">
+              <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
+                Status
+              </p>
+              {selectedMember.hasPaid ? (
+                <div className="flex-1 flex items-center justify-center rounded-md bg-ajo-paid/15 border border-ajo-paid/30 px-2 py-1">
+                  <span className="text-xs font-semibold text-ajo-paid">Paid</span>
+                </div>
+              ) : (
+                <div className="flex-1 flex items-center justify-center rounded-md bg-ajo-outstanding/15 border border-ajo-outstanding/30 px-2 py-1">
+                  <span className="text-xs font-semibold text-ajo-outstanding">Outstanding</span>
                 </div>
               )}
             </div>
           </div>
+
+          {/* ── Contribution ── */}
+          <div className="px-5 py-4 border-b border-border/60">
+            <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              Contribution
+            </p>
+            <div className="flex items-baseline justify-between">
+              <p className="text-xl font-bold text-foreground tabular-nums">
+                {formatNgn(contributionKobo)}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Cycle {cycleNumber}
+              </p>
+            </div>
+          </div>
+
+          {/* ── Payment History (placeholder) ── */}
+          <div className="flex-1 px-5 py-4 overflow-hidden">
+            <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-3">
+              Payment History
+            </p>
+            <div className="space-y-1.5 font-mono text-xs text-muted-foreground/50">
+              <p>— No additional history available</p>
+            </div>
+          </div>
+
         </div>
       )}
     </Card>

--- a/components/dashboard/payment-status-grid.tsx
+++ b/components/dashboard/payment-status-grid.tsx
@@ -98,17 +98,12 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
               <p className="text-xs text-muted-foreground">{formatPhone(selectedMember.member.phone)}</p>
             </div>
             <div className="flex items-center gap-2 shrink-0">
-              <div
-                onClick={e => e.stopPropagation()}
-                onKeyDown={e => e.stopPropagation()}
-              >
-                <PaymentToggleButton
-                  memberId={selectedMember.member.id}
-                  cycleId={cycleId}
-                  hasPaid={selectedMember.hasPaid}
-                  contributionKobo={contributionKobo}
-                />
-              </div>
+              <PaymentToggleButton
+                memberId={selectedMember.member.id}
+                cycleId={cycleId}
+                hasPaid={selectedMember.hasPaid}
+                contributionKobo={contributionKobo}
+              />
               <button
                 onClick={() => setSelectedMember(null)}
                 aria-label="Close member detail"

--- a/components/dashboard/payment-toggle-button.tsx
+++ b/components/dashboard/payment-toggle-button.tsx
@@ -3,6 +3,7 @@
 import { useTransition, useEffect, useRef, useState } from 'react';
 import { Check, RotateCcw, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import { togglePayment } from '@/lib/actions';
 
 interface PaymentToggleButtonProps {
@@ -49,11 +50,12 @@ export function PaymentToggleButton({
         aria-label={hasPaid ? 'Mark as unpaid' : 'Mark as paid'}
         variant="outline"
         size="xs"
-        className={`cursor-pointer transition-colors ${
+        className={cn(
+          'cursor-pointer transition-colors',
           hasPaid
             ? 'border-ajo-outstanding text-ajo-outstanding hover:bg-ajo-outstanding/10 hover:text-ajo-outstanding'
-            : 'border-ajo-paid text-ajo-paid hover:bg-ajo-paid/10 hover:text-ajo-paid'
-        }`}
+            : 'border-ajo-paid text-ajo-paid hover:bg-ajo-paid/10 hover:text-ajo-paid',
+        )}
       >
         {isPending ? (
           <Loader2 className="animate-spin" aria-hidden="true" />

--- a/components/dashboard/payment-toggle-button.tsx
+++ b/components/dashboard/payment-toggle-button.tsx
@@ -47,9 +47,13 @@ export function PaymentToggleButton({
         onClick={handleToggle}
         disabled={isPending}
         aria-label={hasPaid ? 'Mark as unpaid' : 'Mark as paid'}
-        variant={hasPaid ? 'outline' : 'secondary'}
+        variant="outline"
         size="xs"
-        className="cursor-pointer"
+        className={`cursor-pointer transition-colors ${
+          hasPaid
+            ? 'border-ajo-outstanding text-ajo-outstanding hover:bg-ajo-outstanding/10 hover:text-ajo-outstanding'
+            : 'border-ajo-paid text-ajo-paid hover:bg-ajo-paid/10 hover:text-ajo-paid'
+        }`}
       >
         {isPending ? (
           <Loader2 className="animate-spin" aria-hidden="true" />

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -80,7 +80,7 @@ export function SortablePaymentTable({
       {/* Column headers — identical outer grid to rows */}
       <div className="grid gap-x-3 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
         [grid-template-columns:2rem_1fr_8rem]">
-        <span />
+        <span>No</span>
 
         {/* Middle sub-grid — mirrors row middle exactly */}
         <div className="grid gap-x-3

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -79,7 +79,9 @@ export function SortablePaymentTable({
 
       {/* Column headers */}
       <div className="flex items-center gap-4 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        <span className="w-8 shrink-0" />
         <span className="flex-1">Member</span>
+        <span className="hidden sm:block w-36 shrink-0">Phone</span>
         <button
           onClick={toggleSort}
           className="ml-auto inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -77,19 +77,22 @@ export function SortablePaymentTable({
         </div>
       </div>
 
-      {/* Column headers */}
-      <div className="flex items-center gap-4 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-        <span className="w-8 shrink-0" />
-        <span className="flex-1">Member</span>
-        <span className="hidden sm:block w-36 shrink-0">Phone</span>
+      {/* Column headers — same grid as rows */}
+      <div className="grid gap-x-3 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
+        [grid-template-columns:2rem_minmax(0,1fr)_auto]
+        sm:[grid-template-columns:2rem_minmax(0,1fr)_9rem_5rem_auto]">
+        <span />
+        <span>Member</span>
+        <span className="hidden sm:block">Phone</span>
         <button
           onClick={toggleSort}
-          className="ml-auto inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="hidden sm:inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label={`Sort by date ${sortDir === 'asc' ? 'descending' : 'ascending'}`}
         >
-          Date / Status
+          Date
           <SortIcon className="h-3 w-3" aria-hidden="true" />
         </button>
+        <span className="text-right">Status</span>
       </div>
 
       {/* Card list */}

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -77,27 +77,21 @@ export function SortablePaymentTable({
         </div>
       </div>
 
-      {/* Column headers — identical outer grid to rows */}
-      <div className="grid gap-x-3 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
-        [grid-template-columns:2rem_1fr_8rem]">
+      {/* Column headers — exact same flat grid as rows */}
+      <div className="grid gap-x-4 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
+        [grid-template-columns:2rem_1fr_8rem]
+        sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]">
         <span>No</span>
-
-        {/* Middle sub-grid — mirrors row middle exactly */}
-        <div className="grid gap-x-3
-          [grid-template-columns:1fr]
-          sm:[grid-template-columns:minmax(0,9rem)_9rem_5rem]">
-          <span>Member</span>
-          <span className="hidden sm:block">Phone</span>
-          <button
-            onClick={toggleSort}
-            className="hidden sm:inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            aria-label={`Sort by date ${sortDir === 'asc' ? 'descending' : 'ascending'}`}
-          >
-            Date
-            <SortIcon className="h-3 w-3" aria-hidden="true" />
-          </button>
-        </div>
-
+        <span>Member</span>
+        <span className="hidden sm:block">Phone</span>
+        <button
+          onClick={toggleSort}
+          className="hidden sm:inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`Sort by date ${sortDir === 'asc' ? 'descending' : 'ascending'}`}
+        >
+          Date
+          <SortIcon className="h-3 w-3" aria-hidden="true" />
+        </button>
         <span className="text-right">Status</span>
       </div>
 

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -9,9 +9,8 @@ type SortDir = 'asc' | 'desc' | null;
 
 interface SortablePaymentTableProps {
   statuses: MemberPaymentStatus[];
-  cycleId: number;
   cycleNumber: number;
-  contributionKobo: number;
+  onSelectMember: (status: MemberPaymentStatus) => void;
 }
 
 function filterBySearch(statuses: MemberPaymentStatus[], query: string): MemberPaymentStatus[] {
@@ -43,9 +42,8 @@ function sortByDate(statuses: MemberPaymentStatus[], dir: SortDir): MemberPaymen
 
 export function SortablePaymentTable({
   statuses,
-  cycleId,
   cycleNumber,
-  contributionKobo,
+  onSelectMember,
 }: SortablePaymentTableProps) {
   const [sortDir, setSortDir] = useState<SortDir>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -81,7 +79,6 @@ export function SortablePaymentTable({
 
       {/* Column headers */}
       <div className="flex items-center gap-4 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-        <span className="w-8 shrink-0">#</span>
         <span className="flex-1">Member</span>
         <button
           onClick={toggleSort}
@@ -100,9 +97,8 @@ export function SortablePaymentTable({
             <MemberPaymentRow
               key={status.member.id}
               status={status}
-              cycleId={cycleId}
-              contributionKobo={contributionKobo}
               rowNumber={i + 1}
+              onSelect={() => onSelectMember(status)}
             />
           ))
         ) : (

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { ArrowUpDown, ArrowUp, ArrowDown, Search } from 'lucide-react';
 import { MemberPaymentRow, GRID } from '@/components/dashboard/member-payment-row';
 import type { MemberPaymentStatus } from '@/lib/types';
@@ -52,8 +52,8 @@ export function SortablePaymentTable({
     setSortDir(prev => (prev === 'asc' ? 'desc' : prev === 'desc' ? null : 'asc'));
   }
 
-  const filtered = filterBySearch(statuses, searchQuery);
-  const sorted = sortByDate(filtered, sortDir);
+  const filtered = useMemo(() => filterBySearch(statuses, searchQuery), [statuses, searchQuery]);
+  const sorted = useMemo(() => sortByDate(filtered, sortDir), [filtered, sortDir]);
 
   const SortIcon = sortDir === 'asc' ? ArrowUp : sortDir === 'desc' ? ArrowDown : ArrowUpDown;
 

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -10,7 +10,7 @@ type SortDir = 'asc' | 'desc' | null;
 interface SortablePaymentTableProps {
   statuses: MemberPaymentStatus[];
   cycleNumber: number;
-  onSelectMember: (status: MemberPaymentStatus) => void;
+  onSelectMember: (status: MemberPaymentStatus, rowNumber: number) => void;
 }
 
 function filterBySearch(statuses: MemberPaymentStatus[], query: string): MemberPaymentStatus[] {
@@ -100,7 +100,7 @@ export function SortablePaymentTable({
               key={status.member.id}
               status={status}
               rowNumber={i + 1}
-              onSelect={() => onSelectMember(status)}
+              onSelect={() => onSelectMember(status, i + 1)}
             />
           ))
         ) : (

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -77,22 +77,28 @@ export function SortablePaymentTable({
         </div>
       </div>
 
-      {/* Column headers — same grid as rows */}
+      {/* Column headers — identical outer grid to rows */}
       <div className="grid gap-x-3 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
-        [grid-template-columns:2rem_minmax(0,1fr)_auto]
-        sm:[grid-template-columns:2rem_minmax(0,1fr)_9rem_5rem_auto]">
+        [grid-template-columns:2rem_1fr_auto]">
         <span />
-        <span>Member</span>
-        <span className="hidden sm:block">Phone</span>
-        <button
-          onClick={toggleSort}
-          className="hidden sm:inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label={`Sort by date ${sortDir === 'asc' ? 'descending' : 'ascending'}`}
-        >
-          Date
-          <SortIcon className="h-3 w-3" aria-hidden="true" />
-        </button>
-        <span className="text-right">Status</span>
+
+        {/* Middle sub-grid — mirrors row middle exactly */}
+        <div className="grid gap-x-3
+          [grid-template-columns:1fr]
+          sm:[grid-template-columns:minmax(0,9rem)_9rem_5rem]">
+          <span>Member</span>
+          <span className="hidden sm:block">Phone</span>
+          <button
+            onClick={toggleSort}
+            className="hidden sm:inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={`Sort by date ${sortDir === 'asc' ? 'descending' : 'ascending'}`}
+          >
+            Date
+            <SortIcon className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </div>
+
+        <span>Status</span>
       </div>
 
       {/* Card list */}

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -78,7 +78,7 @@ export function SortablePaymentTable({
       </div>
 
       {/* Column headers — exact same flat grid as rows */}
-      <div className="grid gap-x-4 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
+      <div className="grid gap-x-4 px-8 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
         [grid-template-columns:2rem_1fr_8rem]
         sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]">
         <span>No</span>
@@ -96,7 +96,7 @@ export function SortablePaymentTable({
       </div>
 
       {/* Card list */}
-      <div className="pb-4 space-y-2">
+      <div className="pb-4 px-4 space-y-2">
         {sorted.length > 0 ? (
           sorted.map((status, i) => (
             <MemberPaymentRow

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -79,7 +79,7 @@ export function SortablePaymentTable({
 
       {/* Column headers — identical outer grid to rows */}
       <div className="grid gap-x-3 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
-        [grid-template-columns:2rem_1fr_auto]">
+        [grid-template-columns:2rem_1fr_8rem]">
         <span />
 
         {/* Middle sub-grid — mirrors row middle exactly */}
@@ -98,7 +98,7 @@ export function SortablePaymentTable({
           </button>
         </div>
 
-        <span>Status</span>
+        <span className="text-right">Status</span>
       </div>
 
       {/* Card list */}

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -96,7 +96,7 @@ export function SortablePaymentTable({
       </div>
 
       {/* Card list */}
-      <div className="px-4 pb-4 space-y-2">
+      <div className="pb-4 space-y-2">
         {sorted.length > 0 ? (
           sorted.map((status, i) => (
             <MemberPaymentRow

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -2,14 +2,6 @@
 
 import { useState } from 'react';
 import { ArrowUpDown, ArrowUp, ArrowDown, Search } from 'lucide-react';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 import { MemberPaymentRow } from '@/components/dashboard/member-payment-row';
 import type { MemberPaymentStatus } from '@/lib/types';
 
@@ -68,7 +60,8 @@ export function SortablePaymentTable({
   const SortIcon = sortDir === 'asc' ? ArrowUp : sortDir === 'desc' ? ArrowDown : ArrowUpDown;
 
   return (
-    <>
+    <div aria-label={`Member payment statuses for Cycle ${cycleNumber}`}>
+      {/* Search */}
       <div className="px-4 pt-3 pb-2">
         <div className="relative">
           <Search
@@ -86,43 +79,38 @@ export function SortablePaymentTable({
         </div>
       </div>
 
-      <Table aria-label={`Member payment statuses for Cycle ${cycleNumber}`}>
-        <TableHeader>
-          <TableRow className="border-border hover:bg-transparent">
-            <TableHead className="w-10 pl-4 text-xs text-muted-foreground">#</TableHead>
-            <TableHead className="text-xs text-muted-foreground">Member</TableHead>
-            <TableHead className="text-right pr-4 text-xs text-muted-foreground">
-              <button
-                onClick={toggleSort}
-                className="inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors ml-auto rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                aria-label={`Sort by date ${sortDir === 'asc' ? 'descending' : 'ascending'}`}
-              >
-                Date / Status
-                <SortIcon className="h-3 w-3" aria-hidden="true" />
-              </button>
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {sorted.length > 0 ? (
-            sorted.map((status, i) => (
-              <MemberPaymentRow
-                key={status.member.id}
-                status={status}
-                cycleId={cycleId}
-                contributionKobo={contributionKobo}
-                rowNumber={i + 1}
-              />
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={3} className="py-8 text-center text-sm text-muted-foreground">
-                No members match &ldquo;{searchQuery}&rdquo;
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
-    </>
+      {/* Column headers */}
+      <div className="flex items-center gap-4 px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        <span className="w-8 shrink-0">#</span>
+        <span className="flex-1">Member</span>
+        <button
+          onClick={toggleSort}
+          className="ml-auto inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`Sort by date ${sortDir === 'asc' ? 'descending' : 'ascending'}`}
+        >
+          Date / Status
+          <SortIcon className="h-3 w-3" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Card list */}
+      <div className="px-4 pb-4 space-y-2">
+        {sorted.length > 0 ? (
+          sorted.map((status, i) => (
+            <MemberPaymentRow
+              key={status.member.id}
+              status={status}
+              cycleId={cycleId}
+              contributionKobo={contributionKobo}
+              rowNumber={i + 1}
+            />
+          ))
+        ) : (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No members match &ldquo;{searchQuery}&rdquo;
+          </p>
+        )}
+      </div>
+    </div>
   );
 }

--- a/components/dashboard/sortable-payment-table.tsx
+++ b/components/dashboard/sortable-payment-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { ArrowUpDown, ArrowUp, ArrowDown, Search } from 'lucide-react';
-import { MemberPaymentRow } from '@/components/dashboard/member-payment-row';
+import { MemberPaymentRow, GRID } from '@/components/dashboard/member-payment-row';
 import type { MemberPaymentStatus } from '@/lib/types';
 
 type SortDir = 'asc' | 'desc' | null;
@@ -77,10 +77,7 @@ export function SortablePaymentTable({
         </div>
       </div>
 
-      {/* Column headers — exact same flat grid as rows */}
-      <div className="grid gap-x-4 px-8 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
-        [grid-template-columns:2rem_1fr_8rem]
-        sm:[grid-template-columns:2rem_2fr_2fr_1.5fr_1.5fr]">
+      <div className={`grid gap-x-4 px-8 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider ${GRID}`}>
         <span>No</span>
         <span>Member</span>
         <span className="hidden sm:block">Phone</span>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-[backdrop-filter]:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -57,7 +57,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        "border-b transition-colors data-[state=selected]:bg-muted",
         className
       )}
       {...props}

--- a/docs/CODEMAPS/INDEX.md
+++ b/docs/CODEMAPS/INDEX.md
@@ -1,0 +1,98 @@
+# Codemaps Index
+
+Architectural maps of the circle-dashboard codebase. Each map describes entry points, module structure, data flow, and component patterns for a specific area.
+
+**Last Updated:** 2026-03-28
+
+---
+
+## Available Codemaps
+
+### Frontend (`frontend.md`)
+
+Covers the Next.js App Router frontend, dashboard components, UI primitives, and client-side interactions.
+
+**Key Files:**
+- `app/page.tsx` — Dashboard orchestration
+- `components/dashboard/*` — Dashboard components
+- `components/ui/*` — shadcn/ui + custom primitives
+- `lib/utils.ts` — Utility functions and data derivation
+
+**Topics:**
+- Page load data flow (SSR)
+- Component composition patterns
+- Server vs. client component boundaries
+- Theme toggle and loading states
+- Card-based payment table redesign
+- Payment status badge (row and tile variants)
+- Utility functions for formatting and data derivation
+
+---
+
+## Project Overview
+
+```
+circle-dashboard/
+├── Frontend (Next.js 16 App Router)
+│   └── See: frontend.md
+│
+├── Backend API
+│   └── Proxied via lib/data.ts to BACKEND_URL (Rust/SurrealDB)
+│
+├── Design System
+│   └── See: docs/design-system.md (tokens, components, conventions)
+│
+└── Tests
+    └── E2E with Playwright (tests/*.spec.ts)
+```
+
+---
+
+## Quick Links
+
+- **README.md** — Quick start, scripts, environment variables, project structure
+- **design-system.md** — Tokens, color space (OKLCH), component conventions
+- **CONTRIBUTING.md** — Development workflow, testing, branching
+- **RUNBOOK.md** — Deployment and operations checklist
+
+---
+
+## Data Model
+
+All monetary amounts are stored in **kobo** (NGN × 100) as integers.
+
+**Core Types:**
+- `Member` — Group member (name, phone, status, position)
+- `Cycle` — Savings cycle (recipientMemberId, status, contributionPerMember)
+- `Payment` — Payment record (memberId, cycleId, amount, paymentDate)
+
+**Derived Types:**
+- `MemberPaymentStatus` — { member, hasPaid, payment }
+- `CycleSummary` — { cycle, recipient, paidCount, totalMembers, collectedKobo }
+
+---
+
+## Testing
+
+Run E2E tests with Playwright:
+
+```bash
+yarn test:e2e          # Run all tests
+yarn test:e2e:ui       # Interactive UI mode
+yarn test:e2e:report   # View HTML report
+```
+
+Test files: `tests/*.spec.ts` and `tests/pages/*.page.ts` (Page Object Model)
+
+---
+
+## Common Navigation
+
+**Looking for...**
+
+- How to add a new dashboard component? → `frontend.md` → Common Tasks
+- Design tokens or styling conventions? → `design-system.md`
+- Environment configuration? → `lib/config.ts` + `README.md` → Environment Variables
+- Data fetching? → `frontend.md` → Data Flow + `lib/data.ts`
+- Server actions (payment toggle)? → `lib/actions.ts` + `frontend.md` → Payment Toggle flow
+- Component testing? → `tests/dashboard.spec.ts` + `frontend.md` → Testing

--- a/docs/CODEMAPS/frontend.md
+++ b/docs/CODEMAPS/frontend.md
@@ -1,0 +1,281 @@
+# Frontend Codemap
+
+**Last Updated:** 2026-03-28
+
+**Entry Points:**
+- `app/page.tsx` — Dashboard page (server component, data orchestration)
+- `app/layout.tsx` — Root layout (theme provider, metadata)
+- `app/error.tsx` — Error boundary
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        app/page.tsx                              │
+│                   (Server Component)                             │
+│          Fetches members, cycles, payments in parallel          │
+└──────────────────────┬──────────────────────────────────────────┘
+                       │
+         ┌─────────────┼─────────────┐
+         ▼             ▼             ▼
+    DashboardHeader  KpiStats   ActiveCycleCard
+                     │
+                     ├──────────────┬───────────────────┐
+                     ▼              ▼                   ▼
+            PaymentStatusGrid  OutstandingAlert  (Theme Toggle)
+                     │
+        ┌────────────┤
+        ▼            ▼
+  Sortable Table  Chart Toggle
+        │
+        ▼
+  MemberPaymentRow (repeating)
+        │
+   ├─ Payment Badge (icon variant)
+   ├─ Phone formatter
+   ├─ Payment Date display
+   └─ PaymentToggleButton
+```
+
+---
+
+## Key Modules
+
+### Pages
+
+| Module | Purpose | Exports | Dependencies |
+|--------|---------|---------|--------------|
+| `app/page.tsx` | Dashboard orchestration | default (async component) | `lib/data`, `lib/utils`, all dashboard components |
+| `app/error.tsx` | Error boundary | default (client component) | Button, router |
+| `app/layout.tsx` | Root layout | default | ThemeProvider, Geist font |
+| `app/loading.tsx` | Loading skeleton (card-based) | default | Skeleton component |
+
+### Dashboard Components
+
+| Module | Purpose | Key Props | Usage |
+|--------|---------|-----------|-------|
+| `header.tsx` | Group header + date + cycle badge | `activeCycle: CycleSummary \| null` | Rendered once per page |
+| `kpi-stats.tsx` | KPI tile row (3-column grid) | `totalKobo, collectedKobo, paidCount, totalMembers` | Above main content grid |
+| `active-cycle-card.tsx` | Cycle info + recipient info | `summary: CycleSummary` | Left column, top |
+| `collection-progress.tsx` | Progress bar + ₦ display | `collectedKobo, totalKobo` | Embedded in active-cycle-card |
+| `outstanding-alert.tsx` | Alert banner for unpaid members | `statuses: MemberPaymentStatus[], contributionPerMemberKobo` | Left column, below cycle card |
+| `payment-status-grid.tsx` | Table/chart toggle card | `statuses, cycleId, cycleNumber, contributionKobo, cycles, payments` | Right column |
+| `sortable-payment-table.tsx` | Sortable member table with search | `statuses, cycleId, contributionKobo` | Inside payment-status-grid |
+| `member-payment-row.tsx` | Single row in payment table (card-based) | `status, cycleId, contributionKobo, rowNumber` | Repeating rows in table |
+| `cycle-performance-chart.tsx` | Per-cycle + cumulative chart | `cycles, payments, members` | Inside payment-status-grid (toggle target) |
+| `payment-toggle-button.tsx` | Mark paid/unpaid action | `memberId, cycleId, hasPaid, contributionKobo` | Right edge of member-payment-row |
+| `theme-toggle.tsx` | Light/dark mode toggle | (none) | Header area |
+
+### UI Primitives
+
+| Module | Purpose | Variants | Base |
+|--------|---------|----------|------|
+| `ui/button.tsx` | Action button | `variant`, `size` | shadcn/ui (Base UI) |
+| `ui/badge.tsx` | Status indicator | Inline flex with color variants | shadcn/ui |
+| `ui/card.tsx` | Container surface | Semantic wrapper | shadcn/ui |
+| `ui/table.tsx` | Semantic table markup | Thead, Tbody, Tr, Td | shadcn/ui |
+| `ui/progress.tsx` | Visual progress indicator | `value`, `max` | shadcn/ui + CVA |
+| `ui/chart.tsx` | Victory chart wrapper | Victory re-exports | shadcn/ui + Victory |
+| `ui/dropdown-menu.tsx` | Dropdown menu shell | Popover-based | Base UI |
+| `ui/tooltip.tsx` | Hover tooltip | Popover-based | Base UI |
+| `ui/separator.tsx` | Visual divider | `orientation` | shadcn/ui |
+| `ui/skeleton.tsx` | Loading placeholder | Pulse animation | shadcn/ui |
+
+### Dashboard Specific Components
+
+| Module | Purpose | Props | Usage |
+|--------|---------|-------|-------|
+| `dashboard/payment-status-badge.tsx` | Status badge (paid/outstanding) | `hasPaid`, `variant: 'row' \| 'tile'` | Inside member payment rows and detail overlays |
+
+### Utilities
+
+| Module | Purpose | Key Exports |
+|--------|---------|-------------|
+| `lib/utils.ts` | Formatting + data derivation | `cn()`, `formatNgn()`, `formatPhone()`, `formatPaymentDate()`, `padZero()`, `getMemberPaymentStatuses()`, `deriveCycleSummary()` |
+| `lib/types.ts` | Domain types | `Member`, `Payment`, `Cycle`, `MemberPaymentStatus`, `CycleSummary` |
+| `lib/config.ts` | Environment configuration | `BACKEND_URL`, `NEXT_PUBLIC_BASE_URL` |
+
+---
+
+## Data Flow
+
+### Page Load (SSR)
+
+```
+1. app/page.tsx mounts (server component)
+2. Parallel fetches:
+   - fetchMembers() → lib/data.ts → BACKEND_URL/api/members
+   - fetchCycles() → lib/data.ts → BACKEND_URL/api/cycles
+   - fetchPayments() → lib/data.ts → BACKEND_URL/api/payments
+3. Derive computed state:
+   - activeCycle = find cycle with status='active'
+   - activeCycleSummary = deriveCycleSummary(cycle, members, payments)
+   - paymentStatuses = getMemberPaymentStatuses(members, payments, cycleId, recipientId)
+4. Render tree with props passed down
+```
+
+### Payment Toggle (Client-Side Action)
+
+```
+1. User clicks toggle button in MemberPaymentRow
+2. PaymentToggleButton calls server action (lib/actions.ts)
+3. Server action hits BACKEND_URL/api/payments endpoint
+4. Page revalidates via revalidatePath('/')
+5. Component tree re-renders with new payment data
+```
+
+### Theme Toggle
+
+```
+1. User clicks theme-toggle.tsx
+2. next-themes updates localStorage('theme')
+3. HTML element class updated (.dark added/removed)
+4. Tailwind @media(prefers-color-scheme) + .dark CSS apply
+5. All components re-render with new color tokens
+```
+
+---
+
+## Component Composition Patterns
+
+### Composition Over Props Drilling
+
+Dashboard uses **slot-based composition** for empty states:
+
+```tsx
+// Bad: too many props
+<Empty
+  title="404"
+  description="..."
+  icon={GhostIcon}
+  buttons={[...]}
+/>
+
+// Good: semantic slots
+<Empty>
+  <EmptyHeader>
+    <EmptyMedia variant="icon"><Ghost /></EmptyMedia>
+    <EmptyTitle>404</EmptyTitle>
+    <EmptyDescription>...</EmptyDescription>
+  </EmptyHeader>
+  <EmptyContent>
+    {/* Action buttons */}
+  </EmptyContent>
+</Empty>
+```
+
+The `Empty` primitive uses **data-slot attributes** for styling instead of prop cascading.
+
+### Server Components for Data Fetching
+
+- `app/page.tsx` is a server component → fetches directly in render
+- Child components are client components only when they need:
+  - Interactivity (`onClick`, form submits)
+  - Hooks (`useState`, `useRouter`)
+  - Theme awareness (`next-themes`)
+
+This reduces JavaScript sent to the client.
+
+### Loading States
+
+Skeletons in `app/loading.tsx` use the **same layout** as actual content:
+- KPI grid (3 columns)
+- Cycle card skeleton
+- Payment table skeleton
+
+When loading completes, actual content swaps in without layout shift.
+
+---
+
+## External Dependencies
+
+### UI Framework
+- **next.js** (16) — React framework, SSR, App Router
+- **react** (19) — UI primitives
+- **tailwindcss** (v4) — Utility CSS
+- **@headlessui/react** / **@base-ui-components/react** — Headless components
+- **shadcn/ui** — Copy-paste component library
+- **class-variance-authority** — Component variants
+
+### Data Visualization
+- **victory** — Chart library (per-cycle + cumulative)
+- **@recharts/recharts** — Alternative charting (unused, from scaffolding)
+
+### Theme & Styling
+- **next-themes** — Theme provider (light/dark mode)
+- **clsx** — Conditional classnames
+- **tailwind-merge** — Merge Tailwind classes
+
+### Icons
+- **lucide-react** — Icon library
+
+### Testing
+- **@playwright/test** — E2E test runner
+- **zod** — Type validation (testing only)
+
+### Utilities
+- **date-fns** — Date formatting (if used; otherwise native toLocaleDateString)
+
+---
+
+## Related Areas
+
+- **Backend**: `/backend` (Rust/SurrealDB) — See `/docs/backend.md`
+- **Design System**: `/docs/design-system.md` — Token reference, component conventions
+- **Testing**: Tests in `/tests/` directory — See test specs for E2E coverage
+- **Configuration**: `lib/config.ts` — Environment variable handling
+
+---
+
+## Common Tasks
+
+### Add a New KPI Stat
+1. Update `Member`, `Payment`, or `Cycle` in `lib/types.ts`
+2. Add computation to `lib/utils.ts` (or derive in `app/page.tsx`)
+3. Add new stat to `KpiStats` in `components/dashboard/kpi-stats.tsx`
+4. Update `lib/mock-data.ts` for local testing
+
+### Add a New Chart or Toggle
+1. Create component in `components/dashboard/`
+2. Add toggle state to `PaymentStatusGrid` (or new top-level component)
+3. Pass required data through props
+4. Wire into `app/page.tsx` render tree
+5. Add E2E test to `tests/dashboard.spec.ts`
+
+### Style a Component
+1. Use design tokens in `app/globals.css` (`--background`, `--foreground`, etc.)
+2. Build classes with `cn()` from `lib/utils.ts` + `clsx`
+3. Use Tailwind utilities (`bg-card`, `text-foreground`, `border-border`)
+4. No hardcoded colors — all derive from CSS custom properties
+5. Test in both light and dark modes
+
+### Debugging
+
+```bash
+# Build for production
+yarn build
+
+# Check for type errors
+tsc --noEmit
+
+# Run E2E tests with UI
+yarn test:e2e:ui
+
+# Run specific test
+yarn test:e2e -- tests/dashboard.spec.ts
+
+# Check generated CSS
+# Look at .next/static/css/ after yarn build
+```
+
+---
+
+## Notes
+
+- **PaymentStatusBadge** supports two variants: `row` (compact, used in table) and `tile` (full-height, used in detail overlay)
+- **Formatters** (`formatPhone`, `formatPaymentDate`, `padZero`) are exported from `lib/utils.ts` for reuse across components
+- **Payment toggle** is a server action, not a client-side mutation — ensures data consistency with backend
+- **Chart rendering** is lazy-loaded inside `PaymentStatusGrid` toggle to avoid rendering both table and chart simultaneously
+- **Loading skeleton** (`app/loading.tsx`) mimics the card-based layout to prevent layout shift during hydration

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,6 +14,23 @@ export function formatNgn(kobo: number): string {
   return `₦${koboToNgn(kobo).toLocaleString('en-NG')}`;
 }
 
+export function formatPhone(phone: string): string {
+  const digits = phone.replace(/\D/g, '');
+  if (digits.length === 13 && digits.startsWith('234')) {
+    return `+234 ${digits.slice(3, 6)} ${digits.slice(6, 9)} ${digits.slice(9)}`;
+  }
+  return `+${digits}`;
+}
+
+export function formatPaymentDate(isoDate: string, includeYear = false): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    ...(includeYear ? { year: 'numeric' } : {}),
+  });
+}
+
 export function getMemberPaymentStatuses(
   members: Member[],
   payments: Payment[],

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,6 +22,10 @@ export function formatPhone(phone: string): string {
   return `+${digits}`;
 }
 
+export function padZero(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
 export function formatPaymentDate(isoDate: string, includeYear = false): string {
   const [year, month, day] = isoDate.split('-').map(Number);
   return new Date(year, month - 1, day).toLocaleDateString('en-GB', {

--- a/tests/regression.spec.ts
+++ b/tests/regression.spec.ts
@@ -6,7 +6,7 @@
  *
  *   1. Recipient exclusion — the member collecting this cycle is excluded
  *      from the payment table and all contribution-based calculations.
- *   2. Sequential row numbers — table rows are numbered 1…N regardless of
+ *   2. Sequential row numbers — table rows are numbered 01…05 regardless of
  *      the member's position in the rotation order.
  *   3. KPI accuracy — Total Pot, Collected, and Outstanding all reflect the
  *      5 contributing members, not the full 6-member group.
@@ -46,14 +46,14 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Recipient exclusion', () => {
   test('Ngozi Adeyemi does not appear in the payment table', async ({ page }) => {
-    const table = page.locator('table[aria-label*="Cycle 3"]');
+    const table = page.locator('div[aria-label*="Cycle 3"]');
     await expect(table).toBeVisible();
     await expect(table.getByText('Ngozi Adeyemi')).not.toBeVisible();
   });
 
-  test('payment table shows exactly 5 rows (5 contributing members)', async ({ page }) => {
-    const table = page.locator('table[aria-label*="Cycle 3"]');
-    const rows = table.locator('tbody tr');
+  test('payment table shows exactly 5 card rows (5 contributing members)', async ({ page }) => {
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    const rows = table.locator('[role="button"]');
     await expect(rows).toHaveCount(5);
   });
 
@@ -69,21 +69,26 @@ test.describe('Recipient exclusion', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Sequential row numbers', () => {
-  test('first cell of each row is numbered 1 through 5 in order', async ({ page }) => {
-    const table = page.locator('table[aria-label*="Cycle 3"]');
-    const rows = table.locator('tbody tr');
+  test('first cell of each row is numbered 01 through 05 in order', async ({ page }) => {
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    const rows = table.locator('[role="button"]');
 
     for (let i = 1; i <= 5; i++) {
-      const numberCell = rows.nth(i - 1).locator('td').first().locator('span.tabular-nums');
-      await expect(numberCell).toHaveText(String(i));
+      const numberCell = rows.nth(i - 1).locator('span.tabular-nums').first();
+      await expect(numberCell).toHaveText(`0${i}`);
     }
   });
 
   test('row numbers do not skip (no gap at position 3 where recipient was)', async ({ page }) => {
-    const table = page.locator('table[aria-label*="Cycle 3"]');
-    const numberCells = table.locator('tbody tr td:first-child span.tabular-nums');
-    const texts = await numberCells.allInnerTexts();
-    expect(texts).toEqual(['1', '2', '3', '4', '5']);
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    const rows = table.locator('[role="button"]');
+    const numberCells = rows.locator('span.tabular-nums').first();
+    // Collect all row number texts
+    const texts: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      texts.push(await rows.nth(i).locator('span.tabular-nums').first().innerText());
+    }
+    expect(texts).toEqual(['01', '02', '03', '04', '05']);
   });
 });
 
@@ -188,16 +193,60 @@ test.describe('Active cycle card', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 7. Payment toggle — state updates flow back to KPIs and progress bar
+// 7. Card row overlay — inline member detail
+// ---------------------------------------------------------------------------
+
+test.describe('Card row overlay', () => {
+  test('clicking a row opens the inline overlay with the member name', async ({ page }) => {
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    const tundeRow = table.locator('[role="button"]').filter({ hasText: 'Tunde Bakare' });
+    await tundeRow.click();
+
+    // Overlay should appear inside the Member Payments card
+    const overlay = page.locator('[aria-label="Close member detail"]');
+    await expect(overlay).toBeVisible();
+    await expect(page.getByText('Tunde Bakare').first()).toBeVisible();
+  });
+
+  test('overlay close button dismisses the overlay', async ({ page }) => {
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    await table.locator('[role="button"]').first().click();
+
+    const closeBtn = page.getByRole('button', { name: 'Close member detail' });
+    await expect(closeBtn).toBeVisible();
+    await closeBtn.click();
+    await expect(closeBtn).not.toBeVisible();
+  });
+
+  test('overlay shows Outstanding status for Tunde Bakare', async ({ page }) => {
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    await table.locator('[role="button"]').filter({ hasText: 'Tunde Bakare' }).click();
+
+    const overlay = page.locator('button[aria-label="Close member detail"]').locator('..');
+    await expect(page.getByText('Outstanding').last()).toBeVisible();
+  });
+
+  test('overlay shows Paid status for Adaeze', async ({ page }) => {
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    await table.locator('[role="button"]').filter({ hasText: 'Adaeze' }).click();
+
+    await expect(page.getByText('Paid').last()).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Payment toggle — state updates flow back to KPIs and progress bar
 // ---------------------------------------------------------------------------
 
 test.describe('Payment toggle integration', () => {
-  test('marking Tunde as paid updates collected count to 4 of 5', async ({ page }) => {
-    const table = page.locator('table[aria-label*="Cycle 3"]');
-    const tundeRow = table.locator('tr').filter({ hasText: 'Tunde Bakare' });
+  test('marking Tunde as paid via overlay updates collected count to 4 of 5', async ({ page }) => {
+    // Open Tunde's card overlay
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    await table.locator('[role="button"]').filter({ hasText: 'Tunde Bakare' }).click();
 
-    // Click the "Mark paid" button on Tunde's row
-    const markPaidBtn = tundeRow.getByRole('button', { name: 'Mark as paid' });
+    // Mark as paid from the overlay
+    const markPaidBtn = page.getByRole('button', { name: 'Mark as paid' });
+    await expect(markPaidBtn).toBeVisible();
     await markPaidBtn.click();
 
     // Wait for server action + page revalidation
@@ -207,5 +256,41 @@ test.describe('Payment toggle integration', () => {
     const region = page.getByRole('region', { name: 'Cycle summary statistics' });
     const collectedCard = region.locator('[data-slot="card"]').filter({ hasText: 'Collected' });
     await expect(collectedCard.getByText('4 of 5 paid')).toBeVisible({ timeout: 10000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Search
+// ---------------------------------------------------------------------------
+
+test.describe('Search', () => {
+  test('filtering by name hides non-matching rows', async ({ page }) => {
+    const searchInput = page.getByRole('searchbox', { name: 'Search members by name or phone' });
+    await searchInput.fill('Tunde');
+
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    const rows = table.locator('[role="button"]');
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first().getByText('Tunde Bakare')).toBeVisible();
+  });
+
+  test('clearing search restores all 5 rows', async ({ page }) => {
+    const searchInput = page.getByRole('searchbox', { name: 'Search members by name or phone' });
+    await searchInput.fill('Tunde');
+
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    await expect(table.locator('[role="button"]')).toHaveCount(1);
+
+    await searchInput.fill('');
+    await expect(table.locator('[role="button"]')).toHaveCount(5);
+  });
+
+  test('no-match query shows empty state message', async ({ page }) => {
+    const searchInput = page.getByRole('searchbox', { name: 'Search members by name or phone' });
+    await searchInput.fill('zzznomatch');
+
+    const table = page.locator('div[aria-label*="Cycle 3"]');
+    await expect(table.locator('[role="button"]')).toHaveCount(0);
+    await expect(page.getByText(/No members match/)).toBeVisible();
   });
 });

--- a/tests/regression.spec.ts
+++ b/tests/regression.spec.ts
@@ -82,7 +82,6 @@ test.describe('Sequential row numbers', () => {
   test('row numbers do not skip (no gap at position 3 where recipient was)', async ({ page }) => {
     const table = page.locator('div[aria-label*="Cycle 3"]');
     const rows = table.locator('[role="button"]');
-    const numberCells = rows.locator('span.tabular-nums').first();
     // Collect all row number texts
     const texts: string[] = [];
     for (let i = 0; i < 5; i++) {
@@ -222,8 +221,8 @@ test.describe('Card row overlay', () => {
     const table = page.locator('div[aria-label*="Cycle 3"]');
     await table.locator('[role="button"]').filter({ hasText: 'Tunde Bakare' }).click();
 
-    const overlay = page.locator('button[aria-label="Close member detail"]').locator('..');
-    await expect(page.getByText('Outstanding').last()).toBeVisible();
+    const overlay = page.locator('button[aria-label="Close member detail"]').locator('xpath=ancestor::div[3]');
+    await expect(overlay.getByText('Outstanding')).toBeVisible();
   });
 
   test('overlay shows Paid status for Adaeze', async ({ page }) => {

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -95,9 +95,9 @@ test.describe('Visual — light mode', () => {
   });
 
   test('screenshot — payment table', async ({ page }) => {
-    const table = page.locator('table').first();
-    await expect(table).toBeVisible();
-    await table.screenshot({
+    const paymentCard = page.locator('div[aria-label*="Cycle"]').first();
+    await expect(paymentCard).toBeVisible();
+    await paymentCard.screenshot({
       path: path.join(SCREENSHOTS_DIR, 'light-payment-table.png'),
     });
   });
@@ -154,9 +154,9 @@ test.describe('Visual — dark mode', () => {
   });
 
   test('screenshot — payment table in dark mode', async ({ page }) => {
-    const table = page.locator('table').first();
-    await expect(table).toBeVisible();
-    await table.screenshot({
+    const paymentCard = page.locator('div[aria-label*="Cycle"]').first();
+    await expect(paymentCard).toBeVisible();
+    await paymentCard.screenshot({
       path: path.join(SCREENSHOTS_DIR, 'dark-payment-table.png'),
     });
   });


### PR DESCRIPTION
## Summary

- Converts the Member Payments table from a traditional table to a card-based layout matching the reference design
- Replaces the full-screen payment dialog with an inline overlay anchored inside the Member Payments card
- Adds a separate Phone column on sm+ breakpoints (stacked under name on mobile) and decouples Date from Status badge
- Aligns headers and rows using a shared `GRID` constant so they can't drift
- Adds per-row stagger slide-in animation (`row-slide-in` keyframe, 80ms delay increments)
- Moves `formatPhone` and `formatPaymentDate` to `lib/utils` (were duplicated across two components)
- PaymentToggleButton lives exclusively inside the overlay (removed from row cards)

## Test plan

- [ ] Desktop (sm+): No, Member, Phone, Date, Status columns all align with their headers
- [ ] Mobile: No, Member (with stacked phone), Status — three columns, phone/date headers hidden
- [ ] Click a row → inline overlay opens; X button dismisses it
- [ ] Mark paid / undo in overlay → row badge and gradient update after server re-render
- [ ] Search by name and phone number works
- [ ] Date sort (asc/desc/none) works
- [ ] Light and dark mode — both look correct