### PR TITLE
feat: FE-1 NextAuth v5 scaffold against poolpay-api credentials endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,9 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # Defaults to http://localhost:8080 if omitted.
 BACKEND_URL=http://localhost:8080
 
-# Shared HMAC secret used to sign /api/auth/verify-credentials and
-# /api/auth/ensure-user requests. Must match the backend value byte-for-byte
-# and be at least 32 bytes. Generate with `openssl rand -hex 32`.
+# Shared HMAC secret used to sign /api/auth/verify-credentials requests.
+# Must match the backend value byte-for-byte and be at least 32 bytes.
+# Generate with `openssl rand -hex 32`.
 NEXTAUTH_BACKEND_SECRET=
 
 # NextAuth session cookie secret. Unrelated to NEXTAUTH_BACKEND_SECRET.

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,20 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # Defaults to http://localhost:8080 if omitted.
 BACKEND_URL=http://localhost:8080
 
-# Admin token for CRUD operations. Must match the backend ADMIN_TOKEN env var.
+# Shared HMAC secret used to sign /api/auth/verify-credentials and
+# /api/auth/ensure-user requests. Must match the backend value byte-for-byte
+# and be at least 32 bytes. Generate with `openssl rand -hex 32`.
+NEXTAUTH_BACKEND_SECRET=
+
+# NextAuth session cookie secret. Unrelated to NEXTAUTH_BACKEND_SECRET.
+# Generate with `openssl rand -base64 32`.
+NEXTAUTH_SECRET=
+
+# Required by NextAuth v5 for callback URL resolution in non-local deployments.
+NEXTAUTH_URL=http://localhost:3000
+
+# Deprecated: backend removed ADMIN_TOKEN in BE-6 (PR #29). Kept until FE-2
+# wires admin routes onto JWT-minted bearer tokens.
 ADMIN_TOKEN=
 
 # Timeout (in ms) for read (GET) backend fetches. Defaults to 5000ms if omitted.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ Open [http://localhost:3000](http://localhost:3000) (or whichever port Next.js a
 
 ---
 
+## Authentication (FE-1)
+
+Sign-in is scaffolded with NextAuth v5 against the `poolpay-api` Credentials endpoint. Set these before running `yarn dev`:
+
+| Var | Purpose |
+|---|---|
+| `BACKEND_URL` | Base URL of `poolpay-api`. |
+| `NEXTAUTH_BACKEND_SECRET` | HMAC secret shared with the backend. Must match byte-for-byte and be ≥ 32 bytes. Generate with `openssl rand -hex 32`. |
+| `NEXTAUTH_SECRET` | NextAuth's own cookie secret. Generate with `openssl rand -base64 32`. |
+| `NEXTAUTH_URL` | Required for callback URL resolution on non-local deploys. |
+
+Visit `/signin` to log in. Contract lives in the Digital Brain vault: `wiki/poolpay/architecture/auth-api-contract.md`.
+
+---
+
 <!-- AUTO-GENERATED -->
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Sign-in is scaffolded with NextAuth v5 against the `poolpay-api` Credentials end
 
 Visit `/signin` to log in. Contract lives in the Digital Brain vault: `wiki/poolpay/architecture/auth-api-contract.md`.
 
+> Note: the auto-generated "Environment Variables" table below is not yet updated for auth-related vars. Treat this Authentication section as the authoritative source for auth configuration until the generator is updated (and `ADMIN_TOKEN` is fully removed in FE-2).
+
 ---
 
 <!-- AUTO-GENERATED -->

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -1,76 +1,10 @@
-"use client";
-
-import { useState, type FormEvent } from "react";
-import { signIn } from "next-auth/react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { SignInForm } from "./signin-form";
 
 export default function SignInPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") ?? "/";
