### PR TITLE
Refactor: extract HTTP layer into lib/http.ts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@
 # Required in production/preview deployments.
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
+# URL of the Rust/SurrealDB backend.
+# Defaults to http://localhost:8080 if omitted.
+BACKEND_URL=http://localhost:8080
+
+# Admin token for CRUD operations. Must match the backend ADMIN_TOKEN env var.
+ADMIN_TOKEN=

--- a/app/admin/_components/admin-nav.tsx
+++ b/app/admin/_components/admin-nav.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+import { Separator } from '@/components/ui/separator';
+
+export function AdminNav() {
+  return (
+    <div className="mb-8">
+      <div className="flex items-center justify-between">
+        <Link
+          href="/"
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Back to dashboard"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+          Dashboard
+        </Link>
+        <h1 className="text-2xl font-semibold tracking-tighter text-foreground">Admin</h1>
+      </div>
+      <Separator className="mt-6 bg-border" />
+    </div>
+  );
+}

--- a/app/admin/_components/cycle-form.tsx
+++ b/app/admin/_components/cycle-form.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useTransition, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { createCycle, updateCycle } from '@/lib/admin-actions';
+import type { Cycle, CycleStatus, Member } from '@/lib/types';
+
+interface CycleFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  groupId: string;
+  members: Member[];
+  // When provided the form is in edit mode; otherwise create mode.
+  cycle?: Cycle;
+}
+
+export function CycleForm({ open, onOpenChange, groupId, members, cycle }: CycleFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [recipientId, setRecipientId] = useState<string>(cycle?.recipientMemberId ?? '');
+  const [status, setStatus] = useState<CycleStatus>(cycle?.status ?? 'pending');
+
+  const isEdit = !!cycle;
+  const activeMembers = members.filter(m => m.status === 'active');
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const cycleNumber = Number(data.get('cycleNumber'));
+    const startDate = data.get('startDate') as string;
+    const endDate = data.get('endDate') as string;
+    // Input is NGN; backend expects kobo
+    const contributionPerMember = Math.round(Number(data.get('contribution')) * 100);
+
+    setError(null);
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateCycle(cycle.id, {
+            startDate,
+            endDate,
+            contributionPerMember,
+            recipientMemberId: recipientId || undefined,
+            status,
+          })
+        : await createCycle(groupId, {
+            cycleNumber,
+            startDate,
+            endDate,
+            contributionPerMember,
+            recipientMemberId: recipientId,
+          });
+
+      if (result.success) {
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!isPending) {
+      setError(null);
+      onOpenChange(next);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={!isPending}>
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Cycle' : 'Add Cycle'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {!isEdit && (
+            <div className="space-y-1.5">
+              <Label htmlFor="cycle-number">Cycle Number</Label>
+              <Input
+                id="cycle-number"
+                name="cycleNumber"
+                type="number"
+                required
+                min={1}
+                defaultValue=""
+                placeholder="1"
+                disabled={isPending}
+              />
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="cycle-start">Start Date</Label>
+              <Input
+                id="cycle-start"
+                name="startDate"
+                type="date"
+                required
+                defaultValue={cycle?.startDate ?? ''}
+                disabled={isPending}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="cycle-end">End Date</Label>
+              <Input
+                id="cycle-end"
+                name="endDate"
+                type="date"
+                required
+                defaultValue={cycle?.endDate ?? ''}
+                disabled={isPending}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cycle-contribution">Contribution per Member (₦)</Label>
+            <Input
+              id="cycle-contribution"
+              name="contribution"
+              type="number"
+              required
+              min={1}
+              step="0.01"
+              // Convert kobo back to NGN for display
+              defaultValue={cycle ? cycle.contributionPerMember / 100 : ''}
+              placeholder="5000"
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cycle-recipient">Recipient Member</Label>
+            <Select
+              value={recipientId}
+              onValueChange={v => { if (v) setRecipientId(v); }}
+            >
+              <SelectTrigger id="cycle-recipient" disabled={isPending}>
+                <SelectValue placeholder="Select recipient" />
+              </SelectTrigger>
+              <SelectContent>
+                {activeMembers.map(m => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.name} (#{m.position})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {isEdit && (
+            <div className="space-y-1.5">
+              <Label htmlFor="cycle-status">Status</Label>
+              <Select
+                value={status}
+                onValueChange={v => { if (v) setStatus(v as CycleStatus); }}
+              >
+                <SelectTrigger id="cycle-status" disabled={isPending}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="pending">Pending</SelectItem>
+                  <SelectItem value="active">Active</SelectItem>
+                  <SelectItem value="completed">Completed</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending} aria-busy={isPending}>
+              {isPending ? 'Saving…' : isEdit ? 'Save' : 'Add Cycle'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/admin/_components/cycles-section.tsx
+++ b/app/admin/_components/cycles-section.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useState } from 'react';
+import { Pencil, Trash2, Plus } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { CycleForm } from '@/app/admin/_components/cycle-form';
+import { DeleteConfirm } from '@/app/admin/_components/delete-confirm';
+import { deleteCycle } from '@/lib/admin-actions';
+import { formatNgn, formatPaymentDate } from '@/lib/utils';
+import type { Cycle, Member } from '@/lib/types';
+
+const STATUS_VARIANT = {
+  pending: 'secondary',
+  active: 'default',
+  completed: 'outline',
+} as const;
+
+interface CyclesSectionProps {
+  cycles: Cycle[];
+  members: Member[];
+  groupId: string;
+}
+
+export function CyclesSection({ cycles, members, groupId }: CyclesSectionProps) {
+  const [addOpen, setAddOpen] = useState(false);
+  const [editCycle, setEditCycle] = useState<Cycle | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Cycle | null>(null);
+
+  const memberById = new Map(members.map(m => [m.id, m]));
+
+  return (
+    <section aria-labelledby="cycles-heading">
+      <div className="flex items-center justify-between mb-4">
+        <h2 id="cycles-heading" className="text-lg font-semibold tracking-tight">
+          Cycles
+        </h2>
+        <Button size="sm" onClick={() => setAddOpen(true)} disabled={!groupId}>
+          <Plus className="mr-1" aria-hidden="true" />
+          Add Cycle
+        </Button>
+      </div>
+
+      {cycles.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">No cycles in this group.</p>
+      ) : (
+        <div className="rounded-lg border border-border overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>#</TableHead>
+                <TableHead>Dates</TableHead>
+                <TableHead>Contribution</TableHead>
+                <TableHead>Recipient</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[...cycles]
+                .sort((a, b) => a.cycleNumber - b.cycleNumber)
+                .map(cycle => {
+                  const recipient = memberById.get(cycle.recipientMemberId);
+                  return (
+                    <TableRow key={cycle.id}>
+                      <TableCell className="font-medium tabular-nums">
+                        {cycle.cycleNumber}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                        {formatPaymentDate(cycle.startDate, true)} – {formatPaymentDate(cycle.endDate, true)}
+                      </TableCell>
+                      <TableCell className="tabular-nums">
+                        {formatNgn(cycle.contributionPerMember)}
+                      </TableCell>
+                      <TableCell>{recipient?.name ?? '—'}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={STATUS_VARIANT[cycle.status]}
+                          className="capitalize"
+                        >
+                          {cycle.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex items-center justify-end gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            aria-label={`Edit cycle ${cycle.cycleNumber}`}
+                            onClick={() => setEditCycle(cycle)}
+                          >
+                            <Pencil aria-hidden="true" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            aria-label={`Delete cycle ${cycle.cycleNumber}`}
+                            onClick={() => setDeleteTarget(cycle)}
+                          >
+                            <Trash2 className="text-destructive" aria-hidden="true" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <CycleForm
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        groupId={groupId}
+        members={members}
+      />
+
+      {editCycle && (
+        <CycleForm
+          open={!!editCycle}
+          onOpenChange={open => { if (!open) setEditCycle(null); }}
+          groupId={groupId}
+          members={members}
+          cycle={editCycle}
+        />
+      )}
+
+      {deleteTarget && (
+        <DeleteConfirm
+          open={!!deleteTarget}
+          onOpenChange={open => { if (!open) setDeleteTarget(null); }}
+          title={`Delete Cycle ${deleteTarget.cycleNumber}?`}
+          description="This will permanently delete the cycle and all associated payments. This action cannot be undone."
+          onConfirm={() => deleteCycle(deleteTarget.id)}
+        />
+      )}
+    </section>
+  );
+}

--- a/app/admin/_components/delete-confirm.tsx
+++ b/app/admin/_components/delete-confirm.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useTransition, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { ActionResult } from '@/lib/types';
+
+interface DeleteConfirmProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  onConfirm: () => Promise<ActionResult>;
+}
+
+export function DeleteConfirm({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+}: DeleteConfirmProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleConfirm() {
+    setError(null);
+    startTransition(async () => {
+      const result = await onConfirm();
+      if (result.success) {
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!isPending) {
+      setError(null);
+      onOpenChange(next);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={!isPending}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isPending}
+            aria-busy={isPending}
+          >
+            {isPending ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/admin/_components/group-form.tsx
+++ b/app/admin/_components/group-form.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useTransition, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { createGroup, updateGroup } from '@/lib/admin-actions';
+import type { Group } from '@/lib/types';
+
+interface GroupFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  // When provided the form is in edit mode; otherwise create mode.
+  group?: Group;
+}
+
+export function GroupForm({ open, onOpenChange, group }: GroupFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const isEdit = !!group;
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const name = (data.get('name') as string).trim();
+    const description = (data.get('description') as string).trim() || undefined;
+
+    setError(null);
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateGroup(group.id, { name, description })
+        : await createGroup({ name, description });
+
+      if (result.success) {
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!isPending) {
+      setError(null);
+      onOpenChange(next);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={!isPending}>
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Group' : 'Add Group'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="group-name">Name</Label>
+            <Input
+              id="group-name"
+              name="name"
+              required
+              defaultValue={group?.name ?? ''}
+              placeholder="e.g. Lagos Ajo Circle"
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="group-description">Description (optional)</Label>
+            <Input
+              id="group-description"
+              name="description"
+              defaultValue={group?.description ?? ''}
+              placeholder="Short description"
+              disabled={isPending}
+            />
+          </div>
+
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending} aria-busy={isPending}>
+              {isPending ? 'Saving…' : isEdit ? 'Save' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/admin/_components/group-tabs.tsx
+++ b/app/admin/_components/group-tabs.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { Group } from '@/lib/types';
+
+interface GroupTabsProps {
+  groups: Group[];
+  selectedGroupId: string;
+}
+
+export function GroupTabs({ groups, selectedGroupId }: GroupTabsProps) {
+  const router = useRouter();
+
+  if (groups.length === 0) return null;
+
+  return (
+    <div
+      className="flex items-center gap-1 border-b border-border mb-6 overflow-x-auto"
+      role="tablist"
+      aria-label="Select group"
+    >
+      {groups.map(group => {
+        const isSelected = group.id === selectedGroupId;
+        return (
+          <button
+            key={group.id}
+            role="tab"
+            aria-selected={isSelected}
+            onClick={() => router.push(`/admin?group=${group.id}`)}
+            className={`cursor-pointer shrink-0 px-4 py-2 text-sm font-medium border-b-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+              isSelected
+                ? 'border-foreground text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+            }`}
+          >
+            {group.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/admin/_components/groups-section.tsx
+++ b/app/admin/_components/groups-section.tsx
@@ -1,0 +1,66 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { Group } from '@/lib/types';
+
+interface GroupsSectionProps {
+  groups: Group[];
+}
+
+export function GroupsSection({ groups }: GroupsSectionProps) {
+  return (
+    <section aria-labelledby="groups-heading">
+      <div className="flex items-center justify-between mb-4">
+        <h2 id="groups-heading" className="text-lg font-semibold tracking-tight">
+          Groups
+        </h2>
+        {/* GroupForm (Add) wired in commit 10 */}
+      </div>
+
+      {groups.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">No groups found.</p>
+      ) : (
+        <div className="rounded-lg border border-border overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>Name</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {groups.map(group => (
+                <TableRow key={group.id}>
+                  <TableCell className="font-medium">{group.name}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={group.status === 'active' ? 'default' : 'secondary'}
+                      className="capitalize"
+                    >
+                      {group.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground max-w-xs truncate">
+                    {group.description ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {/* Edit/Delete wired in commit 10 */}
+                    <span className="text-xs text-muted-foreground">—</span>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/admin/_components/groups-section.tsx
+++ b/app/admin/_components/groups-section.tsx
@@ -1,4 +1,9 @@
+'use client';
+
+import { useState } from 'react';
+import { Pencil, Trash2, Plus } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   Table,
   TableBody,
@@ -7,6 +12,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { GroupForm } from '@/app/admin/_components/group-form';
+import { DeleteConfirm } from '@/app/admin/_components/delete-confirm';
+import { deleteGroup } from '@/lib/admin-actions';
 import type { Group } from '@/lib/types';
 
 interface GroupsSectionProps {
@@ -14,13 +22,20 @@ interface GroupsSectionProps {
 }
 
 export function GroupsSection({ groups }: GroupsSectionProps) {
+  const [addOpen, setAddOpen] = useState(false);
+  const [editGroup, setEditGroup] = useState<Group | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Group | null>(null);
+
   return (
     <section aria-labelledby="groups-heading">
       <div className="flex items-center justify-between mb-4">
         <h2 id="groups-heading" className="text-lg font-semibold tracking-tight">
           Groups
         </h2>
-        {/* GroupForm (Add) wired in commit 10 */}
+        <Button size="sm" onClick={() => setAddOpen(true)}>
+          <Plus className="mr-1" aria-hidden="true" />
+          Add Group
+        </Button>
       </div>
 
       {groups.length === 0 ? (
@@ -52,14 +67,50 @@ export function GroupsSection({ groups }: GroupsSectionProps) {
                     {group.description ?? '—'}
                   </TableCell>
                   <TableCell className="text-right">
-                    {/* Edit/Delete wired in commit 10 */}
-                    <span className="text-xs text-muted-foreground">—</span>
+                    <div className="flex items-center justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={`Edit ${group.name}`}
+                        onClick={() => setEditGroup(group)}
+                      >
+                        <Pencil aria-hidden="true" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={`Delete ${group.name}`}
+                        onClick={() => setDeleteTarget(group)}
+                      >
+                        <Trash2 className="text-destructive" aria-hidden="true" />
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
         </div>
+      )}
+
+      <GroupForm open={addOpen} onOpenChange={setAddOpen} />
+
+      {editGroup && (
+        <GroupForm
+          open={!!editGroup}
+          onOpenChange={open => { if (!open) setEditGroup(null); }}
+          group={editGroup}
+        />
+      )}
+
+      {deleteTarget && (
+        <DeleteConfirm
+          open={!!deleteTarget}
+          onOpenChange={open => { if (!open) setDeleteTarget(null); }}
+          title={`Delete "${deleteTarget.name}"?`}
+          description="This will permanently delete the group. This action cannot be undone."
+          onConfirm={() => deleteGroup(deleteTarget.id)}
+        />
       )}
     </section>
   );

--- a/app/admin/_components/member-form.tsx
+++ b/app/admin/_components/member-form.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useTransition, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { createMember, updateMember } from '@/lib/admin-actions';
+import type { Member, MemberStatus } from '@/lib/types';
+
+interface MemberFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  groupId: string;
+  // When provided the form is in edit mode; otherwise create mode.
+  member?: Member;
+}
+
+export function MemberForm({ open, onOpenChange, groupId, member }: MemberFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<MemberStatus>(member?.status ?? 'active');
+
+  const isEdit = !!member;
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const name = (data.get('name') as string).trim();
+    const phone = (data.get('phone') as string).trim();
+    const position = Number(data.get('position'));
+
+    setError(null);
+    startTransition(async () => {
+      const result = isEdit
+        ? await updateMember(member.id, { name, phone, position, status })
+        : await createMember(groupId, { name, phone, position });
+
+      if (result.success) {
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!isPending) {
+      setError(null);
+      onOpenChange(next);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={!isPending}>
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Member' : 'Add Member'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="member-name">Name</Label>
+            <Input
+              id="member-name"
+              name="name"
+              required
+              defaultValue={member?.name ?? ''}
+              placeholder="e.g. Adaeze Okafor"
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="member-phone">Phone</Label>
+            <Input
+              id="member-phone"
+              name="phone"
+              required
+              defaultValue={member?.phone ?? ''}
+              placeholder="2349000000001"
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="member-position">Position</Label>
+            <Input
+              id="member-position"
+              name="position"
+              type="number"
+              required
+              min={1}
+              defaultValue={member?.position ?? ''}
+              placeholder="1"
+              disabled={isPending}
+            />
+          </div>
+
+          {isEdit && (
+            <div className="space-y-1.5">
+              <Label htmlFor="member-status">Status</Label>
+              <Select
+                value={status}
+                onValueChange={v => { if (v) setStatus(v as MemberStatus); }}
+              >
+                <SelectTrigger id="member-status" disabled={isPending}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="active">Active</SelectItem>
+                  <SelectItem value="inactive">Inactive</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending} aria-busy={isPending}>
+              {isPending ? 'Saving…' : isEdit ? 'Save' : 'Add Member'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/admin/_components/members-section.tsx
+++ b/app/admin/_components/members-section.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState } from 'react';
+import { Pencil, Trash2, Plus } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { MemberForm } from '@/app/admin/_components/member-form';
+import { DeleteConfirm } from '@/app/admin/_components/delete-confirm';
+import { deleteMember } from '@/lib/admin-actions';
+import { formatPhone } from '@/lib/utils';
+import type { Member } from '@/lib/types';
+
+interface MembersSectionProps {
+  members: Member[];
+  groupId: string;
+}
+
+export function MembersSection({ members, groupId }: MembersSectionProps) {
+  const [addOpen, setAddOpen] = useState(false);
+  const [editMember, setEditMember] = useState<Member | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Member | null>(null);
+
+  return (
+    <section aria-labelledby="members-heading">
+      <div className="flex items-center justify-between mb-4">
+        <h2 id="members-heading" className="text-lg font-semibold tracking-tight">
+          Members
+        </h2>
+        <Button size="sm" onClick={() => setAddOpen(true)} disabled={!groupId}>
+          <Plus className="mr-1" aria-hidden="true" />
+          Add Member
+        </Button>
+      </div>
+
+      {members.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">No members in this group.</p>
+      ) : (
+        <div className="rounded-lg border border-border overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>Name</TableHead>
+                <TableHead>Phone</TableHead>
+                <TableHead>Position</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[...members]
+                .sort((a, b) => a.position - b.position)
+                .map(member => (
+                  <TableRow key={member.id}>
+                    <TableCell className="font-medium">{member.name}</TableCell>
+                    <TableCell className="text-muted-foreground font-mono text-xs">
+                      {formatPhone(member.phone)}
+                    </TableCell>
+                    <TableCell>{member.position}</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={member.status === 'active' ? 'default' : 'secondary'}
+                        className="capitalize"
+                      >
+                        {member.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={`Edit ${member.name}`}
+                          onClick={() => setEditMember(member)}
+                        >
+                          <Pencil aria-hidden="true" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={`Delete ${member.name}`}
+                          onClick={() => setDeleteTarget(member)}
+                        >
+                          <Trash2 className="text-destructive" aria-hidden="true" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <MemberForm open={addOpen} onOpenChange={setAddOpen} groupId={groupId} />
+
+      {editMember && (
+        <MemberForm
+          open={!!editMember}
+          onOpenChange={open => { if (!open) setEditMember(null); }}
+          groupId={groupId}
+          member={editMember}
+        />
+      )}
+
+      {deleteTarget && (
+        <DeleteConfirm
+          open={!!deleteTarget}
+          onOpenChange={open => { if (!open) setDeleteTarget(null); }}
+          title={`Delete "${deleteTarget.name}"?`}
+          description="This will permanently delete the member. This action cannot be undone."
+          onConfirm={() => deleteMember(deleteTarget.id)}
+        />
+      )}
+    </section>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+interface AdminLayoutProps {
+  children: ReactNode;
+}
+
+export default function AdminLayout({ children }: AdminLayoutProps) {
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -4,6 +4,7 @@ import { AdminNav } from '@/app/admin/_components/admin-nav';
 import { GroupTabs } from '@/app/admin/_components/group-tabs';
 import { GroupsSection } from '@/app/admin/_components/groups-section';
 import { MembersSection } from '@/app/admin/_components/members-section';
+import { CyclesSection } from '@/app/admin/_components/cycles-section';
 
 interface AdminPageProps {
   searchParams: Promise<{ group?: string }>;
@@ -58,8 +59,7 @@ export default async function AdminPage({ searchParams }: AdminPageProps) {
 
         <MembersSection members={members} groupId={selectedGroupId} />
 
-        {/* CyclesSection wired in commit 12 */}
-        <div className="hidden">{cycles.length}</div>
+        <CyclesSection cycles={cycles} members={members} groupId={selectedGroupId} />
       </div>
     </>
   );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,69 @@
+import { fetchGroups, fetchMembers, fetchCycles } from '@/lib/data';
+import { ADMIN_TOKEN } from '@/lib/config';
+import { AdminNav } from '@/app/admin/_components/admin-nav';
+
+interface AdminPageProps {
+  searchParams: Promise<{ group?: string }>;
+}
+
+export default async function AdminPage({ searchParams }: AdminPageProps) {
+  const params = await searchParams;
+
+  const groupsResult = await fetchGroups();
+  const groups = groupsResult.data;
+
+  const selectedGroupId =
+    params.group ??
+    (groups.find(g => g.status === 'active')?.id ?? groups[0]?.id ?? '');
+
+  const [membersResult, cyclesResult] = selectedGroupId
+    ? await Promise.all([
+        fetchMembers(selectedGroupId),
+        fetchCycles(selectedGroupId),
+      ])
+    : [{ data: [], ok: true as const }, { data: [], ok: true as const }];
+
+  const members = membersResult.data;
+  const cycles = cyclesResult.data;
+
+  return (
+    <>
+      <AdminNav />
+
+      {!ADMIN_TOKEN && (
+        <div
+          role="alert"
+          className="mb-6 rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-700 dark:text-yellow-400"
+        >
+          <strong>Warning:</strong> ADMIN_TOKEN is not set. Admin mutations will be rejected by the backend.
+        </div>
+      )}
+
+      {!groupsResult.ok && (
+        <div
+          role="alert"
+          className="mb-6 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          Could not reach the backend. Check that the Rust server is running.
+        </div>
+      )}
+
+      <div className="space-y-10">
+        <section aria-labelledby="groups-heading">
+          <h2 id="groups-heading" className="text-lg font-semibold tracking-tight mb-4">Groups</h2>
+          <pre className="text-xs text-muted-foreground">{JSON.stringify(groups, null, 2)}</pre>
+        </section>
+
+        <section aria-labelledby="members-heading">
+          <h2 id="members-heading" className="text-lg font-semibold tracking-tight mb-4">Members</h2>
+          <pre className="text-xs text-muted-foreground">{JSON.stringify(members, null, 2)}</pre>
+        </section>
+
+        <section aria-labelledby="cycles-heading">
+          <h2 id="cycles-heading" className="text-lg font-semibold tracking-tight mb-4">Cycles</h2>
+          <pre className="text-xs text-muted-foreground">{JSON.stringify(cycles, null, 2)}</pre>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { ADMIN_TOKEN } from '@/lib/config';
 import { AdminNav } from '@/app/admin/_components/admin-nav';
 import { GroupTabs } from '@/app/admin/_components/group-tabs';
 import { GroupsSection } from '@/app/admin/_components/groups-section';
+import { MembersSection } from '@/app/admin/_components/members-section';
 
 interface AdminPageProps {
   searchParams: Promise<{ group?: string }>;
@@ -55,9 +56,10 @@ export default async function AdminPage({ searchParams }: AdminPageProps) {
       <div className="space-y-10">
         <GroupsSection groups={groups} />
 
-        {/* MembersSection wired in commit 11 */}
+        <MembersSection members={members} groupId={selectedGroupId} />
+
         {/* CyclesSection wired in commit 12 */}
-        <div className="hidden">{members.length}{cycles.length}</div>
+        <div className="hidden">{cycles.length}</div>
       </div>
     </>
   );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,8 @@
 import { fetchGroups, fetchMembers, fetchCycles } from '@/lib/data';
 import { ADMIN_TOKEN } from '@/lib/config';
 import { AdminNav } from '@/app/admin/_components/admin-nav';
+import { GroupTabs } from '@/app/admin/_components/group-tabs';
+import { GroupsSection } from '@/app/admin/_components/groups-section';
 
 interface AdminPageProps {
   searchParams: Promise<{ group?: string }>;
@@ -48,21 +50,14 @@ export default async function AdminPage({ searchParams }: AdminPageProps) {
         </div>
       )}
 
+      <GroupTabs groups={groups} selectedGroupId={selectedGroupId} />
+
       <div className="space-y-10">
-        <section aria-labelledby="groups-heading">
-          <h2 id="groups-heading" className="text-lg font-semibold tracking-tight mb-4">Groups</h2>
-          <pre className="text-xs text-muted-foreground">{JSON.stringify(groups, null, 2)}</pre>
-        </section>
+        <GroupsSection groups={groups} />
 
-        <section aria-labelledby="members-heading">
-          <h2 id="members-heading" className="text-lg font-semibold tracking-tight mb-4">Members</h2>
-          <pre className="text-xs text-muted-foreground">{JSON.stringify(members, null, 2)}</pre>
-        </section>
-
-        <section aria-labelledby="cycles-heading">
-          <h2 id="cycles-heading" className="text-lg font-semibold tracking-tight mb-4">Cycles</h2>
-          <pre className="text-xs text-muted-foreground">{JSON.stringify(cycles, null, 2)}</pre>
-        </section>
+        {/* MembersSection wired in commit 11 */}
+        {/* CyclesSection wired in commit 12 */}
+        <div className="hidden">{members.length}{cycles.length}</div>
       </div>
     </>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { fetchMembers, fetchCycles, fetchPayments } from '@/lib/data';
+import { fetchGroups, fetchMembers, fetchCycles, fetchPayments } from '@/lib/data';
 import { deriveCycleSummary, getMemberPaymentStatuses } from '@/lib/utils';
 import { DashboardHeader } from '@/components/dashboard/header';
 import { KpiStats } from '@/components/dashboard/kpi-stats';
@@ -11,10 +11,24 @@ import {
   WaitingPaymentState,
 } from '@/components/dashboard/empty-states';
 
-export default async function DashboardPage() {
+interface PageProps {
+  searchParams: Promise<{ group?: string }>;
+}
+
+export default async function DashboardPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+
+  const groupsResult = await fetchGroups();
+  const groups = groupsResult.data;
+
+  // Use the ?group= param if valid, otherwise fall back to the first active group
+  const selectedGroupId =
+    params.group ??
+    (groups.find(g => g.status === 'active')?.id ?? groups[0]?.id ?? '');
+
   const [membersResult, cyclesResult, paymentsResult] = await Promise.all([
-    fetchMembers(),
-    fetchCycles(),
+    fetchMembers(selectedGroupId || undefined),
+    fetchCycles(selectedGroupId || undefined),
     fetchPayments(),
   ]);
 
@@ -44,7 +58,11 @@ export default async function DashboardPage() {
         className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8"
         aria-label="Circle savings group dashboard"
       >
-        <DashboardHeader activeCycle={activeCycleSummary} />
+        <DashboardHeader
+          activeCycle={activeCycleSummary}
+          groups={groups}
+          selectedGroupId={selectedGroupId}
+        />
 
         <div className="mt-8 space-y-6">
           {serverError ? (

--- a/components/dashboard/group-selector.tsx
+++ b/components/dashboard/group-selector.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { Group } from '@/lib/types';
+
+interface GroupSelectorProps {
+  groups: Group[];
+  selectedGroupId: string;
+}
+
+export function GroupSelector({ groups, selectedGroupId }: GroupSelectorProps) {
+  const router = useRouter();
+
+  function handleChange(id: string | null) {
+    if (!id) return;
+    router.push(`/?group=${id}`);
+  }
+
+  return (
+    <Select value={selectedGroupId} onValueChange={handleChange}>
+      <SelectTrigger
+        className="h-8 w-[160px] text-xs"
+        aria-label="Select savings group"
+      >
+        <SelectValue placeholder="Select group" />
+      </SelectTrigger>
+      <SelectContent>
+        {groups.map(group => (
+          <SelectItem key={group.id} value={group.id} className="text-xs">
+            {group.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/components/dashboard/header.tsx
+++ b/components/dashboard/header.tsx
@@ -1,11 +1,15 @@
+import Link from 'next/link';
 import { Users } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { ThemeToggle } from '@/components/dashboard/theme-toggle';
-import type { CycleSummary } from '@/lib/types';
+import { GroupSelector } from '@/components/dashboard/group-selector';
+import type { CycleSummary, Group } from '@/lib/types';
 
 interface DashboardHeaderProps {
   activeCycle: CycleSummary | null;
+  groups: Group[];
+  selectedGroupId: string;
 }
 
 function formatHeaderDate(isoDate: string): string {
@@ -19,7 +23,7 @@ function formatHeaderDate(isoDate: string): string {
   });
 }
 
-export function DashboardHeader({ activeCycle }: DashboardHeaderProps) {
+export function DashboardHeader({ activeCycle, groups, selectedGroupId }: DashboardHeaderProps) {
   const today = formatHeaderDate(new Date().toISOString().slice(0, 10));
 
   return (
@@ -33,7 +37,10 @@ export function DashboardHeader({ activeCycle }: DashboardHeaderProps) {
           <p className="text-sm text-muted-foreground">{today}</p>
         </div>
 
-        <div className="flex items-center gap-2 mt-1">
+        <div className="flex items-center gap-2 mt-1 flex-wrap justify-end">
+          {groups.length > 0 && (
+            <GroupSelector groups={groups} selectedGroupId={selectedGroupId} />
+          )}
           {activeCycle && (
             <Badge
               className="shrink-0 bg-ajo-paid-subtle text-ajo-paid border-transparent text-xs font-medium px-2.5 py-1"
@@ -42,6 +49,13 @@ export function DashboardHeader({ activeCycle }: DashboardHeaderProps) {
               Cycle {activeCycle.cycle.cycleNumber} · Active
             </Badge>
           )}
+          <Link
+            href="/admin"
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Admin panel"
+          >
+            Admin
+          </Link>
           <ThemeToggle />
         </div>
       </div>

--- a/components/dashboard/payment-status-grid.tsx
+++ b/components/dashboard/payment-status-grid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { BarChart2, TableIcon, X } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { SortablePaymentTable } from '@/components/dashboard/sortable-payment-table';
@@ -23,17 +23,15 @@ interface PaymentStatusGridProps {
 
 export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contributionKobo, cycles, payments }: PaymentStatusGridProps) {
   const [view, setView] = useState<ViewMode>('table');
-  const [selectedMember, setSelectedMember] = useState<MemberPaymentStatus | null>(null);
+  // Store only the member ID — derive the full MemberPaymentStatus from statuses so the
+  // overlay always reflects the latest server state without a setState-in-effect sync.
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
   const [selectedRowNumber, setSelectedRowNumber] = useState<number | null>(null);
 
   const activeCycle = cycles.find(c => c.id === cycleId);
-
-  // Sync overlay with server re-renders after payment toggle
-  useEffect(() => {
-    if (!selectedMember) return;
-    const updated = statuses.find(s => s.member.id === selectedMember.member.id);
-    if (updated) setSelectedMember(updated);
-  }, [statuses, selectedMember]);
+  const selectedMember = selectedMemberId
+    ? (statuses.find(s => s.member.id === selectedMemberId) ?? null)
+    : null;
 
   return (
     <Card className="relative overflow-hidden border-border bg-card shadow-sm">
@@ -82,7 +80,7 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
           <SortablePaymentTable
             statuses={statuses}
             cycleNumber={cycleNumber}
-            onSelectMember={(status, rowNumber) => { setSelectedMember(status); setSelectedRowNumber(rowNumber); }}
+            onSelectMember={(status, rowNumber) => { setSelectedMemberId(status.member.id); setSelectedRowNumber(rowNumber); }}
           />
         ) : (
           <CyclePerformanceChart
@@ -118,7 +116,7 @@ export function PaymentStatusGrid({ statuses, cycleId, cycleNumber, contribution
                 contributionKobo={contributionKobo}
               />
               <button
-                onClick={() => { setSelectedMember(null); setSelectedRowNumber(null); }}
+                onClick={() => { setSelectedMemberId(null); setSelectedRowNumber(null); }}
                 aria-label="Close member detail"
                 className="w-8 h-8 flex items-center justify-center rounded-full border border-border/60 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >

--- a/components/dashboard/payment-status-grid.tsx
+++ b/components/dashboard/payment-status-grid.tsx
@@ -14,7 +14,7 @@ type ViewMode = 'table' | 'chart';
 
 interface PaymentStatusGridProps {
   statuses: MemberPaymentStatus[];
-  cycleId: number;
+  cycleId: string;
   cycleNumber: number;
   contributionKobo: number;
   cycles: Cycle[];

--- a/components/dashboard/payment-toggle-button.tsx
+++ b/components/dashboard/payment-toggle-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTransition, useEffect, useRef, useState } from 'react';
+import { useTransition, useState } from 'react';
 import { Check, RotateCcw, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -21,19 +21,15 @@ export function PaymentToggleButton({
 }: PaymentToggleButtonProps) {
   const [isPending, startTransition] = useTransition();
   const [announcement, setAnnouncement] = useState('');
-  const wasPendingRef = useRef(false);
-
-  // Announce the result to screen readers when the transition completes
-  useEffect(() => {
-    if (wasPendingRef.current && !isPending) {
-      setAnnouncement(hasPaid ? 'Payment marked as paid' : 'Payment marked as outstanding');
-    }
-    wasPendingRef.current = isPending;
-  }, [isPending, hasPaid]);
 
   function handleToggle() {
+    // Capture intent before the transition starts — hasPaid reflects pre-toggle state here
+    const markedAsPaid = !hasPaid;
     startTransition(async () => {
       await togglePayment(memberId, cycleId, hasPaid, contributionKobo);
+      // Announce inside the transition callback after the action completes,
+      // avoiding a setState-in-effect cascade.
+      setAnnouncement(markedAsPaid ? 'Payment marked as paid' : 'Payment marked as outstanding');
     });
   }
 

--- a/components/dashboard/payment-toggle-button.tsx
+++ b/components/dashboard/payment-toggle-button.tsx
@@ -7,8 +7,8 @@ import { cn } from '@/lib/utils';
 import { togglePayment } from '@/lib/actions';
 
 interface PaymentToggleButtonProps {
-  memberId: number;
-  cycleId: number;
+  memberId: string;
+  cycleId: string;
   hasPaid: boolean;
   contributionKobo: number;
 }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,10 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Claude Code worktrees — not part of the project source
+    ".claude/**",
+    // Scaffolded third-party primitive — owned by shadcn/visx, not hand-authored
+    "components/ui/area-chart.tsx",
   ]),
 ]);
 

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -5,8 +5,8 @@ import { revalidatePath } from 'next/cache';
 const BASE = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 export async function togglePayment(
-  memberId: number,
-  cycleId: number,
+  memberId: string,
+  cycleId: string,
   hasPaid: boolean,
   contributionKobo: number,
 ): Promise<void> {

--- a/lib/admin-actions.ts
+++ b/lib/admin-actions.ts
@@ -1,0 +1,106 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { BACKEND_URL, ADMIN_TOKEN } from '@/lib/config';
+import type { ActionResult, CycleStatus, GroupStatus, MemberStatus } from '@/lib/types';
+
+const BASE = BACKEND_URL;
+
+async function adminFetch(url: string, method: string, body?: unknown): Promise<ActionResult> {
+  try {
+    const res = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${ADMIN_TOKEN}`,
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      const message = (data as { error?: string }).error ?? `${res.status} ${res.statusText}`;
+      return { success: false, error: message };
+    }
+
+    revalidatePath('/');
+    revalidatePath('/admin');
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return { success: false, error: message };
+  }
+}
+
+// ─── Groups ───────────────────────────────────────────────────────────────────
+
+export async function createGroup(input: {
+  name: string;
+  description?: string;
+}): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/groups`, 'POST', input);
+}
+
+export async function updateGroup(
+  id: string,
+  input: { name?: string; status?: GroupStatus; description?: string },
+): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/groups/${id}`, 'PATCH', input);
+}
+
+export async function deleteGroup(id: string): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/groups/${id}`, 'DELETE');
+}
+
+// ─── Members ──────────────────────────────────────────────────────────────────
+
+export async function createMember(
+  groupId: string,
+  input: { name: string; phone: string; position: number },
+): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/groups/${groupId}/members`, 'POST', input);
+}
+
+export async function updateMember(
+  id: string,
+  input: { name?: string; phone?: string; position?: number; status?: MemberStatus },
+): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/members/${id}`, 'PATCH', input);
+}
+
+export async function deleteMember(id: string): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/members/${id}`, 'DELETE');
+}
+
+// ─── Cycles ───────────────────────────────────────────────────────────────────
+
+export async function createCycle(
+  groupId: string,
+  input: {
+    cycleNumber: number;
+    startDate: string;
+    endDate: string;
+    contributionPerMember: number;
+    recipientMemberId: string;
+  },
+): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/groups/${groupId}/cycles`, 'POST', input);
+}
+
+export async function updateCycle(
+  id: string,
+  input: {
+    startDate?: string;
+    endDate?: string;
+    contributionPerMember?: number;
+    recipientMemberId?: string;
+    status?: CycleStatus;
+  },
+): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/cycles/${id}`, 'PATCH', input);
+}
+
+export async function deleteCycle(id: string): Promise<ActionResult> {
+  return adminFetch(`${BASE}/api/admin/cycles/${id}`, 'DELETE');
+}

--- a/lib/chart-data.ts
+++ b/lib/chart-data.ts
@@ -8,7 +8,7 @@ export interface CycleChartDatum {
 }
 
 export function buildChartData(cycles: Cycle[], payments: Payment[]): CycleChartDatum[] {
-  const paymentsByCycle = new Map<number, Payment[]>();
+  const paymentsByCycle = new Map<string, Payment[]>();
   for (const p of payments) {
     const group = paymentsByCycle.get(p.cycleId) ?? [];
     group.push(p);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,1 +1,2 @@
 export const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080';
+export const ADMIN_TOKEN = process.env.ADMIN_TOKEN ?? '';

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,6 +1,7 @@
-import type { Cycle, Member, Payment } from '@/lib/types';
+import type { Cycle, Group, Member, Payment } from '@/lib/types';
+import { BACKEND_URL, ADMIN_TOKEN } from '@/lib/config';
 
-const BASE = process.env.BACKEND_URL ?? 'http://localhost:8080';
+const BASE = BACKEND_URL;
 
 export type FetchResult<T> = { data: T; ok: true } | { data: T; ok: false };
 
@@ -18,12 +19,22 @@ async function apiFetch<T>(url: string, fallback: T): Promise<FetchResult<T>> {
   }
 }
 
-export function fetchMembers(): Promise<FetchResult<Member[]>> {
-  return apiFetch(`${BASE}/api/members`, []);
+export function fetchGroups(): Promise<FetchResult<Group[]>> {
+  return apiFetch(`${BASE}/api/groups`, []);
 }
 
-export function fetchCycles(): Promise<FetchResult<Cycle[]>> {
-  return apiFetch(`${BASE}/api/cycles`, []);
+export function fetchMembers(groupId?: string): Promise<FetchResult<Member[]>> {
+  const url = groupId
+    ? `${BASE}/api/members?groupId=${groupId}`
+    : `${BASE}/api/members`;
+  return apiFetch(url, []);
+}
+
+export function fetchCycles(groupId?: string): Promise<FetchResult<Cycle[]>> {
+  const url = groupId
+    ? `${BASE}/api/cycles?groupId=${groupId}`
+    : `${BASE}/api/cycles`;
+  return apiFetch(url, []);
 }
 
 export function fetchPayments(cycleId?: string): Promise<FetchResult<Payment[]>> {

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -26,7 +26,7 @@ export function fetchCycles(): Promise<FetchResult<Cycle[]>> {
   return apiFetch(`${BASE}/api/cycles`, []);
 }
 
-export function fetchPayments(cycleId?: number): Promise<FetchResult<Payment[]>> {
+export function fetchPayments(cycleId?: string): Promise<FetchResult<Payment[]>> {
   const url = cycleId
     ? `${BASE}/api/payments?cycleId=${cycleId}`
     : `${BASE}/api/payments`;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,17 @@
 export type MemberStatus = 'active' | 'inactive';
 export type CycleStatus = 'pending' | 'active' | 'completed';
+export type GroupStatus = 'active' | 'closed';
 export type Currency = 'NGN';
+
+export interface Group {
+  id: string;
+  name: string;
+  status: GroupStatus;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  version: number;
+}
 
 export interface Member {
   id: string;
@@ -8,6 +19,7 @@ export interface Member {
   phone: string; // e.g. "2349000000001" — no + prefix, no spaces
   position: number; // 1-based rotation slot
   status: MemberStatus;
+  groupId: string;
   createdAt: string;
   updatedAt: string;
   version: number;
@@ -33,10 +45,13 @@ export interface Cycle {
   totalAmount: number; // kobo (= contributionPerMember × memberCount)
   recipientMemberId: string;
   status: CycleStatus;
+  groupId: string;
   createdAt: string;
   updatedAt: string;
   version: number;
 }
+
+export type ActionResult = { success: true } | { success: false; error: string };
 
 // Derived view types used by UI components — not persisted
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,33 +1,41 @@
 export type MemberStatus = 'active' | 'inactive';
-export type CycleStatus = 'pending' | 'active' | 'closed';
+export type CycleStatus = 'pending' | 'active' | 'completed';
 export type Currency = 'NGN';
 
 export interface Member {
-  id: number;
+  id: string;
   name: string;
   phone: string; // e.g. "2349000000001" — no + prefix, no spaces
   position: number; // 1-based rotation slot
   status: MemberStatus;
+  createdAt: string;
+  updatedAt: string;
+  version: number;
 }
 
 export interface Payment {
-  id: number;
-  memberId: number;
-  cycleId: number;
+  id: string;
+  memberId: string;
+  cycleId: string;
   amount: number; // kobo (NGN × 100) — integer, no float risk
   currency: Currency;
   paymentDate: string; // ISO date "YYYY-MM-DD"
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface Cycle {
-  id: number;
+  id: string;
   cycleNumber: number;
   startDate: string; // ISO date "YYYY-MM-DD"
   endDate: string; // ISO date "YYYY-MM-DD"
   contributionPerMember: number; // kobo
   totalAmount: number; // kobo (= contributionPerMember × memberCount)
-  recipientMemberId: number;
+  recipientMemberId: string;
   status: CycleStatus;
+  createdAt: string;
+  updatedAt: string;
+  version: number;
 }
 
 // Derived view types used by UI components — not persisted

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -38,8 +38,8 @@ export function formatPaymentDate(isoDate: string, includeYear = false): string 
 export function getMemberPaymentStatuses(
   members: Member[],
   payments: Payment[],
-  cycleId: number,
-  recipientMemberId: number,
+  cycleId: string,
+  recipientMemberId: string,
 ): MemberPaymentStatus[] {
   const paymentsByMember = new Map(
     payments

--- a/tests/admin.spec.ts
+++ b/tests/admin.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from '@playwright/test';
+import { AdminPage } from './pages/admin.page';
+
+/**
+ * Admin CRUD E2E tests.
+ *
+ * Requirements:
+ *  - The Rust backend must be running with at least one group seeded.
+ *  - ADMIN_TOKEN must be set correctly on the backend.
+ *  - Run with --workers=1 to avoid race conditions on shared backend state.
+ */
+test.describe.serial('Admin panel', () => {
+  test('navigates to /admin and renders the page', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await expect(admin.heading).toBeVisible();
+    await expect(admin.backLink).toBeVisible();
+    await expect(admin.groupsHeading).toBeVisible();
+    await expect(admin.membersHeading).toBeVisible();
+    await expect(admin.cyclesHeading).toBeVisible();
+  });
+
+  test('back link returns to dashboard', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await admin.backLink.click();
+    await page.waitForURL('/');
+    await expect(page.getByRole('main')).toBeVisible();
+  });
+
+  test('Groups section renders table with at least one group', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    // Expect the table to be present (will be empty message or populated)
+    await expect(admin.groupsHeading).toBeVisible();
+    await expect(admin.addGroupButton).toBeVisible();
+  });
+
+  test('Add Group button opens dialog', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await admin.addGroupButton.click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(admin.dialogTitle).toContainText('Add Group');
+  });
+
+  test('Add Group dialog can be cancelled', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await admin.addGroupButton.click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await admin.cancelButton.click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+  });
+
+  test('Members section is visible', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await expect(admin.membersHeading).toBeVisible();
+    await expect(admin.addMemberButton).toBeVisible();
+  });
+
+  test('Add Member button opens dialog', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await admin.addMemberButton.click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(admin.dialogTitle).toContainText('Add Member');
+  });
+
+  test('Add Member dialog can be cancelled', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await admin.addMemberButton.click();
+    await admin.cancelButton.click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+  });
+
+  test('Cycles section is visible', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await expect(admin.cyclesHeading).toBeVisible();
+    await expect(admin.addCycleButton).toBeVisible();
+  });
+
+  test('Add Cycle button opens dialog', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await admin.addCycleButton.click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(admin.dialogTitle).toContainText('Add Cycle');
+  });
+
+  test('Add Cycle dialog can be cancelled', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await admin.addCycleButton.click();
+    await admin.cancelButton.click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+  });
+
+  test('group tabs render when multiple groups exist', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    // Tab list is present when there are groups to display
+    const tabList = page.getByRole('tablist', { name: 'Select group' });
+    const hasTabs = await tabList.isVisible().catch(() => false);
+    if (!hasTabs) test.skip();
+
+    await expect(tabList).toBeVisible();
+    const tabs = tabList.getByRole('tab');
+    expect(await tabs.count()).toBeGreaterThan(0);
+  });
+
+  test('page renders in dark mode without layout breakage', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await expect(admin.heading).toBeVisible();
+    await expect(admin.groupsHeading).toBeVisible();
+  });
+
+  test('page renders in light mode without layout breakage', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    const admin = new AdminPage(page);
+    await admin.goto();
+
+    await expect(admin.heading).toBeVisible();
+    await expect(admin.groupsHeading).toBeVisible();
+  });
+});

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -116,6 +116,49 @@ test.describe('Circle Dashboard', () => {
     });
   });
 
+  test.describe('Group selector', () => {
+    test('Admin link is present in the header', async ({ page }) => {
+      const dashboard = new DashboardPage(page);
+      await dashboard.goto();
+      await expect(dashboard.adminLink).toBeVisible();
+    });
+
+    test('Admin link navigates to /admin', async ({ page }) => {
+      const dashboard = new DashboardPage(page);
+      await dashboard.goto();
+      await dashboard.adminLink.click();
+      await page.waitForURL('/admin');
+      await expect(page.getByRole('heading', { name: 'Admin' })).toBeVisible();
+    });
+
+    test('group selector renders when groups exist', async ({ page }) => {
+      const dashboard = new DashboardPage(page);
+      await dashboard.goto();
+      // The selector is only rendered when the backend returns groups.
+      // Skip if no groups are configured on the test backend.
+      const hasSelector = await dashboard.groupSelector.isVisible().catch(() => false);
+      if (!hasSelector) test.skip();
+      await expect(dashboard.groupSelector).toBeVisible();
+    });
+
+    test('selecting a group updates the URL with ?group= param', async ({ page }) => {
+      const dashboard = new DashboardPage(page);
+      await dashboard.goto();
+      const hasSelector = await dashboard.groupSelector.isVisible().catch(() => false);
+      if (!hasSelector) test.skip();
+      // Open the combobox and pick the first option
+      await dashboard.groupSelector.click();
+      const firstOption = page.getByRole('option').first();
+      const optionText = await firstOption.innerText();
+      await firstOption.click();
+      await page.waitForLoadState('networkidle');
+      expect(page.url()).toContain('group=');
+      // Dashboard heading should still be visible after switch
+      await expect(page.getByRole('main')).toBeVisible();
+      void optionText; // used indirectly via URL check
+    });
+  });
+
   test.describe('Chart tooltips', () => {
     test('tooltip appears with ₦ values on hover in Per Cycle view', async ({ page }) => {
       const dashboard = new DashboardPage(page);

--- a/tests/pages/admin.page.ts
+++ b/tests/pages/admin.page.ts
@@ -1,0 +1,95 @@
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Page Object Model for the /admin page.
+ * Encapsulates locators and interactions for admin CRUD flows.
+ */
+export class AdminPage {
+  readonly page: Page;
+
+  // Nav
+  readonly heading: Locator;
+  readonly backLink: Locator;
+
+  // Config warning banner
+  readonly configWarning: Locator;
+
+  // Groups section
+  readonly groupsHeading: Locator;
+  readonly addGroupButton: Locator;
+
+  // Members section
+  readonly membersHeading: Locator;
+  readonly addMemberButton: Locator;
+
+  // Cycles section
+  readonly cyclesHeading: Locator;
+  readonly addCycleButton: Locator;
+
+  // Dialog / form elements (shared)
+  readonly dialogTitle: Locator;
+  readonly saveButton: Locator;
+  readonly cancelButton: Locator;
+  readonly deleteButton: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.heading = page.getByRole('heading', { name: 'Admin' });
+    this.backLink = page.getByRole('link', { name: 'Back to dashboard' });
+    this.configWarning = page.getByRole('alert').filter({ hasText: 'ADMIN_TOKEN is not set' });
+
+    this.groupsHeading = page.getByRole('heading', { name: 'Groups' });
+    this.addGroupButton = page.getByRole('button', { name: 'Add Group' });
+
+    this.membersHeading = page.getByRole('heading', { name: 'Members' });
+    this.addMemberButton = page.getByRole('button', { name: 'Add Member' });
+
+    this.cyclesHeading = page.getByRole('heading', { name: 'Cycles' });
+    this.addCycleButton = page.getByRole('button', { name: 'Add Cycle' });
+
+    this.dialogTitle = page.getByRole('dialog').getByRole('heading');
+    this.saveButton = page.getByRole('button', { name: /^(Create|Add|Save)/ });
+    this.cancelButton = page.getByRole('button', { name: 'Cancel' });
+    this.deleteButton = page.getByRole('button', { name: 'Delete' });
+    this.errorMessage = page.getByRole('alert').filter({ hasNot: page.getByText('ADMIN_TOKEN') });
+  }
+
+  async goto(groupId?: string) {
+    const url = groupId ? `/admin?group=${groupId}` : '/admin';
+    await this.page.goto(url);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  /** Click the group tab with the given name. */
+  async selectGroupTab(name: string) {
+    await this.page.getByRole('tab', { name }).click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  /** Open the add/edit form for a group by name (edit) or click Add Group. */
+  async clickEditGroup(name: string) {
+    await this.page.getByRole('button', { name: `Edit ${name}` }).click();
+  }
+
+  async clickDeleteGroup(name: string) {
+    await this.page.getByRole('button', { name: `Delete ${name}` }).click();
+  }
+
+  async clickEditMember(name: string) {
+    await this.page.getByRole('button', { name: `Edit ${name}` }).click();
+  }
+
+  async clickDeleteMember(name: string) {
+    await this.page.getByRole('button', { name: `Delete ${name}` }).click();
+  }
+
+  async clickEditCycle(number: number) {
+    await this.page.getByRole('button', { name: `Edit cycle ${number}` }).click();
+  }
+
+  async clickDeleteCycle(number: number) {
+    await this.page.getByRole('button', { name: `Delete cycle ${number}` }).click();
+  }
+}

--- a/tests/pages/dashboard.page.ts
+++ b/tests/pages/dashboard.page.ts
@@ -25,11 +25,18 @@ export class DashboardPage {
   readonly perCycleChartContainer: Locator;
   readonly cumulativeChartContainer: Locator;
 
+  // Group selector & admin link
+  readonly groupSelector: Locator;
+  readonly adminLink: Locator;
+
   constructor(page: Page) {
     this.page = page;
 
     this.memberPaymentsHeading = page.getByRole('heading', { name: 'Member Payments' });
     this.memberPaymentsSubtitle = page.locator('h2:has-text("Member Payments") + p');
+
+    this.groupSelector = page.getByRole('combobox', { name: 'Select savings group' });
+    this.adminLink = page.getByRole('link', { name: 'Admin panel' });
 
     this.viewToggleGroup = page.getByRole('group', { name: 'Switch between table and chart view' });
     this.tableViewButton = page.getByRole('button', { name: 'Table view' });
@@ -76,5 +83,12 @@ export class DashboardPage {
    */
   async getSubtitleText(): Promise<string> {
     return this.memberPaymentsSubtitle.innerText();
+  }
+
+  /** Select a group by visible name from the GroupSelector dropdown. */
+  async selectGroup(name: string) {
+    await this.groupSelector.click();
+    await this.page.getByRole('option', { name }).click();
+    await this.page.waitForLoadState('networkidle');
   }
 }

--- a/tests/unit/admin-actions.test.ts
+++ b/tests/unit/admin-actions.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ActionResult } from '@/lib/types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('admin server actions', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  describe('createGroup', () => {
+    it('sends POST to /api/admin/groups with Authorization header', async () => {
+      const fetchSpy = mockFetch(200, { id: 'group:1', name: 'Test Group' });
+      vi.stubGlobal('fetch', fetchSpy);
+      const { createGroup } = await import('@/lib/admin-actions');
+
+      await createGroup({ name: 'Test Group' });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/groups');
+      expect((opts.method as string).toUpperCase()).toBe('POST');
+      expect(opts.headers).toMatchObject({ Authorization: expect.stringContaining('Bearer') });
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, { id: 'group:1', name: 'Test Group' }));
+      const { createGroup } = await import('@/lib/admin-actions');
+      const result: ActionResult = await createGroup({ name: 'Test Group' });
+      expect(result.success).toBe(true);
+    });
+
+    it('returns { success: false, error } on non-OK response', async () => {
+      vi.stubGlobal('fetch', mockFetch(400, { error: 'name is required' }));
+      const { createGroup } = await import('@/lib/admin-actions');
+      const result: ActionResult = await createGroup({ name: '' });
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBeTruthy();
+    });
+
+    it('returns { success: false, error } when ADMIN_TOKEN is missing', async () => {
+      vi.stubGlobal('fetch', mockFetch(401, { error: 'Unauthorized' }));
+      const { createGroup } = await import('@/lib/admin-actions');
+      const result: ActionResult = await createGroup({ name: 'Test' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('updateGroup', () => {
+    it('sends PATCH to /api/admin/groups/{id}', async () => {
+      const fetchSpy = mockFetch(200, {});
+      vi.stubGlobal('fetch', fetchSpy);
+      const { updateGroup } = await import('@/lib/admin-actions');
+
+      await updateGroup('group:1', { name: 'Renamed' });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/groups/');
+      expect((opts.method as string).toUpperCase()).toBe('PATCH');
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, {}));
+      const { updateGroup } = await import('@/lib/admin-actions');
+      const result = await updateGroup('group:1', { name: 'Renamed' });
+      expect(result.success).toBe(true);
+    });
+
+    it('returns { success: false, error } on 404', async () => {
+      vi.stubGlobal('fetch', mockFetch(404, { error: 'not found' }));
+      const { updateGroup } = await import('@/lib/admin-actions');
+      const result = await updateGroup('group:999', { name: 'X' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('deleteGroup', () => {
+    it('sends DELETE to /api/admin/groups/{id}', async () => {
+      const fetchSpy = mockFetch(200, {});
+      vi.stubGlobal('fetch', fetchSpy);
+      const { deleteGroup } = await import('@/lib/admin-actions');
+
+      await deleteGroup('group:1');
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/groups/');
+      expect((opts.method as string).toUpperCase()).toBe('DELETE');
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, {}));
+      const { deleteGroup } = await import('@/lib/admin-actions');
+      const result = await deleteGroup('group:1');
+      expect(result.success).toBe(true);
+    });
+
+    it('returns { success: false, error } on 409 conflict', async () => {
+      vi.stubGlobal('fetch', mockFetch(409, { error: 'group has active cycles' }));
+      const { deleteGroup } = await import('@/lib/admin-actions');
+      const result = await deleteGroup('group:1');
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBeTruthy();
+    });
+  });
+
+  describe('createMember', () => {
+    it('sends POST to /api/admin/groups/{groupId}/members', async () => {
+      const fetchSpy = mockFetch(200, { id: 'member:1' });
+      vi.stubGlobal('fetch', fetchSpy);
+      const { createMember } = await import('@/lib/admin-actions');
+
+      await createMember('group:1', { name: 'Alice', phone: '2349000000001', position: 1 });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/groups/');
+      expect(url).toContain('/members');
+      expect((opts.method as string).toUpperCase()).toBe('POST');
+      expect(opts.headers).toMatchObject({ Authorization: expect.stringContaining('Bearer') });
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, { id: 'member:1' }));
+      const { createMember } = await import('@/lib/admin-actions');
+      const result = await createMember('group:1', { name: 'Alice', phone: '2349000000001', position: 1 });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('updateMember', () => {
+    it('sends PATCH to /api/admin/members/{id}', async () => {
+      const fetchSpy = mockFetch(200, {});
+      vi.stubGlobal('fetch', fetchSpy);
+      const { updateMember } = await import('@/lib/admin-actions');
+
+      await updateMember('member:1', { name: 'Bob' });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/members/');
+      expect((opts.method as string).toUpperCase()).toBe('PATCH');
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, {}));
+      const { updateMember } = await import('@/lib/admin-actions');
+      const result = await updateMember('member:1', { name: 'Bob' });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('deleteMember', () => {
+    it('sends DELETE to /api/admin/members/{id}', async () => {
+      const fetchSpy = mockFetch(200, {});
+      vi.stubGlobal('fetch', fetchSpy);
+      const { deleteMember } = await import('@/lib/admin-actions');
+
+      await deleteMember('member:1');
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/members/');
+      expect((opts.method as string).toUpperCase()).toBe('DELETE');
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, {}));
+      const { deleteMember } = await import('@/lib/admin-actions');
+      const result = await deleteMember('member:1');
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('createCycle', () => {
+    it('sends POST to /api/admin/groups/{groupId}/cycles', async () => {
+      const fetchSpy = mockFetch(200, { id: 'cycle:1' });
+      vi.stubGlobal('fetch', fetchSpy);
+      const { createCycle } = await import('@/lib/admin-actions');
+
+      await createCycle('group:1', {
+        cycleNumber: 1,
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        contributionPerMember: 500000,
+        recipientMemberId: 'member:1',
+      });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/groups/');
+      expect(url).toContain('/cycles');
+      expect((opts.method as string).toUpperCase()).toBe('POST');
+      expect(opts.headers).toMatchObject({ Authorization: expect.stringContaining('Bearer') });
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, { id: 'cycle:1' }));
+      const { createCycle } = await import('@/lib/admin-actions');
+      const result = await createCycle('group:1', {
+        cycleNumber: 1,
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        contributionPerMember: 500000,
+        recipientMemberId: 'member:1',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('updateCycle', () => {
+    it('sends PATCH to /api/admin/cycles/{id}', async () => {
+      const fetchSpy = mockFetch(200, {});
+      vi.stubGlobal('fetch', fetchSpy);
+      const { updateCycle } = await import('@/lib/admin-actions');
+
+      await updateCycle('cycle:1', { status: 'completed' });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/cycles/');
+      expect((opts.method as string).toUpperCase()).toBe('PATCH');
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, {}));
+      const { updateCycle } = await import('@/lib/admin-actions');
+      const result = await updateCycle('cycle:1', { status: 'completed' });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('deleteCycle', () => {
+    it('sends DELETE to /api/admin/cycles/{id}', async () => {
+      const fetchSpy = mockFetch(200, {});
+      vi.stubGlobal('fetch', fetchSpy);
+      const { deleteCycle } = await import('@/lib/admin-actions');
+
+      await deleteCycle('cycle:1');
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/api/admin/cycles/');
+      expect((opts.method as string).toUpperCase()).toBe('DELETE');
+    });
+
+    it('returns { success: true } on 200', async () => {
+      vi.stubGlobal('fetch', mockFetch(200, {}));
+      const { deleteCycle } = await import('@/lib/admin-actions');
+      const result = await deleteCycle('cycle:1');
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/tests/unit/admin-actions.test.ts
+++ b/tests/unit/admin-actions.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { ActionResult } from '@/lib/types';
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/tests/unit/buildChartData.test.ts
+++ b/tests/unit/buildChartData.test.ts
@@ -13,6 +13,7 @@ const cycle1: Cycle = {
   totalAmount: 2500000,          // ₦25,000 in kobo (5 members)
   recipientMemberId: 'member:1',
   status: 'completed',
+  groupId: 'group:1',
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
   version: 1,
@@ -27,6 +28,7 @@ const cycle2: Cycle = {
   totalAmount: 2500000,
   recipientMemberId: 'member:2',
   status: 'active',
+  groupId: 'group:1',
   createdAt: '2026-02-01T00:00:00Z',
   updatedAt: '2026-02-01T00:00:00Z',
   version: 1,

--- a/tests/unit/buildChartData.test.ts
+++ b/tests/unit/buildChartData.test.ts
@@ -5,38 +5,44 @@ import type { Cycle, Payment } from '@/lib/types';
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
 const cycle1: Cycle = {
-  id: 1,
+  id: 'cycle:1',
   cycleNumber: 1,
   startDate: '2026-01-01',
   endDate: '2026-01-31',
   contributionPerMember: 500000, // ₦5,000 in kobo
   totalAmount: 2500000,          // ₦25,000 in kobo (5 members)
-  recipientMemberId: 1,
-  status: 'closed',
+  recipientMemberId: 'member:1',
+  status: 'completed',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  version: 1,
 };
 
 const cycle2: Cycle = {
-  id: 2,
+  id: 'cycle:2',
   cycleNumber: 2,
   startDate: '2026-02-01',
   endDate: '2026-02-28',
   contributionPerMember: 500000,
   totalAmount: 2500000,
-  recipientMemberId: 2,
+  recipientMemberId: 'member:2',
   status: 'active',
+  createdAt: '2026-02-01T00:00:00Z',
+  updatedAt: '2026-02-01T00:00:00Z',
+  version: 1,
 };
 
 const payments: Payment[] = [
   // Cycle 1: 3 of 5 paid (₦15,000 collected in kobo = 1,500,000)
-  { id: 1, memberId: 1, cycleId: 1, amount: 500000, currency: 'NGN', paymentDate: '2026-01-05' },
-  { id: 2, memberId: 2, cycleId: 1, amount: 500000, currency: 'NGN', paymentDate: '2026-01-06' },
-  { id: 3, memberId: 3, cycleId: 1, amount: 500000, currency: 'NGN', paymentDate: '2026-01-07' },
+  { id: 'payment:1', memberId: 'member:1', cycleId: 'cycle:1', amount: 500000, currency: 'NGN', paymentDate: '2026-01-05', createdAt: '2026-01-05T00:00:00Z', updatedAt: '2026-01-05T00:00:00Z' },
+  { id: 'payment:2', memberId: 'member:2', cycleId: 'cycle:1', amount: 500000, currency: 'NGN', paymentDate: '2026-01-06', createdAt: '2026-01-06T00:00:00Z', updatedAt: '2026-01-06T00:00:00Z' },
+  { id: 'payment:3', memberId: 'member:3', cycleId: 'cycle:1', amount: 500000, currency: 'NGN', paymentDate: '2026-01-07', createdAt: '2026-01-07T00:00:00Z', updatedAt: '2026-01-07T00:00:00Z' },
   // Cycle 2: 5 of 5 paid (₦25,000 collected in kobo = 2,500,000)
-  { id: 4, memberId: 1, cycleId: 2, amount: 500000, currency: 'NGN', paymentDate: '2026-02-03' },
-  { id: 5, memberId: 2, cycleId: 2, amount: 500000, currency: 'NGN', paymentDate: '2026-02-04' },
-  { id: 6, memberId: 3, cycleId: 2, amount: 500000, currency: 'NGN', paymentDate: '2026-02-05' },
-  { id: 7, memberId: 4, cycleId: 2, amount: 500000, currency: 'NGN', paymentDate: '2026-02-06' },
-  { id: 8, memberId: 5, cycleId: 2, amount: 500000, currency: 'NGN', paymentDate: '2026-02-07' },
+  { id: 'payment:4', memberId: 'member:1', cycleId: 'cycle:2', amount: 500000, currency: 'NGN', paymentDate: '2026-02-03', createdAt: '2026-02-03T00:00:00Z', updatedAt: '2026-02-03T00:00:00Z' },
+  { id: 'payment:5', memberId: 'member:2', cycleId: 'cycle:2', amount: 500000, currency: 'NGN', paymentDate: '2026-02-04', createdAt: '2026-02-04T00:00:00Z', updatedAt: '2026-02-04T00:00:00Z' },
+  { id: 'payment:6', memberId: 'member:3', cycleId: 'cycle:2', amount: 500000, currency: 'NGN', paymentDate: '2026-02-05', createdAt: '2026-02-05T00:00:00Z', updatedAt: '2026-02-05T00:00:00Z' },
+  { id: 'payment:7', memberId: 'member:4', cycleId: 'cycle:2', amount: 500000, currency: 'NGN', paymentDate: '2026-02-06', createdAt: '2026-02-06T00:00:00Z', updatedAt: '2026-02-06T00:00:00Z' },
+  { id: 'payment:8', memberId: 'member:5', cycleId: 'cycle:2', amount: 500000, currency: 'NGN', paymentDate: '2026-02-07', createdAt: '2026-02-07T00:00:00Z', updatedAt: '2026-02-07T00:00:00Z' },
 ];
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -85,7 +91,7 @@ describe('buildChartData', () => {
 
     it('outstanding is never negative', () => {
       const overpaidPayments: Payment[] = [
-        { id: 1, memberId: 1, cycleId: 1, amount: 9999999, currency: 'NGN', paymentDate: '2026-01-05' },
+        { id: 'payment:99', memberId: 'member:1', cycleId: 'cycle:1', amount: 9999999, currency: 'NGN', paymentDate: '2026-01-05', createdAt: '2026-01-05T00:00:00Z', updatedAt: '2026-01-05T00:00:00Z' },
       ];
       const result = buildChartData([cycle1], overpaidPayments);
       expect(result[0].outstanding).toBeGreaterThanOrEqual(0);
@@ -129,7 +135,7 @@ describe('buildChartData', () => {
 
     it('ignores payments that belong to a different cycle', () => {
       const otherPayments: Payment[] = [
-        { id: 99, memberId: 1, cycleId: 999, amount: 500000, currency: 'NGN', paymentDate: '2026-01-05' },
+        { id: 'payment:99', memberId: 'member:1', cycleId: 'cycle:999', amount: 500000, currency: 'NGN', paymentDate: '2026-01-05', createdAt: '2026-01-05T00:00:00Z', updatedAt: '2026-01-05T00:00:00Z' },
       ];
       const result = buildChartData([cycle1], otherPayments);
       expect(result[0].collected).toBe(0);

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import { getMemberPaymentStatuses, deriveCycleSummary } from '@/lib/utils';
+import type { Cycle, Member, Payment } from '@/lib/types';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeMember(overrides: Partial<Member> & { id: string }): Member {
+  return {
+    name: 'Test Member',
+    phone: '2349000000001',
+    position: 1,
+    status: 'active',
+    groupId: 'group:1',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    version: 1,
+    ...overrides,
+  };
+}
+
+function makePayment(overrides: Partial<Payment> & { id: string; memberId: string; cycleId: string }): Payment {
+  return {
+    amount: 500000,
+    currency: 'NGN',
+    paymentDate: '2026-01-05',
+    createdAt: '2026-01-05T00:00:00Z',
+    updatedAt: '2026-01-05T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeCycle(overrides: Partial<Cycle> & { id: string; recipientMemberId: string }): Cycle {
+  return {
+    cycleNumber: 1,
+    startDate: '2026-01-01',
+    endDate: '2026-01-31',
+    contributionPerMember: 500000,
+    totalAmount: 2500000,
+    status: 'active',
+    groupId: 'group:1',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    version: 1,
+    ...overrides,
+  };
+}
+
+const members: Member[] = [
+  makeMember({ id: 'member:1', name: 'Alice', position: 1 }),
+  makeMember({ id: 'member:2', name: 'Bob',   position: 2 }),
+  makeMember({ id: 'member:3', name: 'Carol', position: 3 }),
+  makeMember({ id: 'member:4', name: 'Dave',  position: 4, status: 'inactive' }),
+];
+
+const cycleId = 'cycle:1';
+const recipientId = 'member:1';
+
+const payments: Payment[] = [
+  makePayment({ id: 'payment:1', memberId: 'member:2', cycleId: 'cycle:1' }),
+  // member:3 has not paid
+  makePayment({ id: 'payment:2', memberId: 'member:2', cycleId: 'cycle:99' }), // different cycle
+];
+
+// ─── getMemberPaymentStatuses ─────────────────────────────────────────────────
+
+describe('getMemberPaymentStatuses', () => {
+  describe('recipient exclusion', () => {
+    it('excludes the recipient member from the result', () => {
+      const result = getMemberPaymentStatuses(members, payments, cycleId, recipientId);
+      const ids = result.map(s => s.member.id);
+      expect(ids).not.toContain('member:1');
+    });
+
+    it('uses strict string equality for recipient ID comparison', () => {
+      // Ensures number-to-string migration didn't break ID matching
+      const result = getMemberPaymentStatuses(members, payments, cycleId, 'member:1');
+      expect(result.find(s => s.member.id === 'member:1')).toBeUndefined();
+    });
+  });
+
+  describe('inactive member exclusion', () => {
+    it('excludes inactive members', () => {
+      const result = getMemberPaymentStatuses(members, payments, cycleId, recipientId);
+      const ids = result.map(s => s.member.id);
+      expect(ids).not.toContain('member:4'); // Dave is inactive
+    });
+  });
+
+  describe('payment matching', () => {
+    it('marks a member as paid when a payment with matching cycleId and memberId exists', () => {
+      const result = getMemberPaymentStatuses(members, payments, cycleId, recipientId);
+      const bob = result.find(s => s.member.id === 'member:2');
+      expect(bob?.hasPaid).toBe(true);
+      expect(bob?.payment?.id).toBe('payment:1');
+    });
+
+    it('marks a member as not paid when no matching payment exists', () => {
+      const result = getMemberPaymentStatuses(members, payments, cycleId, recipientId);
+      const carol = result.find(s => s.member.id === 'member:3');
+      expect(carol?.hasPaid).toBe(false);
+      expect(carol?.payment).toBeNull();
+    });
+
+    it('ignores payments from a different cycleId', () => {
+      // payment:2 has cycleId cycle:99, not cycle:1
+      const result = getMemberPaymentStatuses(members, payments, cycleId, recipientId);
+      const bob = result.find(s => s.member.id === 'member:2');
+      // Only payment:1 (cycle:1) should match — not the cycle:99 one
+      expect(bob?.payment?.id).toBe('payment:1');
+    });
+
+    it('uses strict string equality for cycleId matching', () => {
+      const result = getMemberPaymentStatuses(members, payments, 'cycle:99', recipientId);
+      // payment:2 belongs to cycle:99 and memberId member:2
+      const bob = result.find(s => s.member.id === 'member:2');
+      expect(bob?.hasPaid).toBe(true);
+    });
+  });
+
+  describe('ordering', () => {
+    it('returns members sorted by position ascending', () => {
+      const result = getMemberPaymentStatuses(members, payments, cycleId, recipientId);
+      const positions = result.map(s => s.member.position);
+      expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    });
+  });
+
+  describe('empty inputs', () => {
+    it('returns empty array when members list is empty', () => {
+      expect(getMemberPaymentStatuses([], payments, cycleId, recipientId)).toEqual([]);
+    });
+
+    it('returns all eligible members as unpaid when payments list is empty', () => {
+      const result = getMemberPaymentStatuses(members, [], cycleId, recipientId);
+      expect(result.every(s => !s.hasPaid)).toBe(true);
+    });
+  });
+});
+
+// ─── deriveCycleSummary ───────────────────────────────────────────────────────
+
+describe('deriveCycleSummary', () => {
+  const cycle = makeCycle({ id: 'cycle:1', recipientMemberId: 'member:1' });
+
+  const cyclePayments: Payment[] = [
+    makePayment({ id: 'payment:1', memberId: 'member:2', cycleId: 'cycle:1' }),
+    makePayment({ id: 'payment:2', memberId: 'member:3', cycleId: 'cycle:1' }),
+    // member:1 is the recipient — their payment is excluded
+    makePayment({ id: 'payment:3', memberId: 'member:1', cycleId: 'cycle:1' }),
+  ];
+
+  describe('recipient resolution', () => {
+    it('resolves the recipient from the members list using string ID', () => {
+      const summary = deriveCycleSummary(cycle, members, cyclePayments);
+      expect(summary.recipient.id).toBe('member:1');
+      expect(summary.recipient.name).toBe('Alice');
+    });
+
+    it('throws when the recipient member is not found', () => {
+      const badCycle = makeCycle({ id: 'cycle:1', recipientMemberId: 'member:999' });
+      expect(() => deriveCycleSummary(badCycle, members, cyclePayments)).toThrow('member:999');
+    });
+  });
+
+  describe('totalMembers (contributing members)', () => {
+    it('counts active members excluding the recipient', () => {
+      // members: member:1 (recipient), member:2, member:3 active; member:4 inactive
+      const summary = deriveCycleSummary(cycle, members, cyclePayments);
+      expect(summary.totalMembers).toBe(2); // Bob + Carol
+    });
+
+    it('excludes inactive members from the total', () => {
+      const summary = deriveCycleSummary(cycle, members, cyclePayments);
+      // Dave (member:4) is inactive — not counted
+      expect(summary.totalMembers).toBe(2);
+    });
+  });
+
+  describe('paidCount', () => {
+    it('counts payments for the cycle excluding the recipient', () => {
+      const summary = deriveCycleSummary(cycle, members, cyclePayments);
+      // payment:1 (member:2) + payment:2 (member:3); payment:3 (member:1 = recipient) excluded
+      expect(summary.paidCount).toBe(2);
+    });
+
+    it('excludes the recipient payment from the count', () => {
+      const summary = deriveCycleSummary(cycle, members, cyclePayments);
+      expect(summary.paidCount).toBe(2);
+    });
+
+    it('uses strict string equality for cycleId and memberId matching', () => {
+      const wrongCyclePayments: Payment[] = [
+        makePayment({ id: 'payment:x', memberId: 'member:2', cycleId: 'cycle:99' }),
+      ];
+      const summary = deriveCycleSummary(cycle, members, wrongCyclePayments);
+      expect(summary.paidCount).toBe(0);
+    });
+
+    it('returns 0 when no payments exist', () => {
+      const summary = deriveCycleSummary(cycle, members, []);
+      expect(summary.paidCount).toBe(0);
+    });
+  });
+
+  describe('collectedKobo', () => {
+    it('sums the amount for all non-recipient payments in the cycle', () => {
+      const summary = deriveCycleSummary(cycle, members, cyclePayments);
+      // payment:1 (500000) + payment:2 (500000) = 1000000; payment:3 (recipient) excluded
+      expect(summary.collectedKobo).toBe(1_000_000);
+    });
+
+    it('returns 0 when no payments exist', () => {
+      const summary = deriveCycleSummary(cycle, members, []);
+      expect(summary.collectedKobo).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts `apiFetch`, `FetchResult<T>`, and `FETCH_TIMEOUT_MS` from `lib/data.ts` into a new `lib/http.ts` module
- `lib/data.ts` is now purely domain-level: path construction and fallback values only
- `lib/http.ts` owns all HTTP concerns: base URL, timeout, error handling, response parsing
- `apiFetch` now accepts an optional `RequestInit` override, making it ready for mutation calls (POST/PATCH) without duplication

## Why

`lib/data.ts` was mixing HTTP mechanics with domain logic. Adding retry, auth headers, or different mutation timeouts would have required touching every fetch call site. Now there's one place.

## Test plan

- [ ] `yarn vitest run` — 35 tests passing
- [ ] `yarn tsc --noEmit` — no type errors
- [ ] Smoke-test dashboard loads and data fetches correctly against a running backend