### PR TITLE
feat: 404 page visual polish — hero sizing, gradient, button styles

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -17,7 +17,7 @@ export default function NotFound() {
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center px-4">
-      <Empty>
+      <Empty className="border-0">
         <EmptyHeader>
           <EmptyMedia variant="icon">
             <Ghost aria-hidden="true" />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -19,13 +19,13 @@ export default function NotFound() {
     <div className="min-h-screen bg-background flex items-center justify-center px-4">
       <Empty className="border-0">
         <EmptyHeader>
-          <EmptyMedia variant="icon" className="scale-150 mb-10">
+          <EmptyMedia variant="icon" className="scale-150 mb-5">
             <Ghost aria-hidden="true" />
           </EmptyMedia>
 
           <h1
             data-slot="empty-title"
-            className="font-bold tracking-tight text-8xl md:text-[10rem] leading-none mt-4 bg-gradient-to-br from-foreground via-ajo-paid to-ajo-paid/50 bg-clip-text text-transparent"
+            className="font-bold tracking-tight text-8xl md:text-[10rem] leading-none mt-4 bg-gradient-to-r from-primary via-primary/80 to-blue-500 bg-clip-text text-transparent"
           >
             404
           </h1>
@@ -39,14 +39,14 @@ export default function NotFound() {
 
         <EmptyContent>
           <div className="flex items-center gap-3">
-            <Link href="/" className={buttonVariants({ variant: 'outline', className: 'gap-2' })}>
+            <Link href="/" className={buttonVariants({ variant: 'outline', className: 'gap-2 border-input bg-background shadow-sm shadow-black/5 hover:bg-accent' })}>
               <Home className="h-4 w-4" aria-hidden="true" />
               Go Home
             </Link>
 
             <Button
               variant="default"
-              className="gap-2 cursor-pointer"
+              className="gap-2 cursor-pointer bg-primary text-primary-foreground shadow-sm shadow-black/5 hover:bg-primary/90"
               onClick={() => router.back()}
             >
               <ArrowLeft className="h-4 w-4" aria-hidden="true" />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -19,19 +19,18 @@ export default function NotFound() {
     <div className="min-h-screen bg-background flex items-center justify-center px-4">
       <Empty className="border-0">
         <EmptyHeader>
-          <EmptyMedia variant="icon">
+          <EmptyMedia variant="icon" className="scale-150 mb-10">
             <Ghost aria-hidden="true" />
           </EmptyMedia>
 
           <h1
             data-slot="empty-title"
-            className="font-bold tracking-tight text-xl leading-none"
+            className="font-bold tracking-tight text-8xl md:text-[10rem] leading-none mt-4 bg-gradient-to-br from-foreground via-ajo-paid to-ajo-paid/50 bg-clip-text text-transparent"
           >
-            <span className="text-muted-foreground">40</span>
-            <span className="text-ajo-paid">4</span>
+            404
           </h1>
 
-          <EmptyDescription>
+          <EmptyDescription className="mt-4 text-base md:text-lg">
             The page you&apos;re looking for doesn&apos;t exist.
             <br />
             It may have been moved or deleted.
@@ -40,18 +39,17 @@ export default function NotFound() {
 
         <EmptyContent>
           <div className="flex items-center gap-3">
-            <Link href="/" className={buttonVariants({ variant: 'outline', size: 'sm', className: 'gap-1.5' })}>
-              <Home className="h-3.5 w-3.5" aria-hidden="true" />
+            <Link href="/" className={buttonVariants({ variant: 'outline', className: 'gap-2' })}>
+              <Home className="h-4 w-4" aria-hidden="true" />
               Go Home
             </Link>
 
             <Button
               variant="default"
-              size="sm"
-              className="gap-1.5 cursor-pointer"
+              className="gap-2 cursor-pointer"
               onClick={() => router.back()}
             >
-              <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
               Go Back
             </Button>
           </div>


### PR DESCRIPTION
## Summary

- Full-screen layout: removed the `border` box so the 404 page is truly full-page with centered content (`border-0` on `Empty`)
- Hero text: `text-8xl` on mobile → `text-[10rem]` on desktop with `bg-gradient-to-r from-primary via-primary/80 to-blue-500 bg-clip-text text-transparent` matching the 21st.dev reference
- Icon: reduced bottom margin from `mb-10` to `mb-5`
- Button styles: aligned to reference — outline uses `border-input bg-background shadow-sm shadow-black/5 hover:bg-accent`, primary uses `bg-primary shadow-sm shadow-black/5 hover:bg-primary/90`
- Description text: `text-base` mobile / `text-lg` desktop

## Test plan

- [ ] Navigate to any unknown route — 404 page renders full-screen, no box border
- [ ] "404" gradient reads left-to-right from primary → blue in both light and dark mode
- [ ] Text is large and readable on mobile and desktop
- [ ] "Go Home" and "Go Back" buttons are correctly styled
- [ ] All 9 Playwright tests pass: `yarn test:e2e`