-
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setSubmitting(true);
-    setError(null);
-
-    const result = await signIn("credentials", {
-      email,
-      password,
-      redirect: false,
-    });
-
-    setSubmitting(false);
-
-    if (!result || result.error) {
-      setError("Invalid email or password.");
-      return;
-    }
-
-    router.push(callbackUrl);
-    router.refresh();
-  }
-
   return (
-    <main style={{ maxWidth: 360, margin: "4rem auto", fontFamily: "sans-serif" }}>
-      <h1>Sign in</h1>
-      <form onSubmit={handleSubmit}>
-        <label style={{ display: "block", marginBottom: 12 }}>
-          Email
-          <input
-            type="email"
-            required
-            autoComplete="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            style={{ width: "100%", padding: 8 }}
-          />
-        </label>
-        <label style={{ display: "block", marginBottom: 12 }}>
-          Password
-          <input
-            type="password"
-            required
-            autoComplete="current-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            style={{ width: "100%", padding: 8 }}
-          />
-        </label>
-        {error ? (
-          <p role="alert" style={{ color: "crimson" }}>
-            {error}
-          </p>
-        ) : null}
-        <button type="submit" disabled={submitting} style={{ padding: "8px 16px" }}>
-          {submitting ? "Signing in…" : "Sign in"}
-        </button>
-      </form>
-    </main>
+    <Suspense fallback={null}>
+      <SignInForm />
+    </Suspense>
   );
 }

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function SignInPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") ?? "/";
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const result = await signIn("credentials", {
+      email,
+      password,
+      redirect: false,
+    });
+
+    setSubmitting(false);
+
+    if (!result || result.error) {
+      setError("Invalid email or password.");
+      return;
+    }
+
+    router.push(callbackUrl);
+    router.refresh();
+  }
+
+  return (
+    <main style={{ maxWidth: 360, margin: "4rem auto", fontFamily: "sans-serif" }}>
+      <h1>Sign in</h1>
+      <form onSubmit={handleSubmit}>
+        <label style={{ display: "block", marginBottom: 12 }}>
+          Email
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            style={{ width: "100%", padding: 8 }}
+          />
+        </label>
+        <label style={{ display: "block", marginBottom: 12 }}>
+          Password
+          <input
+            type="password"
+            required
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            style={{ width: "100%", padding: 8 }}
+          />
+        </label>
+        {error ? (
+          <p role="alert" style={{ color: "crimson" }}>
+            {error}
+          </p>
+        ) : null}
+        <button type="submit" disabled={submitting} style={{ padding: "8px 16px" }}>
+          {submitting ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/signin/signin-form.tsx
+++ b/app/signin/signin-form.tsx
@@ -16,6 +16,8 @@ function messageForCode(code: string | undefined): string {
       return "Too many attempts. Please wait before trying again.";
     case "field_validation":
       return "Email or password is too long.";
+    case "backend_unavailable":
+      return "Sign-in is temporarily unavailable. Please try again in a few minutes.";
     default:
       return "Invalid email or password.";
   }

--- a/app/signin/signin-form.tsx
+++ b/app/signin/signin-form.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export function safeCallbackUrl(raw: string | null): string {
+  if (!raw) return "/";
+  if (raw.startsWith("/") && !raw.startsWith("//")) return raw;
+  return "/";
+}
+
+function messageForCode(code: string | undefined): string {
+  switch (code) {
+    case "rate_limited":
+      return "Too many attempts. Please wait before trying again.";
+    case "field_validation":
+      return "Email or password is too long.";
+    default:
+      return "Invalid email or password.";
+  }
+}
+
+export function SignInForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const result = await signIn("credentials", {
+      email,
+      password,
+      redirect: false,
+    });
+
+    setSubmitting(false);
+
+    if (!result || result.error) {
+      setError(messageForCode(result?.code));
+      return;
+    }
+
+    router.push(callbackUrl);
+    router.refresh();
+  }
+
+  return (
+    <main style={{ maxWidth: 360, margin: "4rem auto", fontFamily: "sans-serif" }}>
+      <h1>Sign in</h1>
+      <form onSubmit={handleSubmit}>
+        <label style={{ display: "block", marginBottom: 12 }}>
+          Email
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            style={{ width: "100%", padding: 8 }}
+          />
+        </label>
+        <label style={{ display: "block", marginBottom: 12 }}>
+          Password
+          <input
+            type="password"
+            required
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            style={{ width: "100%", padding: 8 }}
+          />
+        </label>
+        {error ? (
+          <p role="alert" style={{ color: "crimson" }}>
+            {error}
+          </p>
+        ) : null}
+        <button type="submit" disabled={submitting} style={{ padding: "8px 16px" }}>
+          {submitting ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/signin/signin-form.tsx
+++ b/app/signin/signin-form.tsx
@@ -3,12 +3,7 @@
 import { useState, type FormEvent } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
-
-export function safeCallbackUrl(raw: string | null): string {
-  if (!raw) return "/";
-  if (raw.startsWith("/") && !raw.startsWith("//")) return raw;
-  return "/";
-}
+import { safeCallbackUrl } from "@/lib/auth/safe-callback-url";
 
 function messageForCode(code: string | undefined): string {
   switch (code) {

--- a/app/signin/signin-form.tsx
+++ b/app/signin/signin-form.tsx
@@ -38,21 +38,25 @@ export function SignInForm() {
     setSubmitting(true);
     setError(null);
 
-    const result = await signIn("credentials", {
-      email,
-      password,
-      redirect: false,
-    });
+    try {
+      const result = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+      });
 
-    setSubmitting(false);
+      if (!result || result.error) {
+        setError(messageForCode(result?.code));
+        return;
+      }
 
-    if (!result || result.error) {
-      setError(messageForCode(result?.code));
-      return;
+      router.push(callbackUrl);
+      router.refresh();
+    } catch {
+      setError(messageForCode("backend_unavailable"));
+    } finally {
+      setSubmitting(false);
     }
-
-    router.push(callbackUrl);
-    router.refresh();
   }
 
   return (

--- a/auth.ts
+++ b/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth, { CredentialsSignin, type DefaultSession } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import {
+  BackendError,
   CredentialFieldError,
   InvalidCredentialsError,
   RateLimitedError,
@@ -45,6 +46,10 @@ class FieldValidationSignin extends CredentialsSignin {
   code = "field_validation";
 }
 
+class BackendUnavailableSignin extends CredentialsSignin {
+  code = "backend_unavailable";
+}
+
 export const { auth, handlers, signIn, signOut } = NextAuth({
   session: { strategy: "jwt" },
   pages: { signIn: "/signin" },
@@ -79,7 +84,13 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           if (err instanceof CredentialFieldError) {
             throw new FieldValidationSignin();
           }
-          throw err;
+          if (err instanceof BackendError) {
+            throw new BackendUnavailableSignin();
+          }
+          if (err instanceof Error && err.name === "TimeoutError") {
+            throw new BackendUnavailableSignin();
+          }
+          throw new BackendUnavailableSignin();
         }
       },
     }),
@@ -95,6 +106,9 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       return token;
     },
     async session({ session, token }) {
+      if (!session.user) {
+        session.user = {} as typeof session.user;
+      }
       session.user.id = token.userId ?? "";
       session.user.role = token.role ?? "member";
       session.user.mustResetPassword = token.mustResetPassword ?? false;

--- a/auth.ts
+++ b/auth.ts
@@ -112,6 +112,9 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       session.user.id = token.userId ?? "";
       session.user.role = token.role ?? "member";
       session.user.mustResetPassword = token.mustResetPassword ?? false;
+      if (token.email) session.user.email = token.email;
+      if (token.name) session.user.name = token.name;
+      if (token.picture) session.user.image = token.picture;
       return session;
     },
   },

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,80 @@
+import NextAuth, { type DefaultSession } from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import {
+  InvalidCredentialsError,
+  verifyCredentials,
+} from "@/lib/auth/verify-credentials";
+
+type AppRole = "super_admin" | "admin" | "member";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      role: AppRole;
+      mustResetPassword: boolean;
+    } & DefaultSession["user"];
+  }
+
+  interface User {
+    id?: string;
+    role?: AppRole;
+    mustResetPassword?: boolean;
+  }
+}
+
+declare module "@auth/core/jwt" {
+  interface JWT {
+    userId?: string;
+    role?: AppRole;
+    mustResetPassword?: boolean;
+  }
+}
+
+export const { auth, handlers, signIn, signOut } = NextAuth({
+  session: { strategy: "jwt" },
+  pages: { signIn: "/signin" },
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(raw) {
+        const email = typeof raw?.email === "string" ? raw.email : "";
+        const password = typeof raw?.password === "string" ? raw.password : "";
+        if (!email || !password) return null;
+
+        try {
+          const user = await verifyCredentials(email, password);
+          return {
+            id: user.userId,
+            email: user.email,
+            role: user.role,
+            mustResetPassword: user.mustResetPassword,
+          };
+        } catch (err) {
+          if (err instanceof InvalidCredentialsError) return null;
+          throw err;
+        }
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.userId = user.id;
+        token.role = user.role;
+        token.mustResetPassword = user.mustResetPassword;
+        token.email = user.email;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token.userId) session.user.id = token.userId;
+      if (token.role) session.user.role = token.role;
+      session.user.mustResetPassword = token.mustResetPassword ?? false;
+      return session;
+    },
+  },
+});

