### PR TITLE
feat: branded 404 not-found page with Empty primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ circle-dashboard/
 │   ├── page.tsx                # Dashboard page — server component, fetches + composes
 │   ├── loading.tsx             # Loading skeleton with card layout
 │   ├── error.tsx               # Error boundary for dashboard
+│   ├── not-found.tsx           # 404 page — branded error with <h1> heading for a11y
 │   ├── globals.css             # Tailwind v4 + shadcn tokens + Ajo accent colours
 │   └── api/
 │       ├── members/route.ts    # GET /api/members  → Member[]
@@ -86,9 +87,10 @@ circle-dashboard/
 │   └── actions.ts      # Server actions (payment toggle)
 │
 └── tests/
-    ├── dashboard.spec.ts       # E2E tests — toggle flows, chart rendering, tooltips
-    ├── pages/dashboard.page.ts # Page Object Model for dashboard
-    └── screenshots/            # Visual regression baselines (gitignored)
+    ├── pages/dashboard.page.ts  # Page Object Model for dashboard
+    ├── dashboard.spec.ts        # E2E tests — toggle flows, chart rendering, tooltips
+    ├── not-found.spec.ts        # E2E tests — 404 page rendering, navigation, a11y (9 tests)
+    └── screenshots/             # Visual regression baselines (gitignored)
 ```
 
 ---
@@ -109,4 +111,11 @@ All components meet **WCAG 2.2 AA**. Tested with Playwright E2E tests:
 yarn test:e2e
 ```
 
