### PR TITLE
Fix: extract HTTP client into lib/http.ts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,15 @@
 # Required in production/preview deployments.
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
+# URL of the Rust/SurrealDB backend.
+# Defaults to http://localhost:8080 if omitted.
+BACKEND_URL=http://localhost:8080
+
+# Admin token for CRUD operations. Must match the backend ADMIN_TOKEN env var.
+ADMIN_TOKEN=
+
+# Timeout (in ms) for read (GET) backend fetches. Defaults to 5000ms if omitted.
+FETCH_TIMEOUT_MS=5000
+
+# Timeout (in ms) for mutation (POST/PATCH/DELETE) backend calls. Defaults to 10000ms if omitted.
+MUTATION_TIMEOUT_MS=10000

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -1,38 +1,36 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-
-const BASE = process.env.BACKEND_URL ?? 'http://localhost:8080';
+import { apiAction } from '@/lib/http';
+import type { ActionResult } from '@/lib/types';
 
 export async function togglePayment(
   memberId: number,
   cycleId: number,
   hasPaid: boolean,
   contributionKobo: number,
-): Promise<void> {
+): Promise<ActionResult> {
+  let result: ActionResult;
+
   if (hasPaid) {
-    const res = await fetch(`${BASE}/api/payments/${memberId}/${cycleId}`, {
-      method: 'DELETE',
-    });
-    if (!res.ok && res.status !== 404) {
-      throw new Error(`Failed to remove payment: ${res.status} ${res.statusText}`);
+    result = await apiAction(`/api/payments/${memberId}/${cycleId}`, { method: 'DELETE' });
+    // 404 means the payment was already removed — treat as success (idempotent intent)
+    if (!result.success && result.error.startsWith('404')) {
+      result = { success: true };
     }
   } else {
-    const res = await fetch(`${BASE}/api/payments`, {
+    result = await apiAction('/api/payments', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+      body: {
         memberId,
         cycleId,
         amount: contributionKobo,
         currency: 'NGN',
         paymentDate: new Date().toISOString().slice(0, 10),
-      }),
+      },
     });
-    if (!res.ok) {
-      throw new Error(`Failed to record payment: ${res.status} ${res.statusText}`);
-    }
   }
 
-  revalidatePath('/');
+  if (result.success) revalidatePath('/');
+  return result;
 }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,34 +1,17 @@
+import { apiFetch, type FetchResult } from '@/lib/http';
 import type { Cycle, Member, Payment } from '@/lib/types';
 