--- a/auth.ts
+++ b/auth.ts
@@ -6,9 +6,10 @@ import {
   InvalidCredentialsError,
   RateLimitedError,
   verifyCredentials,
+  type Role,
 } from "@/lib/auth/verify-credentials";
 
-type AppRole = "super_admin" | "admin" | "member";
+type AppRole = Role;
 
 declare module "next-auth" {
   interface Session {

--- a/auth.ts
+++ b/auth.ts
@@ -1,7 +1,9 @@
-import NextAuth, { type DefaultSession } from "next-auth";
+import NextAuth, { CredentialsSignin, type DefaultSession } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import {
+  CredentialFieldError,
   InvalidCredentialsError,
+  RateLimitedError,
   verifyCredentials,
 } from "@/lib/auth/verify-credentials";
 
@@ -31,6 +33,18 @@ declare module "@auth/core/jwt" {
   }
 }
 
+class InvalidCredentialsSignin extends CredentialsSignin {
+  code = "invalid_credentials";
+}
+
+class RateLimitedSignin extends CredentialsSignin {
+  code = "rate_limited";
+}
+
+class FieldValidationSignin extends CredentialsSignin {
+  code = "field_validation";
+}
+
 export const { auth, handlers, signIn, signOut } = NextAuth({
   session: { strategy: "jwt" },
   pages: { signIn: "/signin" },
@@ -43,7 +57,9 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       async authorize(raw) {
         const email = typeof raw?.email === "string" ? raw.email : "";
         const password = typeof raw?.password === "string" ? raw.password : "";
-        if (!email || !password) return null;
+        if (!email || !password) {
+          throw new InvalidCredentialsSignin();
+        }
 
         try {
           const user = await verifyCredentials(email, password);
@@ -54,7 +70,15 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
             mustResetPassword: user.mustResetPassword,
           };
         } catch (err) {
-          if (err instanceof InvalidCredentialsError) return null;
+          if (err instanceof InvalidCredentialsError) {
+            throw new InvalidCredentialsSignin();
+          }
+          if (err instanceof RateLimitedError) {
+            throw new RateLimitedSignin();
+          }
+          if (err instanceof CredentialFieldError) {
+            throw new FieldValidationSignin();
+          }
           throw err;
         }
       },
@@ -71,8 +95,8 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       return token;
     },
     async session({ session, token }) {
-      if (token.userId) session.user.id = token.userId;
-      if (token.role) session.user.role = token.role;
+      session.user.id = token.userId ?? "";
+      session.user.role = token.role ?? "member";
       session.user.mustResetPassword = token.mustResetPassword ?? false;
       return session;
     },

--- a/lib/auth/hmac.ts
+++ b/lib/auth/hmac.ts
@@ -1,0 +1,27 @@
+import { createHmac } from "node:crypto";
+
+const MIN_SECRET_BYTES = 32;
+
+export type SignedHeaders = {
+  signature: string;
+  timestamp: string;
+};
+
+export function signBackendRequest(
+  body: string,
+  secret: string,
+  now: () => number = Date.now,
+): SignedHeaders {
+  if (Buffer.byteLength(secret, "utf8") < MIN_SECRET_BYTES) {
+    throw new Error(
+      `NEXTAUTH_BACKEND_SECRET must be at least ${MIN_SECRET_BYTES} bytes`,
+    );
+  }
+
+  const timestamp = Math.floor(now() / 1000).toString();
+  const digest = createHmac("sha256", secret)
+    .update(`${timestamp}.${body}`, "utf8")
+    .digest("hex");
+
+  return { signature: `sha256=${digest}`, timestamp };
+}

--- a/lib/auth/safe-callback-url.ts
+++ b/lib/auth/safe-callback-url.ts
@@ -1,0 +1,5 @@
+export function safeCallbackUrl(raw: string | null): string {
+  if (!raw) return "/";
+  if (raw.startsWith("/") && !raw.startsWith("//")) return raw;
+  return "/";
+}

--- a/lib/auth/verify-credentials.ts
+++ b/lib/auth/verify-credentials.ts
@@ -1,19 +1,17 @@
-import { getBackendHmacSecret } from "@/lib/config";
+import { getBackendHmacSecret, getBackendUrl } from "@/lib/config";
+import { FETCH_TIMEOUT_MS } from "@/lib/http";
 import { signBackendRequest } from "@/lib/auth/hmac";
+
+const EMAIL_MAX = 320;
+const PASSWORD_MAX = 1024;
+const ROLES = ["super_admin", "admin", "member"] as const;
 
 export type VerifiedUser = {
   userId: string;
   email: string;
-  role: "super_admin" | "admin" | "member";
+  role: (typeof ROLES)[number];
   mustResetPassword: boolean;
 };
-
-export class RateLimitedError extends Error {
-  constructor(public readonly retryAfterSecs: number | null) {
-    super("rate limited");
-    this.name = "RateLimitedError";
-  }
-}
 
 export class InvalidCredentialsError extends Error {
   constructor() {
@@ -22,19 +20,59 @@ export class InvalidCredentialsError extends Error {
   }
 }
 
+export class RateLimitedError extends Error {
+  constructor(public readonly retryAfterSecs: number | null) {
+    super("rate limited");
+    this.name = "RateLimitedError";
+  }
+}
+
+export class CredentialFieldError extends Error {
+  constructor(public readonly backendMessage: string) {
+    super(backendMessage);
+    this.name = "CredentialFieldError";
+  }
+}
+
+export class BackendError extends Error {
+  constructor(public readonly status: number) {
+    super(`verify-credentials failed: ${status}`);
+    this.name = "BackendError";
+  }
+}
+
+function isVerifiedUser(value: unknown): value is VerifiedUser {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.userId === "string" &&
+    v.userId.length > 0 &&
+    typeof v.email === "string" &&
+    typeof v.role === "string" &&
+    (ROLES as readonly string[]).includes(v.role) &&
+    typeof v.mustResetPassword === "boolean"
+  );
+}
+
 export async function verifyCredentials(
   email: string,
   password: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<VerifiedUser> {
+  if (email.length > EMAIL_MAX) {
+    throw new CredentialFieldError("email too long");
+  }
+  if (password.length > PASSWORD_MAX) {
+    throw new CredentialFieldError("password too long");
+  }
+
   const body = JSON.stringify({ email, password });
   const { signature, timestamp } = signBackendRequest(
     body,
     getBackendHmacSecret(),
   );
 
-  const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8080";
-  const res = await fetchImpl(`${backendUrl}/api/auth/verify-credentials`, {
+  const res = await fetchImpl(`${getBackendUrl()}/api/auth/verify-credentials`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -42,10 +80,22 @@ export async function verifyCredentials(
       "X-Signature": signature,
     },
     body,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 
   if (res.status === 200) {
-    return (await res.json()) as VerifiedUser;
+    const payload = (await res.json()) as unknown;
+    if (!isVerifiedUser(payload)) {
+      throw new BackendError(200);
+    }
+    return payload;
+  }
+
+  if (res.status === 400) {
+    const payload = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new CredentialFieldError(payload?.error ?? "invalid request");
   }
 
   if (res.status === 401) {
@@ -58,5 +108,5 @@ export async function verifyCredentials(
     throw new RateLimitedError(Number.isFinite(parsed) ? parsed : null);
   }
 
-  throw new Error(`verify-credentials failed: ${res.status}`);
+  throw new BackendError(res.status);
 }

--- a/lib/auth/verify-credentials.ts
+++ b/lib/auth/verify-credentials.ts
@@ -1,0 +1,62 @@
+import { getBackendHmacSecret } from "@/lib/config";
+import { signBackendRequest } from "@/lib/auth/hmac";
+
+export type VerifiedUser = {
+  userId: string;
+  email: string;
+  role: "super_admin" | "admin" | "member";
+  mustResetPassword: boolean;
+};
+
+export class RateLimitedError extends Error {
+  constructor(public readonly retryAfterSecs: number | null) {
+    super("rate limited");
+    this.name = "RateLimitedError";
+  }
+}
+
+export class InvalidCredentialsError extends Error {
+  constructor() {
+    super("invalid credentials");
+    this.name = "InvalidCredentialsError";
+  }
+}
+
+export async function verifyCredentials(
+  email: string,
+  password: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<VerifiedUser> {
+  const body = JSON.stringify({ email, password });
+  const { signature, timestamp } = signBackendRequest(
+    body,
+    getBackendHmacSecret(),
+  );
+
+  const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8080";
+  const res = await fetchImpl(`${backendUrl}/api/auth/verify-credentials`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Timestamp": timestamp,
+      "X-Signature": signature,
+    },
+    body,
+  });
+
+  if (res.status === 200) {
+    return (await res.json()) as VerifiedUser;
+  }
+
+  if (res.status === 401) {
+    throw new InvalidCredentialsError();
+  }
+
+  if (res.status === 429) {
+    const retryAfter = res.headers.get("retry-after");
+    const parsed = retryAfter ? Number.parseInt(retryAfter, 10) : Number.NaN;
+    throw new RateLimitedError(Number.isFinite(parsed) ? parsed : null);
+  }
+
+  throw new Error(`verify-credentials failed: ${res.status}`);
+}

--- a/lib/auth/verify-credentials.ts
+++ b/lib/auth/verify-credentials.ts
@@ -4,12 +4,13 @@ import { signBackendRequest } from "@/lib/auth/hmac";
 
 const EMAIL_MAX = 320;
 const PASSWORD_MAX = 1024;
-const ROLES = ["super_admin", "admin", "member"] as const;
+export const ROLES = ["super_admin", "admin", "member"] as const;
+export type Role = (typeof ROLES)[number];
 
 export type VerifiedUser = {
   userId: string;
   email: string;
-  role: (typeof ROLES)[number];
+  role: Role;
   mustResetPassword: boolean;
 };
 
@@ -48,6 +49,7 @@ function isVerifiedUser(value: unknown): value is VerifiedUser {
     typeof v.userId === "string" &&
     v.userId.length > 0 &&
     typeof v.email === "string" &&
+    v.email.length > 0 &&
     typeof v.role === "string" &&
     (ROLES as readonly string[]).includes(v.role) &&
     typeof v.mustResetPassword === "boolean"

--- a/lib/auth/verify-credentials.ts
+++ b/lib/auth/verify-credentials.ts
@@ -1,5 +1,5 @@
 import { getBackendHmacSecret, getBackendUrl } from "@/lib/config";
-import { FETCH_TIMEOUT_MS } from "@/lib/http";
+import { MUTATION_TIMEOUT_MS } from "@/lib/http";
 import { signBackendRequest } from "@/lib/auth/hmac";
 
 const EMAIL_MAX = 320;
@@ -80,11 +80,16 @@ export async function verifyCredentials(
       "X-Signature": signature,
     },
     body,
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    signal: AbortSignal.timeout(MUTATION_TIMEOUT_MS),
   });
 
   if (res.status === 200) {
-    const payload = (await res.json()) as unknown;
+    let payload: unknown;
+    try {
+      payload = await res.json();
+    } catch {
+      throw new BackendError(200);
+    }
     if (!isVerifiedUser(payload)) {
       throw new BackendError(200);
     }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -2,6 +2,10 @@ export const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 export const ADMIN_TOKEN = process.env.ADMIN_TOKEN ?? '';
 
+export function getBackendUrl(): string {
+  return process.env.BACKEND_URL ?? 'http://localhost:8080';
+}
+
 export function getBackendHmacSecret(): string {
   const secret = process.env.NEXTAUTH_BACKEND_SECRET;
   if (!secret) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,2 +1,11 @@
 export const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080';
+
 export const ADMIN_TOKEN = process.env.ADMIN_TOKEN ?? '';
+
+export function getBackendHmacSecret(): string {
+  const secret = process.env.NEXTAUTH_BACKEND_SECRET;
+  if (!secret) {
+    throw new Error('NEXTAUTH_BACKEND_SECRET is not set');
+  }
+  return secret;
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lucide-react": "^0.577.0",
     "motion": "^12.38.0",
     "next": "16.1.6",
+    "next-auth": "5.0.0-beta.31",
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/tests/unit/hmac.test.ts
+++ b/tests/unit/hmac.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { signBackendRequest } from "@/lib/auth/hmac";
+
+const SECRET = "x".repeat(32);
+const BODY = '{"email":"a@b.c","password":"pw"}';
+const FIXED_MS = 1_700_000_000_000;
+
+describe("signBackendRequest", () => {
+  it("produces the documented known vector", () => {
+    const { signature, timestamp } = signBackendRequest(
+      BODY,
+      SECRET,
+      () => FIXED_MS,
+    );
+
+    expect(timestamp).toBe("1700000000");
+    expect(signature).toBe(
+      "sha256=b586f572f2e1f8972f0f81d4e4ec979516b22dea04255ef208b121d90b7927fa",
+    );
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const a = signBackendRequest(BODY, SECRET, () => FIXED_MS);
+    const b = signBackendRequest(BODY, SECRET, () => FIXED_MS);
+    expect(a).toEqual(b);
+  });
+
+  it("changes signature when body differs by one byte", () => {
+    const a = signBackendRequest(BODY, SECRET, () => FIXED_MS);
+    const b = signBackendRequest(`${BODY} `, SECRET, () => FIXED_MS);
+    expect(a.signature).not.toBe(b.signature);
+  });
+
+  it("rejects secrets shorter than 32 bytes", () => {
+    expect(() => signBackendRequest(BODY, "x".repeat(31))).toThrow(
+      /at least 32 bytes/,
+    );
+  });
+
+  it("floors fractional milliseconds to whole seconds", () => {
+    const { timestamp } = signBackendRequest(
+      BODY,
+      SECRET,
+      () => 1_700_000_000_999,
+    );
+    expect(timestamp).toBe("1700000000");
+  });
+});

--- a/tests/unit/safe-callback-url.test.ts
+++ b/tests/unit/safe-callback-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { safeCallbackUrl } from "@/app/signin/signin-form";
+import { safeCallbackUrl } from "@/lib/auth/safe-callback-url";
 
 describe("safeCallbackUrl", () => {
   it("returns root when input is null", () => {

--- a/tests/unit/safe-callback-url.test.ts
+++ b/tests/unit/safe-callback-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { safeCallbackUrl } from "@/app/signin/signin-form";
+
+describe("safeCallbackUrl", () => {
+  it("returns root when input is null", () => {
+    expect(safeCallbackUrl(null)).toBe("/");
+  });
+
+  it("allows internal absolute paths", () => {
+    expect(safeCallbackUrl("/admin")).toBe("/admin");
+    expect(safeCallbackUrl("/admin/groups?page=2")).toBe("/admin/groups?page=2");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(safeCallbackUrl("//evil.com")).toBe("/");
+    expect(safeCallbackUrl("//evil.com/steal")).toBe("/");
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(safeCallbackUrl("https://evil.com")).toBe("/");
+    expect(safeCallbackUrl("http://evil.com")).toBe("/");
+  });
+
+  it("rejects javascript: URIs", () => {
+    expect(safeCallbackUrl("javascript:alert(1)")).toBe("/");
+  });
+
+  it("rejects relative paths without leading slash", () => {
+    expect(safeCallbackUrl("admin")).toBe("/");
+  });
+});

--- a/tests/unit/verify-credentials.test.ts
+++ b/tests/unit/verify-credentials.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BackendError,
+  CredentialFieldError,
   InvalidCredentialsError,
   RateLimitedError,
   verifyCredentials,
@@ -42,10 +44,43 @@ describe("verifyCredentials", () => {
     expect(result).toEqual(user);
   });
 
+  it("throws BackendError when 200 body has unknown role", async () => {
+    const fetchImpl = mockFetch({
+      status: 200,
+      json: async () => ({
+        userId: "abcd",
+        email: "a@b.c",
+        role: "root",
+        mustResetPassword: false,
+      }),
+    });
+    await expect(verifyCredentials("a@b.c", "pw", fetchImpl)).rejects.toBeInstanceOf(
+      BackendError,
+    );
+  });
+
+  it("throws BackendError when 200 body is missing fields", async () => {
+    const fetchImpl = mockFetch({
+      status: 200,
+      json: async () => ({ userId: "abcd" }),
+    });
+    await expect(verifyCredentials("a@b.c", "pw", fetchImpl)).rejects.toBeInstanceOf(
+      BackendError,
+    );
+  });
+
   it("signs the request with the documented headers", async () => {
     const fetchImpl = vi.fn(
       async () =>
-        ({ status: 200, json: async () => ({}) }) as Response,
+        ({
+          status: 200,
+          json: async () => ({
+            userId: "abcd",
+            email: "admin@example.com",
+            role: "super_admin",
+            mustResetPassword: false,
+          }),
+        }) as Response,
     ) as unknown as typeof fetch;
 
     await verifyCredentials("admin@example.com", "pw", fetchImpl);
@@ -62,6 +97,41 @@ describe("verifyCredentials", () => {
     expect(init.body).toBe(
       JSON.stringify({ email: "admin@example.com", password: "pw" }),
     );
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("throws CredentialFieldError with the backend message on 400", async () => {
+    const fetchImpl = mockFetch({
+      status: 400,
+      json: async () => ({ error: "email too long" }),
+    });
+    try {
+      await verifyCredentials("a@b.c", "pw", fetchImpl);
+      expect.fail("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CredentialFieldError);
+      expect((err as CredentialFieldError).backendMessage).toBe("email too long");
+    }
+  });
+
+  it("pre-checks email cap without calling the backend", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    await expect(
+      verifyCredentials("a".repeat(321), "pw", fetchImpl),
+    ).rejects.toBeInstanceOf(CredentialFieldError);
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ).toHaveLength(0);
+  });
+
+  it("pre-checks password cap without calling the backend", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    await expect(
+      verifyCredentials("a@b.c", "p".repeat(1025), fetchImpl),
+    ).rejects.toBeInstanceOf(CredentialFieldError);
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ).toHaveLength(0);
   });
 
   it("throws InvalidCredentialsError on 401", async () => {
@@ -104,10 +174,10 @@ describe("verifyCredentials", () => {
     }
   });
 
-  it("throws a generic error on unexpected status", async () => {
+  it("throws BackendError on unexpected status", async () => {
     const fetchImpl = mockFetch({ status: 500 });
     await expect(
       verifyCredentials("a@b.c", "pw", fetchImpl),
-    ).rejects.toThrow(/500/);
+    ).rejects.toBeInstanceOf(BackendError);
   });
 });

--- a/tests/unit/verify-credentials.test.ts
+++ b/tests/unit/verify-credentials.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  InvalidCredentialsError,
+  RateLimitedError,
+  verifyCredentials,
+} from "@/lib/auth/verify-credentials";
+
+const SECRET = "x".repeat(32);
+
+beforeEach(() => {
+  process.env.NEXTAUTH_BACKEND_SECRET = SECRET;
+  process.env.BACKEND_URL = "http://backend.test";
+});
+
+afterEach(() => {
+  delete process.env.NEXTAUTH_BACKEND_SECRET;
+  delete process.env.BACKEND_URL;
+});
+
+function mockFetch(response: Partial<Response>): typeof fetch {
+  return vi.fn(async () => response as Response) as unknown as typeof fetch;
+}
+
+describe("verifyCredentials", () => {
+  it("returns the user row on 200", async () => {
+    const user = {
+      userId: "abcd",
+      email: "admin@example.com",
+      role: "super_admin" as const,
+      mustResetPassword: false,
+    };
+    const fetchImpl = mockFetch({
+      status: 200,
+      json: async () => user,
+    });
+
+    const result = await verifyCredentials(
+      "admin@example.com",
+      "pw",
+      fetchImpl,
+    );
+    expect(result).toEqual(user);
+  });
+
+  it("signs the request with the documented headers", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({ status: 200, json: async () => ({}) }) as Response,
+    ) as unknown as typeof fetch;
+
+    await verifyCredentials("admin@example.com", "pw", fetchImpl);
+
+    const call = (fetchImpl as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0];
+    const [url, init] = call as [string, RequestInit];
+    expect(url).toBe("http://backend.test/api/auth/verify-credentials");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["X-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+    expect(headers["X-Timestamp"]).toMatch(/^\d+$/);
+    expect(init.body).toBe(
+      JSON.stringify({ email: "admin@example.com", password: "pw" }),
+    );
+  });
+
+  it("throws InvalidCredentialsError on 401", async () => {
+    const fetchImpl = mockFetch({
+      status: 401,
+      json: async () => ({ error: "unauthorized" }),
+    });
+    await expect(verifyCredentials("a@b.c", "pw", fetchImpl)).rejects.toBeInstanceOf(
+      InvalidCredentialsError,
+    );
+  });
+
+  it("throws RateLimitedError with Retry-After on 429", async () => {
+    const fetchImpl = mockFetch({
+      status: 429,
+      headers: new Headers({ "Retry-After": "42" }),
+      json: async () => ({ error: "too many requests" }),
+    });
+
+    try {
+      await verifyCredentials("a@b.c", "pw", fetchImpl);
+      expect.fail("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RateLimitedError);
+      expect((err as RateLimitedError).retryAfterSecs).toBe(42);
+    }
+  });
+
+  it("surfaces null retryAfter when header is missing or non-numeric", async () => {
+    const fetchImpl = mockFetch({
+      status: 429,
+      headers: new Headers(),
+      json: async () => ({}),
+    });
+    try {
+      await verifyCredentials("a@b.c", "pw", fetchImpl);
+      expect.fail("expected throw");
+    } catch (err) {
+      expect((err as RateLimitedError).retryAfterSecs).toBeNull();
+    }
+  });
+
+  it("throws a generic error on unexpected status", async () => {
+    const fetchImpl = mockFetch({ status: 500 });
+    await expect(
+      verifyCredentials("a@b.c", "pw", fetchImpl),
+    ).rejects.toThrow(/500/);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,17 @@
     package-manager-detector "^1.3.0"
     tinyexec "^1.0.1"
 
+"@auth/core@0.41.2":
+  version "0.41.2"
+  resolved "https://registry.yarnpkg.com/@auth/core/-/core-0.41.2.tgz#c03f14426bcd6e06c1ba4f767e46914a23f4d376"
+  integrity sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==
+  dependencies:
+    "@panva/hkdf" "^1.2.1"
+    jose "^6.0.6"
+    oauth4webapi "^3.3.0"
+    preact "10.24.3"
+    preact-render-to-string "6.5.11"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz"
@@ -842,6 +853,11 @@
   version "0.122.0"
   resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.122.0.tgz#2f4e77a3b183c87b2a326affd703ef71ba836601"
   integrity sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==
+
+"@panva/hkdf@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@panva/hkdf/-/hkdf-1.2.1.tgz#cb0d111ef700136f4580349ff0226bf25c853f23"
+  integrity sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==
 
 "@playwright/test@^1.58.2":
   version "1.58.2"
@@ -3734,6 +3750,11 @@ jiti@^2.6.1:
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
 
+jose@^6.0.6:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.2.tgz#d6b5279b89b3e88d531c202e3fbe351f39a44aac"
+  integrity sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==
+
 jose@^6.1.3:
   version "6.2.1"
   resolved "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz"
@@ -4211,6 +4232,13 @@ negotiator@^1.0.0:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
+next-auth@5.0.0-beta.31:
+  version "5.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-5.0.0-beta.31.tgz#c6ba3ec92e4b3cc4de87ed4bac3d71a272291ae7"
+  integrity sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==
+  dependencies:
+    "@auth/core" "0.41.2"
+
 next-themes@^0.4.6:
   version "0.4.6"
   resolved "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz"
@@ -4281,6 +4309,11 @@ npm-run-path@^6.0.0:
   dependencies:
     path-key "^4.0.0"
     unicorn-magic "^0.3.0"
+
+oauth4webapi@^3.3.0:
+  version "3.8.5"
+  resolved "https://registry.yarnpkg.com/oauth4webapi/-/oauth4webapi-3.8.5.tgz#4aa8a73f5c4644daf674a7c40497be910db99d3f"
+  integrity sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==
 
 object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"
@@ -4599,6 +4632,16 @@ powershell-utils@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz"
   integrity sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==
+
+preact-render-to-string@6.5.11:
+  version "6.5.11"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz#467e69908a453497bb93d4d1fc35fb749a78e027"
+  integrity sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==
+
+preact@10.24.3:
+  version "10.24.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.24.3.tgz#086386bd47071e3b45410ef20844c21e23828f64"
+  integrity sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Summary

- Installs `next-auth@5.0.0-beta.31` and wires a Credentials provider whose `authorize()` POSTs to `poolpay-api`'s HMAC-gated `/api/auth/verify-credentials`.
- Adds `lib/auth/hmac.ts` implementing the documented signing recipe (`HMAC-SHA256(secret, timestamp + "." + body)` → `X-Signature: sha256=<hex>` + `X-Timestamp`) with a 32-byte secret minimum.
- Adds `lib/auth/verify-credentials.ts` with typed error surface (`InvalidCredentialsError`, `RateLimitedError` carrying `Retry-After`) and a mocked-fetch integration test covering 200 / 401 / 429 / 500 + signed-header assertion.
- Scaffolds `auth.ts` (JWT session strategy), `/api/auth/[...nextauth]` route, and a minimal `/signin` form page. Session callback exposes `{ id, email, role, mustResetPassword }`.
- Documents `NEXTAUTH_BACKEND_SECRET`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL` in `.env.example` and README; marks `ADMIN_TOKEN` as deprecated (backend removed it in BE-6).

Spec source of truth: `wiki/poolpay/architecture/auth-api-contract.md` in the Digital Brain vault.

## Out of scope (deferred to FE-2..FE-7)

- Access/refresh token minting, silent refresh rotation, social providers, logout family-revocation wiring, change-password page, admin-dashboard route guards.

## Test plan

- [x] `yarn test` — 98 unit tests pass (HMAC known-vector, deterministic round-trip, 32-byte secret enforcement; verify-credentials 200/401/429/500 + signed-header shape).
- [x] `yarn build` — clean; `/signin` and `/api/auth/[...nextauth]` registered.
- [x] `tsc --noEmit` — no new errors (pre-existing `.next/types/validator.ts` errors exist on `main`, unrelated).
- [ ] Manual: spin up `poolpay-api` with a seeded super_admin, visit `/signin`, log in, verify session cookie populates `{ id, email, role, mustResetPassword }`.
- [ ] Manual: trigger 401 (wrong password) — form shows "Invalid email or password".
- [ ] Manual: exceed composite `(ip, email)` limiter — confirm 429 path doesn't crash (surfaced as generic error in FE-1; UX polish in FE-6).