-Key requirements met: semantic `<table>`, `role="progressbar"` with aria attrs, `role="alert"` on outstanding banner, status badges use text (not colour alone), visible focus rings, full keyboard navigation, proper dark mode contrast in all states.
+Key requirements met:
+- Semantic `<table>` for tabular data
+- `role="progressbar"` with aria attrs for collection progress
+- `role="alert"` on outstanding members banner
+- `<h1>` heading on 404 page for screen reader navigation
+- Status badges use text (not colour alone)
+- Visible focus rings and full keyboard navigation
+- Proper dark mode contrast in all states

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -10,7 +10,6 @@ import {
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
-  EmptyTitle,
 } from '@/components/ui/empty';
 
 export default function NotFound() {
@@ -24,10 +23,13 @@ export default function NotFound() {
             <Ghost aria-hidden="true" />
           </EmptyMedia>
 
-          <EmptyTitle>
+          <h1
+            data-slot="empty-title"
+            className="font-bold tracking-tight text-xl leading-none"
+          >
             <span className="text-muted-foreground">40</span>
             <span className="text-ajo-paid">4</span>
-          </EmptyTitle>
+          </h1>
 
           <EmptyDescription>
             The page you&apos;re looking for doesn&apos;t exist.

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Ghost, Home, ArrowLeft } from 'lucide-react';
+import { Button, buttonVariants } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+
+export default function NotFound() {
+  const router = useRouter();
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Ghost aria-hidden="true" />
+          </EmptyMedia>
+
+          <EmptyTitle>
+            <span className="text-muted-foreground">40</span>
+            <span className="text-ajo-paid">4</span>
+          </EmptyTitle>
+
+          <EmptyDescription>
+            The page you&apos;re looking for doesn&apos;t exist.
+            <br />
+            It may have been moved or deleted.
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <div className="flex items-center gap-3">
+            <Link href="/" className={buttonVariants({ variant: 'outline', size: 'sm', className: 'gap-1.5' })}>
+              <Home className="h-3.5 w-3.5" aria-hidden="true" />
+              Go Home
+            </Link>
+
+            <Button
+              variant="default"
+              size="sm"
+              className="gap-1.5 cursor-pointer"
+              onClick={() => router.back()}
+            >
+              <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+              Go Back
+            </Button>
+          </div>
+        </EmptyContent>
+      </Empty>
+    </div>
+  );
+}

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -6,7 +6,7 @@ function Empty({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="empty"
       className={cn(
-        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-xl border-dashed p-6 text-center text-balance md:p-12',
+        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-xl border border-dashed p-6 text-center text-balance md:p-12',
         className,
       )}
       {...props}
@@ -49,7 +49,6 @@ function EmptyMedia({
       data-slot="empty-media"
       data-variant={variant}
       className={cn('relative mb-6', className)}
-      {...props}
     >
       {variant === 'icon' && (
         <>
@@ -84,7 +83,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="empty-description"

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -1,0 +1,113 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+function Empty({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-xl border-dashed p-6 text-center text-balance md:p-12',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn('flex max-w-sm flex-col items-center text-center', className)}
+      {...props}
+    />
+  );
+}
+
+const emptyMediaVariants = cva(
+  'flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        icon: "relative flex size-9 shrink-0 items-center justify-center rounded-md border bg-card text-foreground shadow-sm shadow-black/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/8%)] [&_svg:not([class*='size-'])]:size-4.5",
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function EmptyMedia({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-media"
+      data-variant={variant}
+      className={cn('relative mb-6', className)}
+      {...props}
+    >
+      {variant === 'icon' && (
+        <>
+          <div
+            className={cn(
+              emptyMediaVariants({ variant, className }),
+              'pointer-events-none absolute bottom-px origin-bottom-left -translate-x-0.5 scale-84 -rotate-10 shadow-none',
+            )}
+            aria-hidden="true"
+          />
+          <div
+            className={cn(
+              emptyMediaVariants({ variant, className }),
+              'pointer-events-none absolute bottom-px origin-bottom-right translate-x-0.5 scale-84 rotate-10 shadow-none',
+            )}
+            aria-hidden="true"
+          />
+        </>
+      )}
+      <div className={cn(emptyMediaVariants({ variant, className }))} {...props} />
+    </div>
+  );
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn('font-bold tracking-tight text-xl leading-none', className)}
+      {...props}
+    />
+  );
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        'text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary [[data-slot=empty-title]+&]:mt-1',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        'flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Empty, EmptyHeader, EmptyTitle, EmptyDescription, EmptyContent, EmptyMedia };

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -89,5 +89,6 @@ Tests are located in `tests/` and target `http://localhost:3001`. The Playwright
 - [ ] `npx tsc --noEmit` passes with zero errors
 - [ ] `yarn lint` passes
 - [ ] `yarn test:e2e` passes (if component or flow changes made)
-- [ ] WCAG 2.2 AA audit passes (zero axe violations)
+- [ ] WCAG 2.2 AA audit passes (zero axe violations) — includes all pages (dashboard, 404, error boundaries)
 - [ ] Monetary amounts displayed via `formatNgn()`, never raw kobo
+- [ ] Error pages use semantic heading tags (`<h1>` for screen reader navigation)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -55,7 +55,7 @@ yarn test:e2e  # Terminal 2
 ```
 
 **Accessibility audit fails**
-Run an axe audit via Playwright tests or manually. Common causes: missing `aria-label`, colour contrast below 4.5:1, status conveyed by colour alone.
+Run an axe audit via Playwright tests or manually. Common causes: missing `aria-label`, colour contrast below 4.5:1, status conveyed by colour alone. All routes (dashboard, 404, error boundaries) must be tested in light and dark mode. Error pages must use semantic heading tags (`<h1>`) for proper screen reader navigation.
 
 ## Deployment
 

--- a/tests/not-found.spec.ts
+++ b/tests/not-found.spec.ts
@@ -28,6 +28,11 @@ test.describe('404 Not-Found page', () => {
     await expect(page.getByText('4').last()).toBeVisible();
   });
 
+  test('404 title is an h1 heading for screen-reader navigation', async ({ page }) => {
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toBeVisible();
+  });
+
   test('shows the description text', async ({ page }) => {
     await expect(page.getByText("The page you're looking for doesn't exist.")).toBeVisible();
     await expect(page.getByText('It may have been moved or deleted.')).toBeVisible();

--- a/tests/not-found.spec.ts
+++ b/tests/not-found.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the branded 404 not-found page.
+ *
+ * Covers:
+ *   1. Rendering — correct content on any unknown route
+ *   2. Navigation — "Go Home" returns to /, "Go Back" is present
+ *   3. Visual — light and dark mode screenshots
+ */
+
+import path from 'path';
+import { test, expect } from '@playwright/test';
+
+const SCREENSHOTS_DIR = path.join(__dirname, 'screenshots');
+
+test.describe('404 Not-Found page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/this-route-does-not-exist');
+    await page.waitForLoadState('networkidle');
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Rendering
+  // -------------------------------------------------------------------------
+
+  test('renders the 404 page on an unknown route', async ({ page }) => {
+    // Both spans together form "404"
+    await expect(page.getByText('40')).toBeVisible();
+    await expect(page.getByText('4').last()).toBeVisible();
+  });
+
+  test('shows the description text', async ({ page }) => {
+    await expect(page.getByText("The page you're looking for doesn't exist.")).toBeVisible();
+    await expect(page.getByText('It may have been moved or deleted.')).toBeVisible();
+  });
+
+  test('renders "Go Home" link', async ({ page }) => {
+    const goHome = page.getByRole('link', { name: /go home/i });
+    await expect(goHome).toBeVisible();
+  });
+
+  test('renders "Go Back" button', async ({ page }) => {
+    const goBack = page.getByRole('button', { name: /go back/i });
+    await expect(goBack).toBeVisible();
+  });
+
+  test('Ghost icon widget is present', async ({ page }) => {
+    // EmptyMedia renders a div[data-slot="empty-media"]
+    const media = page.locator('[data-slot="empty-media"]');
+    await expect(media).toBeVisible();
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Navigation
+  // -------------------------------------------------------------------------
+
+  test('"Go Home" navigates to the root dashboard', async ({ page }) => {
+    await page.getByRole('link', { name: /go home/i }).click();
+    await page.waitForURL('**/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('main')).toBeVisible();
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Visual
+  // -------------------------------------------------------------------------
+
+  test('screenshot — 404 page light mode', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.goto('/this-route-does-not-exist');
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: path.join(SCREENSHOTS_DIR, 'light-not-found.png'),
+      fullPage: true,
+    });
+  });
+
+  test('screenshot — 404 page dark mode', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.goto('/this-route-does-not-exist');
+    await page.waitForLoadState('networkidle');
+
+    const htmlClass = await page.locator('html').getAttribute('class');
+    expect(htmlClass).toContain('dark');
+
+    await page.screenshot({
+      path: path.join(SCREENSHOTS_DIR, 'dark-not-found.png'),
+      fullPage: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `components/ui/empty.tsx` — the `Empty` primitive from 21st.dev (with `font-heading` replaced by `font-bold tracking-tight` since the project has no heading font token)
- Adds `app/not-found.tsx` — a branded 404 page using the Empty components

## Design

- Full-screen centred layout matching `error.tsx`
- `EmptyMedia variant="icon"` renders a `Ghost` icon with two faded, rotated copies behind it (stacked-cards widget from the reference)
- `"404"` title: `"40"` in `text-muted-foreground`, final `"4"` in `text-ajo-paid` (brand accent)
- Two action buttons: **Go Home** (outline, Link to `/`) and **Go Back** (default, `router.back()`)

## Test plan

- [ ] Navigate to `/anything-missing` — branded 404 page renders
- [ ] "Go Home" navigates to `/`
- [ ] "Go Back" goes to previous history entry
- [ ] Light mode and dark mode both look correct