-const BASE = process.env.BACKEND_URL ?? 'http://localhost:8080';
-
-export type FetchResult<T> = { data: T; ok: true } | { data: T; ok: false };
-
-async function apiFetch<T>(url: string, fallback: T): Promise<FetchResult<T>> {
-  try {
-    const res = await fetch(url, {
-      cache: 'no-store',
-      signal: AbortSignal.timeout(5000),
-    });
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-    return { data: await res.json(), ok: true };
-  } catch (err) {
-    console.error(`[data] fetch ${url} failed:`, err);
-    return { data: fallback, ok: false };
-  }
-}
+export type { FetchResult } from '@/lib/http';
 
 export function fetchMembers(): Promise<FetchResult<Member[]>> {
-  return apiFetch(`${BASE}/api/members`, []);
+  return apiFetch('/api/members', []);
 }
 
 export function fetchCycles(): Promise<FetchResult<Cycle[]>> {
-  return apiFetch(`${BASE}/api/cycles`, []);
+  return apiFetch('/api/cycles', []);
 }
 
 export function fetchPayments(cycleId?: number): Promise<FetchResult<Payment[]>> {
-  const url = cycleId
-    ? `${BASE}/api/payments?cycleId=${cycleId}`
-    : `${BASE}/api/payments`;
-  return apiFetch(url, []);
+  const path = cycleId ? `/api/payments?cycleId=${cycleId}` : '/api/payments';
+  return apiFetch(path, []);
 }

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,124 @@
+import { BACKEND_URL } from '@/lib/config';
+import type { ActionResult } from '@/lib/types';
+
+// ─── Timeouts ──────────────────────────────────────────────────────────────────
+
+// Configurable via env — 5 s is long enough for a cold backend, short enough
+// to surface a down server quickly.
+export const FETCH_TIMEOUT_MS = Number(process.env.FETCH_TIMEOUT_MS ?? 5_000);
+export const MUTATION_TIMEOUT_MS = Number(process.env.MUTATION_TIMEOUT_MS ?? 10_000);
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+export type FetchResult<T> = { data: T; ok: true } | { data: T; ok: false };
+
+// Transient server/infra errors that are safe to retry.
+// 4xx client errors are never retried — the request is definitionally broken.
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+
+// ─── Internal retry helper ─────────────────────────────────────────────────────
+
+async function withRetry(
+  fn: () => Promise<Response>,
+  retries: number,
+  backoffMs: number,
+): Promise<Response> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, attempt * backoffMs));
+    try {
+      const res = await fn();
+      if (!RETRYABLE_STATUSES.has(res.status)) return res;
+      lastErr = new Error(`${res.status} ${res.statusText}`);
+    } catch (err) {
+      // Only retry on network failures (TypeError). Timeout/abort DOMExceptions propagate immediately.
+      if (!(err instanceof TypeError)) throw err;
+      lastErr = err;
+    }
+  }
+  throw lastErr;
+}
+
+// ─── apiFetch — read operations ────────────────────────────────────────────────
+// Defaults: 5 s timeout, up to 2 retries with 300 ms linear backoff.
+
+export async function apiFetch<T>(
+  path: string,
+  fallback: T,
+  opts?: RequestInit & { token?: string; retries?: number; backoffMs?: number },
+): Promise<FetchResult<T>> {
+  const { token, retries = 2, backoffMs = 300, ...fetchOpts } = opts ?? {};
+
+  const headers: Record<string, string> = {
+    ...(fetchOpts.headers as Record<string, string> | undefined),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+
+  try {
+    const res = await withRetry(
+      () =>
+        fetch(`${BACKEND_URL}${path}`, {
+          cache: 'no-store',
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+          ...fetchOpts,
+          headers,
+        }),
+      retries,
+      backoffMs,
+    );
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return { data: await res.json(), ok: true };
+  } catch (err) {
+    console.error(`[http] fetch ${path} failed:`, err);
+    return { data: fallback, ok: false };
+  }
+}
+
+// ─── apiAction — mutation operations ───────────────────────────────────────────
+// Defaults: 10 s timeout, no retries (mutations are not idempotent by default).
+// Pass token explicitly — no default so non-admin callers don't inadvertently
+// attach ADMIN_TOKEN to public endpoints.
+
+export interface ApiActionOptions {
+  method?: string;    // default 'POST'
+  body?: unknown;
+  token?: string;     // attaches Authorization: Bearer when provided
+  retries?: number;   // default 0
+  backoffMs?: number; // default 300
+}
+
+export async function apiAction(
+  path: string,
+  opts: ApiActionOptions = {},
+): Promise<ActionResult> {
+  const { method = 'POST', body, token, retries = 0, backoffMs = 300 } = opts;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+
+  try {
+    const res = await withRetry(
+      () =>
+        fetch(`${BACKEND_URL}${path}`, {
+          method,
+          headers,
+          ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+          signal: AbortSignal.timeout(MUTATION_TIMEOUT_MS),
+        }),
+      retries,
+      backoffMs,
+    );
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      const message = (data as { error?: string }).error ?? `${res.status} ${res.statusText}`;
+      return { success: false, error: message };
+    }
+
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -45,3 +45,5 @@ export interface CycleSummary {
   totalMembers: number;
   collectedKobo: number;
 }
+
+export type ActionResult = { success: true } | { success: false; error: string };

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FETCH_TIMEOUT_MS, MUTATION_TIMEOUT_MS } from '@/lib/http';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : String(status),
+    json: async () => body,
+  };
+}
+
+function stubFetch(...responses: ReturnType<typeof mockResponse>[]) {
+  const spy = vi.fn();
+  for (const r of responses) spy.mockResolvedValueOnce(r);
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('lib/http', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  // ── Constants ──────────────────────────────────────────────────────────────
+
+  describe('constants', () => {
+    it('FETCH_TIMEOUT_MS defaults to 5000', () => {
+      expect(FETCH_TIMEOUT_MS).toBe(5000);
+    });
+
+    it('MUTATION_TIMEOUT_MS defaults to 10000', () => {
+      expect(MUTATION_TIMEOUT_MS).toBe(10000);
+    });
+  });
+
+  // ── apiFetch ───────────────────────────────────────────────────────────────
+
+  describe('apiFetch', () => {
+    it('returns { ok: true, data } on 200', async () => {
+      stubFetch(mockResponse(200, { id: '1' }));
+      const { apiFetch } = await import('@/lib/http');
+
+      const result = await apiFetch('/api/groups', [], { retries: 0 });
+
+      expect(result.ok).toBe(true);
+      expect(result.data).toEqual({ id: '1' });
+    });
+
+    it('returns { ok: false, data: fallback } on non-ok status', async () => {
+      stubFetch(mockResponse(500, {}));
+      const { apiFetch } = await import('@/lib/http');
+
+      const result = await apiFetch('/api/groups', ['fallback'], { retries: 0 });
+
+      expect(result.ok).toBe(false);
+      expect(result.data).toEqual(['fallback']);
+    });
+
+    it('passes cache: no-store to every fetch call', async () => {
+      const spy = stubFetch(mockResponse(200, []));
+      const { apiFetch } = await import('@/lib/http');
+
+      await apiFetch('/api/groups', [], { retries: 0 });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect(opts.cache).toBe('no-store');
+    });
+
+    it('attaches Authorization header when token is provided', async () => {
+      const spy = stubFetch(mockResponse(200, []));
+      const { apiFetch } = await import('@/lib/http');
+
+      await apiFetch('/api/groups', [], { token: 'my-token', retries: 0 });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer my-token');
+    });
+
+    it('does NOT attach Authorization header when token is undefined', async () => {
+      const spy = stubFetch(mockResponse(200, []));
+      const { apiFetch } = await import('@/lib/http');
+
+      await apiFetch('/api/groups', [], { retries: 0 });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect((opts.headers as Record<string, string>)['Authorization']).toBeUndefined();
+    });
+
+    it('retries on 503 and succeeds on 3rd attempt', async () => {
+      const spy = stubFetch(
+        mockResponse(503, {}),
+        mockResponse(503, {}),
+        mockResponse(200, [{ id: '1' }]),
+      );
+      const { apiFetch } = await import('@/lib/http');
+
+      const result = await apiFetch('/api/groups', [], { retries: 2, backoffMs: 0 });
+
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(result.ok).toBe(true);
+    });
+
+    it('does NOT retry on 404 — calls fetch exactly once', async () => {
+      const spy = stubFetch(mockResponse(404, {}));
+      const { apiFetch } = await import('@/lib/http');
+
+      const result = await apiFetch('/api/groups', [], { retries: 2, backoffMs: 0 });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(result.ok).toBe(false);
+    });
+
+    it('retries on TypeError (network failure) and returns fallback after all retries', async () => {
+      const spy = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+      vi.stubGlobal('fetch', spy);
+      const { apiFetch } = await import('@/lib/http');
+
+      const result = await apiFetch('/api/groups', ['fallback'], { retries: 2, backoffMs: 0 });
+
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(result.ok).toBe(false);
+      expect(result.data).toEqual(['fallback']);
+    });
+
+    it('does NOT retry on non-TypeError errors (e.g. AbortError)', async () => {
+      const abortErr = new DOMException('Aborted', 'AbortError');
+      const spy = vi.fn().mockRejectedValue(abortErr);
+      vi.stubGlobal('fetch', spy);
+      const { apiFetch } = await import('@/lib/http');
+
+      const result = await apiFetch('/api/groups', [], { retries: 2, backoffMs: 0 });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(result.ok).toBe(false);
+    });
+
+    it('returns fallback after all retries on 503 exhausted', async () => {
+      stubFetch(mockResponse(503, {}), mockResponse(503, {}), mockResponse(503, {}));
+      const { apiFetch } = await import('@/lib/http');
+
+      const result = await apiFetch('/api/groups', ['fallback'], { retries: 2, backoffMs: 0 });
+
+      expect(result.ok).toBe(false);
+      expect(result.data).toEqual(['fallback']);
+    });
+  });
+
+  // ── apiAction ──────────────────────────────────────────────────────────────
+
+  describe('apiAction', () => {
+    it('returns { success: true } on 200', async () => {
+      stubFetch(mockResponse(200, {}));
+      const { apiAction } = await import('@/lib/http');
+
+      const result = await apiAction('/api/payments');
+
+      expect(result.success).toBe(true);
+    });
+
+    it('returns { success: false, error } from JSON error body on non-ok', async () => {
+      stubFetch(mockResponse(400, { error: 'name is required' }));
+      const { apiAction } = await import('@/lib/http');
+
+      const result = await apiAction('/api/admin/groups', { method: 'POST', body: {} });
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe('name is required');
+    });
+
+    it('falls back to status text when error body has no error field', async () => {
+      stubFetch(mockResponse(422, { message: 'unprocessable' }));
+      const { apiAction } = await import('@/lib/http');
+
+      const result = await apiAction('/api/admin/groups', { method: 'POST', body: {} });
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('422');
+    });
+
+    it('attaches Authorization header when token is provided', async () => {
+      const spy = stubFetch(mockResponse(200, {}));
+      const { apiAction } = await import('@/lib/http');
+
+      await apiAction('/api/admin/groups', { method: 'POST', body: {}, token: 'admin-token' });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer admin-token');
+    });
+
+    it('does NOT attach Authorization header when token is undefined', async () => {
+      const spy = stubFetch(mockResponse(200, {}));
+      const { apiAction } = await import('@/lib/http');
+
+      await apiAction('/api/payments', { method: 'POST', body: {} });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect((opts.headers as Record<string, string>)['Authorization']).toBeUndefined();
+    });
+
+    it('always attaches Content-Type: application/json', async () => {
+      const spy = stubFetch(mockResponse(200, {}));
+      const { apiAction } = await import('@/lib/http');
+
+      await apiAction('/api/payments', { method: 'POST', body: {} });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect((opts.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    });
+
+    it('omits body from fetch call when body is undefined (DELETE)', async () => {
+      const spy = stubFetch(mockResponse(200, {}));
+      const { apiAction } = await import('@/lib/http');
+
+      await apiAction('/api/payments/1/2', { method: 'DELETE' });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect(opts.body).toBeUndefined();
+    });
+
+    it('serialises body as JSON when provided', async () => {
+      const spy = stubFetch(mockResponse(200, {}));
+      const { apiAction } = await import('@/lib/http');
+
+      await apiAction('/api/payments', { method: 'POST', body: { amount: 5000 } });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect(opts.body).toBe(JSON.stringify({ amount: 5000 }));
+    });
+
+    it('defaults to method POST', async () => {
+      const spy = stubFetch(mockResponse(200, {}));
+      const { apiAction } = await import('@/lib/http');
+
+      await apiAction('/api/payments', { body: {} });
+
+      const [, opts] = spy.mock.calls[0] as [string, RequestInit];
+      expect((opts.method as string).toUpperCase()).toBe('POST');
+    });
+
+    it('defaults to retries: 0 — fetch called exactly once on failure', async () => {
+      const spy = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+      vi.stubGlobal('fetch', spy);
+      const { apiAction } = await import('@/lib/http');
+
+      const result = await apiAction('/api/payments', { method: 'POST', body: {} });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+    });
+
+    it('returns { success: false, error: err.message } on caught Error', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+      const { apiAction } = await import('@/lib/http');
+
+      const result = await apiAction('/api/payments', { method: 'POST', body: {} });
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe('network down');
+    });
+  });
+});


### PR DESCRIPTION
## Context

Raised from Copilot review comments on PR #14 — the magic timeout, inline fetch mechanics, and missing retry/auth infrastructure were flagged as architectural debt.

## What changed

- **`lib/http.ts`** (new) — single home for all HTTP concerns:
  - `FETCH_TIMEOUT_MS` + `MUTATION_TIMEOUT_MS` (both env-configurable)
  - Private `withRetry` — linear backoff, retries on 429/502/503/504 and `TypeError` (network failure), never retries 4xx or timeouts
  - `apiFetch` — reads, 2 retries by default, optional `token` / `retries` / `backoffMs`
  - `apiAction` — mutations, 0 retries by default, optional `token`; token is passed explicitly so non-admin callers never inadvertently attach `ADMIN_TOKEN`
- **`lib/data.ts`** — stripped to path construction; imports `apiFetch` from `lib/http.ts`
- **`lib/actions.ts`** — `togglePayment` uses `apiAction`; return type `void → ActionResult`; 404-on-DELETE treated as idempotent success
- **`lib/types.ts`** — adds `ActionResult` discriminated union
- **`.env.example`** — documents `BACKEND_URL`, `ADMIN_TOKEN`, `FETCH_TIMEOUT_MS`, `MUTATION_TIMEOUT_MS`
- **`tests/unit/http.test.ts`** (new) — 23 unit tests covering retry, auth header, fallback, timeout, DELETE no-body

## Test plan

- [ ] `yarn tsc --noEmit` — zero type errors
- [ ] `yarn vitest run` — 36 tests passing
- [ ] Manual: toggle payment — revalidates, no errors
- [ ] Manual: kill backend, make read request — retry attempts in server log, fallback data rendered