### PR TITLE
Fix fetchPayments missing groupId filter

### DIFF
--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -4,10 +4,13 @@ import type { NextRequest } from 'next/server';
 const BASE = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 export async function GET(request: NextRequest) {
+  const params = new URLSearchParams();
+  const groupId = request.nextUrl.searchParams.get('groupId');
   const cycleId = request.nextUrl.searchParams.get('cycleId');
-  const url = cycleId
-    ? `${BASE}/api/payments?cycleId=${cycleId}`
-    : `${BASE}/api/payments`;
+  if (groupId) params.set('groupId', groupId);
+  if (cycleId) params.set('cycleId', cycleId);
+  const query = params.toString();
+  const url = query ? `${BASE}/api/payments?${query}` : `${BASE}/api/payments`;
 
   const res = await fetch(url, { cache: 'no-store' });
   if (!res.ok) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ export default async function DashboardPage({ searchParams }: PageProps) {
   const [membersResult, cyclesResult, paymentsResult] = await Promise.all([
     fetchMembers(selectedGroupId || undefined),
     fetchCycles(selectedGroupId || undefined),
-    fetchPayments(),
+    fetchPayments(selectedGroupId || undefined),
   ]);
 
   const serverError =

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -17,7 +17,14 @@ export function fetchCycles(groupId?: string): Promise<FetchResult<Cycle[]>> {
   return apiFetch(path, []);
 }
 
-export function fetchPayments(cycleId?: string): Promise<FetchResult<Payment[]>> {
-  const path = cycleId ? `/api/payments?cycleId=${cycleId}` : '/api/payments';
+export function fetchPayments(
+  groupId?: string,
+  cycleId?: string,
+): Promise<FetchResult<Payment[]>> {
+  const params = new URLSearchParams();
+  if (groupId) params.set('groupId', groupId);
+  if (cycleId) params.set('cycleId', cycleId);
+  const query = params.toString();
+  const path = query ? `/api/payments?${query}` : '/api/payments';
   return apiFetch(path, []);
 }


### PR DESCRIPTION
## Summary
- `fetchPayments()` in `lib/data.ts` fetched ALL payments with no `groupId` filter, unlike `fetchMembers` and `fetchCycles` which already scoped by group
- Added `groupId` as the first parameter to `fetchPayments()`, using `URLSearchParams` for clean query string building
- Updated the dashboard page caller to pass `selectedGroupId`, matching the pattern used by the other two fetch functions

## Test plan
- [x] All 87 unit tests pass (`npx vitest run`)
- [x] 63/65 e2e tests pass — 2 pre-existing admin page failures (confirmed same on `main`)
- [ ] Verify dashboard shows only payments for the selected group when switching groups