### PR TITLE
Add empty and error state UI

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -3,6 +3,14 @@
 import { useEffect } from 'react';
 import { AlertTriangle, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
 
 interface ErrorProps {
   error: Error & { digest?: string };
@@ -16,25 +24,29 @@ export default function DashboardError({ error, reset }: ErrorProps) {
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center px-4">
-      <div className="max-w-sm w-full text-center space-y-4">
-        <div className="flex justify-center">
-          <div className="rounded-full bg-ajo-outstanding-subtle p-3">
-            <AlertTriangle className="h-6 w-6 text-ajo-outstanding" aria-hidden="true" />
-          </div>
-        </div>
-
-        <div className="space-y-1">
-          <h1 className="text-lg font-semibold text-foreground">Failed to load dashboard</h1>
-          <p className="text-sm text-muted-foreground">
-            Something went wrong fetching the circle data. Try again or check back later.
-          </p>
-        </div>
-
-        <Button onClick={reset} variant="outline" size="sm" className="gap-2 cursor-pointer">
-          <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
-          Try again
-        </Button>
-      </div>
+      <Empty className="border-0" aria-live="assertive">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <AlertTriangle className="text-destructive" aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>Failed to load dashboard</EmptyTitle>
+          <EmptyDescription>
+            Something went wrong fetching the circle data. Try again or check
+            back later.
+          </EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <Button
+            onClick={reset}
+            variant="outline"
+            size="sm"
+            className="gap-2 cursor-pointer"
+          >
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+            Try again
+          </Button>
+        </EmptyContent>
+      </Empty>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,20 +5,36 @@ import { KpiStats } from '@/components/dashboard/kpi-stats';
 import { ActiveCycleCard } from '@/components/dashboard/active-cycle-card';
 import { PaymentStatusGrid } from '@/components/dashboard/payment-status-grid';
 import { OutstandingAlert } from '@/components/dashboard/outstanding-alert';
+import {
+  ServerErrorState,
+  NoDataState,
+  WaitingPaymentState,
+} from '@/components/dashboard/empty-states';
 
 export default async function DashboardPage() {
-  const [members, cycles, payments] = await Promise.all([
+  const [membersResult, cyclesResult, paymentsResult] = await Promise.all([
     fetchMembers(),
     fetchCycles(),
     fetchPayments(),
   ]);
+
+  const serverError =
+    !membersResult.ok || !cyclesResult.ok || !paymentsResult.ok;
+  const members = membersResult.data;
+  const cycles = cyclesResult.data;
+  const payments = paymentsResult.data;
 
   const activeCycle = cycles.find(c => c.status === 'active') ?? null;
   const activeCycleSummary = activeCycle
     ? deriveCycleSummary(activeCycle, members, payments)
     : null;
   const paymentStatuses = activeCycle
-    ? getMemberPaymentStatuses(members, payments, activeCycle.id, activeCycle.recipientMemberId)
+    ? getMemberPaymentStatuses(
+        members,
+        payments,
+        activeCycle.id,
+        activeCycle.recipientMemberId,
+      )
     : [];
 
   return (
@@ -31,36 +47,52 @@ export default async function DashboardPage() {
         <DashboardHeader activeCycle={activeCycleSummary} />
 
         <div className="mt-8 space-y-6">
-          {activeCycleSummary && (
-            <KpiStats
-              totalKobo={activeCycleSummary.totalMembers * activeCycleSummary.cycle.contributionPerMember}
-              collectedKobo={activeCycleSummary.collectedKobo}
-              paidCount={activeCycleSummary.paidCount}
-              totalMembers={activeCycleSummary.totalMembers}
-            />
-          )}
+          {serverError ? (
+            <ServerErrorState />
+          ) : cycles.length === 0 ? (
+            <NoDataState />
+          ) : (
+            <>
+              {activeCycleSummary && (
+                <KpiStats
+                  totalKobo={
+                    activeCycleSummary.totalMembers *
+                    activeCycleSummary.cycle.contributionPerMember
+                  }
+                  collectedKobo={activeCycleSummary.collectedKobo}
+                  paidCount={activeCycleSummary.paidCount}
+                  totalMembers={activeCycleSummary.totalMembers}
+                />
+              )}
 
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {activeCycleSummary && (
-              <ActiveCycleCard summary={activeCycleSummary} />
-            )}
-            {activeCycle && (
-              <OutstandingAlert
-                statuses={paymentStatuses}
-                contributionPerMemberKobo={activeCycle.contributionPerMember}
-              />
-            )}
-          </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {activeCycleSummary && (
+                  <ActiveCycleCard summary={activeCycleSummary} />
+                )}
+                {activeCycle && (
+                  <OutstandingAlert
+                    statuses={paymentStatuses}
+                    contributionPerMemberKobo={activeCycle.contributionPerMember}
+                  />
+                )}
+              </div>
 
-          {paymentStatuses.length > 0 && activeCycle && (
-            <PaymentStatusGrid
-              statuses={paymentStatuses}
-              cycleId={activeCycle.id}
-              cycleNumber={activeCycle.cycleNumber}
-              contributionKobo={activeCycle.contributionPerMember}
-              cycles={cycles}
-              payments={payments}
-            />
+              {activeCycle && paymentStatuses.length === 0 ? (
+                <WaitingPaymentState />
+              ) : (
+                paymentStatuses.length > 0 &&
+                activeCycle && (
+                  <PaymentStatusGrid
+                    statuses={paymentStatuses}
+                    cycleId={activeCycle.id}
+                    cycleNumber={activeCycle.cycleNumber}
+                    contributionKobo={activeCycle.contributionPerMember}
+                    cycles={cycles}
+                    payments={payments}
+                  />
+                )
+              )}
+            </>
           )}
         </div>
       </main>

--- a/components/dashboard/empty-states.tsx
+++ b/components/dashboard/empty-states.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { WifiOff, CircleDollarSign, Clock, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+
+export function ServerErrorState() {
+  const router = useRouter();
+
+  return (
+    <Empty aria-live="polite">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <WifiOff className="text-destructive" aria-hidden="true" />
+        </EmptyMedia>
+        <EmptyTitle>Unable to reach the server</EmptyTitle>
+        <EmptyDescription>
+          This is usually temporary. Check that the backend is running and try
+          again.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-2 cursor-pointer"
+          onClick={() => router.refresh()}
+        >
+          <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+          Retry
+        </Button>
+      </EmptyContent>
+    </Empty>
+  );
+}
+
+export function NoDataState() {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <CircleDollarSign aria-hidden="true" />
+        </EmptyMedia>
+        <EmptyTitle>No cycles yet</EmptyTitle>
+        <EmptyDescription>
+          Once a savings cycle is created, your dashboard will come to life here.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}
+
+export function WaitingPaymentState() {
+  return (
+    <Empty role="status" className="border-0 py-16">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Clock className="text-muted-foreground" aria-hidden="true" />
+        </EmptyMedia>
+        <EmptyTitle>No payments yet</EmptyTitle>
+        <EmptyDescription>
+          Payments will appear here as members contribute to this cycle.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -2,28 +2,31 @@ import type { Cycle, Member, Payment } from '@/lib/types';
 
 const BASE = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
-async function apiFetch<T>(url: string, fallback: T): Promise<T> {
+export type FetchResult<T> = { data: T; ok: true } | { data: T; ok: false };
+
+async function apiFetch<T>(url: string, fallback: T): Promise<FetchResult<T>> {
   try {
-    const res = await fetch(url, { cache: 'no-store' });
+    const res = await fetch(url, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(5000),
+    });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-    return res.json();
+    return { data: await res.json(), ok: true };
   } catch (err) {
-    // Backend unavailable — log server-side and return fallback so the page
-    // still renders. Start `cargo run` in rust-receipt-engine to populate data.
     console.error(`[data] fetch ${url} failed:`, err);
-    return fallback;
+    return { data: fallback, ok: false };
   }
 }
 
-export function fetchMembers(): Promise<Member[]> {
+export function fetchMembers(): Promise<FetchResult<Member[]>> {
   return apiFetch(`${BASE}/api/members`, []);
 }
 
-export function fetchCycles(): Promise<Cycle[]> {
+export function fetchCycles(): Promise<FetchResult<Cycle[]>> {
   return apiFetch(`${BASE}/api/cycles`, []);
 }
 
-export function fetchPayments(cycleId?: number): Promise<Payment[]> {
+export function fetchPayments(cycleId?: number): Promise<FetchResult<Payment[]>> {
   const url = cycleId
     ? `${BASE}/api/payments?cycleId=${cycleId}`
     : `${BASE}/api/payments`;


### PR DESCRIPTION
## Summary
- Add three distinct UI states for when the dashboard has no data to show: **server unreachable**, **no cycles yet**, and **waiting for payments**
- Update `apiFetch` to return a `FetchResult<T>` that distinguishes server errors from empty data (previously both returned `[]` silently)
- Restyle `error.tsx` boundary with the existing `Empty` component system for visual consistency

## What changed
- **`lib/data.ts`** — `apiFetch` returns `{ data, ok }` instead of raw data; added `AbortSignal.timeout(5000)`
- **`components/dashboard/empty-states.tsx`** — New file with `ServerErrorState` (WifiOff + retry), `NoDataState` (CircleDollarSign), `WaitingPaymentState` (Clock)
- **`app/page.tsx`** — Conditional rendering: server error → no data → normal flow (with waiting state in payment grid area)
- **`app/error.tsx`** — Restyled with `Empty`/`EmptyMedia`/`EmptyTitle` primitives

## Test plan
- [ ] Stop backend → load dashboard → "Unable to reach the server" with retry button
- [ ] Backend up, no cycles → "No cycles yet" state
- [ ] Active cycle, no payments → KPIs + cycle card visible, "No payments yet" in grid area
- [ ] Full data → normal dashboard, no empty states visible
- [ ] Verify both light and dark mode
- [ ] Check `aria-live` and `role="status"` on dynamic states