### PR TITLE
[FEAT] FE-2 — Token issue + silent refresh + Retry-After (issue #21)

### DIFF
--- a/app/signin/actions.ts
+++ b/app/signin/actions.ts
@@ -15,6 +15,7 @@ import {
   issueTokens,
 } from "@/lib/auth/issue";
 import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
+import { signPostAuthNonce } from "@/lib/auth/post-auth-nonce";
 import { safeCallbackUrl } from "@/lib/auth/safe-callback-url";
 
 export type SignInCode =
@@ -81,6 +82,14 @@ export async function signInAction(
     return { ok: false, code: "backend_unavailable" };
   }
 
+  const accessTokenExpiresAt = String(accessExp);
+  const { nonce, issuedAt } = signPostAuthNonce({
+    userId: user.userId,
+    accessToken: pair.accessToken,
+    refreshToken: pair.refreshToken,
+    accessTokenExpiresAt,
+  });
+
   try {
     await signIn("credentials-post-auth", {
       userId: user.userId,
@@ -89,7 +98,9 @@ export async function signInAction(
       mustResetPassword: String(user.mustResetPassword),
       accessToken: pair.accessToken,
       refreshToken: pair.refreshToken,
-      accessTokenExpiresAt: String(accessExp),
+      accessTokenExpiresAt,
+      postAuthNonce: nonce,
+      postAuthIssuedAt: issuedAt,
       redirect: false,
     });
   } catch {

--- a/app/signin/actions.ts
+++ b/app/signin/actions.ts
@@ -83,8 +83,12 @@ export async function signInAction(
   }
 
   const accessTokenExpiresAt = String(accessExp);
+  const mustResetPassword = String(user.mustResetPassword);
   const { nonce, issuedAt } = signPostAuthNonce({
     userId: user.userId,
+    email: user.email,
+    role: user.role,
+    mustResetPassword,
     accessToken: pair.accessToken,
     refreshToken: pair.refreshToken,
     accessTokenExpiresAt,
@@ -95,7 +99,7 @@ export async function signInAction(
       userId: user.userId,
       email: user.email,
       role: user.role,
-      mustResetPassword: String(user.mustResetPassword),
+      mustResetPassword,
       accessToken: pair.accessToken,
       refreshToken: pair.refreshToken,
       accessTokenExpiresAt,

--- a/app/signin/actions.ts
+++ b/app/signin/actions.ts
@@ -1,0 +1,100 @@
+"use server";
+
+import { signIn } from "@/auth";
+import {
+  BackendError,
+  CredentialFieldError,
+  InvalidCredentialsError,
+  RateLimitedError,
+  verifyCredentials,
+} from "@/lib/auth/verify-credentials";
+import {
+  IssueBackendError,
+  IssueFailedError,
+  IssueValidationError,
+  issueTokens,
+} from "@/lib/auth/issue";
+import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
+import { safeCallbackUrl } from "@/lib/auth/safe-callback-url";
+
+export type SignInCode =
+  | "invalid_credentials"
+  | "rate_limited"
+  | "field_validation"
+  | "backend_unavailable"
+  | "post_auth_failed";
+
+export type SignInResult =
+  | { ok: true; redirectTo: string }
+  | { ok: false; code: SignInCode; retryAfterSecs?: number };
+
+export async function signInAction(
+  input: { email: string; password: string; callbackUrl: string | null },
+): Promise<SignInResult> {
+  const email = typeof input.email === "string" ? input.email : "";
+  const password = typeof input.password === "string" ? input.password : "";
+  if (!email || !password) {
+    return { ok: false, code: "invalid_credentials" };
+  }
+
+  let user;
+  try {
+    user = await verifyCredentials(email, password);
+  } catch (err) {
+    if (err instanceof InvalidCredentialsError) {
+      return { ok: false, code: "invalid_credentials" };
+    }
+    if (err instanceof RateLimitedError) {
+      return {
+        ok: false,
+        code: "rate_limited",
+        retryAfterSecs: err.retryAfterSecs ?? undefined,
+      };
+    }
+    if (err instanceof CredentialFieldError) {
+      return { ok: false, code: "field_validation" };
+    }
+    if (err instanceof BackendError) {
+      return { ok: false, code: "backend_unavailable" };
+    }
+    return { ok: false, code: "backend_unavailable" };
+  }
+
+  let pair;
+  try {
+    pair = await issueTokens(user.userId);
+  } catch (err) {
+    if (err instanceof IssueFailedError) {
+      return { ok: false, code: "backend_unavailable" };
+    }
+    if (err instanceof IssueValidationError) {
+      return { ok: false, code: "backend_unavailable" };
+    }
+    if (err instanceof IssueBackendError) {
+      return { ok: false, code: "backend_unavailable" };
+    }
+    return { ok: false, code: "backend_unavailable" };
+  }
+
+  const accessExp = readJwtExpSecs(pair.accessToken);
+  if (!accessExp) {
+    return { ok: false, code: "backend_unavailable" };
+  }
+
+  try {
+    await signIn("credentials-post-auth", {
+      userId: user.userId,
+      email: user.email,
+      role: user.role,
+      mustResetPassword: String(user.mustResetPassword),
+      accessToken: pair.accessToken,
+      refreshToken: pair.refreshToken,
+      accessTokenExpiresAt: String(accessExp),
+      redirect: false,
+    });
+  } catch {
+    return { ok: false, code: "post_auth_failed" };
+  }
+
+  return { ok: true, redirectTo: safeCallbackUrl(input.callbackUrl) };
+}

--- a/app/signin/signin-form.tsx
+++ b/app/signin/signin-form.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
-import { signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { safeCallbackUrl } from "@/lib/auth/safe-callback-url";
+import { signInAction, type SignInCode } from "@/app/signin/actions";
 
-function messageForCode(code: string | undefined): string {
+function messageForCode(
+  code: SignInCode | undefined,
+  retryAfterSecs: number | undefined,
+): string {
   switch (code) {
     case "rate_limited":
-      return "Too many attempts. Please wait before trying again.";
+      return typeof retryAfterSecs === "number"
+        ? `Too many attempts. Try again in ${retryAfterSecs} seconds.`
+        : "Too many attempts. Please wait before trying again.";
     case "field_validation":
       return "Email or password is too long.";
     case "backend_unavailable":
+    case "post_auth_failed":
       return "Sign-in is temporarily unavailable. Please try again in a few minutes.";
     default:
       return "Invalid email or password.";
@@ -21,7 +26,7 @@ function messageForCode(code: string | undefined): string {
 export function SignInForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
+  const callbackUrl = searchParams.get("callbackUrl");
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -34,21 +39,17 @@ export function SignInForm() {
     setError(null);
 
     try {
-      const result = await signIn("credentials", {
-        email,
-        password,
-        redirect: false,
-      });
+      const result = await signInAction({ email, password, callbackUrl });
 
-      if (!result || result.error) {
-        setError(messageForCode(result?.code));
+      if (!result.ok) {
+        setError(messageForCode(result.code, result.retryAfterSecs));
         return;
       }
 
-      router.push(callbackUrl);
+      router.push(result.redirectTo);
       router.refresh();
     } catch {
-      setError(messageForCode("backend_unavailable"));
+      setError(messageForCode("backend_unavailable", undefined));
     } finally {
       setSubmitting(false);
     }

--- a/auth.ts
+++ b/auth.ts
@@ -9,7 +9,7 @@ import { refreshTokens } from "@/lib/auth/refresh";
 
 type AppRole = Role;
 
-const REFRESH_SKEW_SECS = 30;
+const REFRESH_SKEW_SECS = 360;
 
 declare module "next-auth" {
   interface Session {

--- a/auth.ts
+++ b/auth.ts
@@ -5,6 +5,7 @@ import {
   type Role,
 } from "@/lib/auth/verify-credentials";
 import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
+import { verifyPostAuthNonce } from "@/lib/auth/post-auth-nonce";
 import { refreshTokens } from "@/lib/auth/refresh";
 
 type AppRole = Role;
@@ -67,6 +68,8 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         accessToken: {},
         refreshToken: {},
         accessTokenExpiresAt: {},
+        postAuthNonce: {},
+        postAuthIssuedAt: {},
       },
       async authorize(raw) {
         const userId = typeof raw?.userId === "string" ? raw.userId : "";
@@ -76,10 +79,17 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           typeof raw?.accessToken === "string" ? raw.accessToken : "";
         const refreshToken =
           typeof raw?.refreshToken === "string" ? raw.refreshToken : "";
-        const expiresAtRaw =
+        const accessTokenExpiresAt =
           typeof raw?.accessTokenExpiresAt === "string"
-            ? Number.parseInt(raw.accessTokenExpiresAt, 10)
-            : Number.NaN;
+            ? raw.accessTokenExpiresAt
+            : "";
+        const postAuthNonce =
+          typeof raw?.postAuthNonce === "string" ? raw.postAuthNonce : "";
+        const postAuthIssuedAt =
+          typeof raw?.postAuthIssuedAt === "string" ? raw.postAuthIssuedAt : "";
+        const expiresAtRaw = accessTokenExpiresAt
+          ? Number.parseInt(accessTokenExpiresAt, 10)
+          : Number.NaN;
         const mustResetPassword = raw?.mustResetPassword === "true";
 
         if (
@@ -88,8 +98,22 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           !role ||
           !accessToken ||
           !refreshToken ||
-          !Number.isFinite(expiresAtRaw)
+          !Number.isFinite(expiresAtRaw) ||
+          !postAuthNonce ||
+          !postAuthIssuedAt
         ) {
+          throw new PostAuthFailedSignin();
+        }
+
+        const nonceOk = verifyPostAuthNonce({
+          userId,
+          accessToken,
+          refreshToken,
+          accessTokenExpiresAt,
+          issuedAt: postAuthIssuedAt,
+          nonce: postAuthNonce,
+        });
+        if (!nonceOk) {
           throw new PostAuthFailedSignin();
         }
 
@@ -121,9 +145,25 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
 
       if (token.error) return token;
 
+      if (!token.refreshToken) {
+        return token;
+      }
+
       const now = Math.floor(Date.now() / 1000);
-      const expiresAt = token.accessTokenExpiresAt ?? 0;
-      if (!token.refreshToken || expiresAt - now > REFRESH_SKEW_SECS) {
+      const expiresAt = token.accessTokenExpiresAt;
+      if (
+        typeof expiresAt !== "number" ||
+        !Number.isFinite(expiresAt) ||
+        expiresAt <= 0
+      ) {
+        token.accessToken = undefined;
+        token.refreshToken = undefined;
+        token.accessTokenExpiresAt = undefined;
+        token.error = "RefreshFailedError";
+        return token;
+      }
+
+      if (expiresAt - now > REFRESH_SKEW_SECS) {
         return token;
       }
 
@@ -133,6 +173,7 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
 
         if (!refreshedAccessTokenExpiresAt) {
           token.accessToken = undefined;
+          token.refreshToken = undefined;
           token.accessTokenExpiresAt = undefined;
           token.error = "RefreshFailedError";
           return token;
@@ -143,6 +184,9 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         token.accessTokenExpiresAt = refreshedAccessTokenExpiresAt;
         return token;
       } catch {
+        token.accessToken = undefined;
+        token.refreshToken = undefined;
+        token.accessTokenExpiresAt = undefined;
         token.error = "RefreshFailedError";
         return token;
       }

--- a/auth.ts
+++ b/auth.ts
@@ -5,7 +5,7 @@ import {
   type Role,
 } from "@/lib/auth/verify-credentials";
 import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
-import { refreshTokens, RefreshFailedError } from "@/lib/auth/refresh";
+import { refreshTokens } from "@/lib/auth/refresh";
 
 type AppRole = Role;
 
@@ -129,16 +129,21 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
 
       try {
         const pair = await refreshTokens(token.refreshToken);
+        const refreshedAccessTokenExpiresAt = readJwtExpSecs(pair.accessToken);
+
+        if (!refreshedAccessTokenExpiresAt) {
+          token.accessToken = undefined;
+          token.accessTokenExpiresAt = undefined;
+          token.error = "RefreshFailedError";
+          return token;
+        }
+
         token.accessToken = pair.accessToken;
         token.refreshToken = pair.refreshToken;
-        token.accessTokenExpiresAt =
-          readJwtExpSecs(pair.accessToken) ?? now + 60;
+        token.accessTokenExpiresAt = refreshedAccessTokenExpiresAt;
         return token;
-      } catch (err) {
-        token.error =
-          err instanceof RefreshFailedError
-            ? "RefreshFailedError"
-            : "RefreshFailedError";
+      } catch {
+        token.error = "RefreshFailedError";
         return token;
       }
     },

--- a/auth.ts
+++ b/auth.ts
@@ -10,7 +10,7 @@ import { refreshTokens } from "@/lib/auth/refresh";
 
 type AppRole = Role;
 
-const REFRESH_SKEW_SECS = 360;
+const REFRESH_SKEW_SECS = 30;
 
 declare module "next-auth" {
   interface Session {
@@ -107,6 +107,9 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
 
         const nonceOk = verifyPostAuthNonce({
           userId,
+          email,
+          role,
+          mustResetPassword: mustResetPassword ? "true" : "false",
           accessToken,
           refreshToken,
           accessTokenExpiresAt,

--- a/auth.ts
+++ b/auth.ts
@@ -10,7 +10,7 @@ import { refreshTokens } from "@/lib/auth/refresh";
 
 type AppRole = Role;
 
-const REFRESH_SKEW_SECS = 30;
+const REFRESH_SKEW_SECS = 360;
 
 declare module "next-auth" {
   interface Session {

--- a/auth.ts
+++ b/auth.ts
@@ -1,15 +1,15 @@
 import NextAuth, { CredentialsSignin, type DefaultSession } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import {
-  BackendError,
-  CredentialFieldError,
-  InvalidCredentialsError,
-  RateLimitedError,
-  verifyCredentials,
+  ROLES,
   type Role,
 } from "@/lib/auth/verify-credentials";
+import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
+import { refreshTokens, RefreshFailedError } from "@/lib/auth/refresh";
 
 type AppRole = Role;
+
+const REFRESH_SKEW_SECS = 30;
 
 declare module "next-auth" {
   interface Session {
@@ -18,12 +18,16 @@ declare module "next-auth" {
       role: AppRole;
       mustResetPassword: boolean;
     } & DefaultSession["user"];
+    error?: "RefreshFailedError";
   }
 
   interface User {
     id?: string;
     role?: AppRole;
     mustResetPassword?: boolean;
+    accessToken?: string;
+    refreshToken?: string;
+    accessTokenExpiresAt?: number;
   }
 }
 
@@ -32,23 +36,21 @@ declare module "@auth/core/jwt" {
     userId?: string;
     role?: AppRole;
     mustResetPassword?: boolean;
+    accessToken?: string;
+    refreshToken?: string;
+    accessTokenExpiresAt?: number;
+    error?: "RefreshFailedError";
   }
 }
 
-class InvalidCredentialsSignin extends CredentialsSignin {
-  code = "invalid_credentials";
+class PostAuthFailedSignin extends CredentialsSignin {
+  code = "post_auth_failed";
 }
 
-class RateLimitedSignin extends CredentialsSignin {
-  code = "rate_limited";
-}
-
-class FieldValidationSignin extends CredentialsSignin {
-  code = "field_validation";
-}
-
-class BackendUnavailableSignin extends CredentialsSignin {
-  code = "backend_unavailable";
+function parseRole(raw: unknown): AppRole | null {
+  return typeof raw === "string" && (ROLES as readonly string[]).includes(raw)
+    ? (raw as AppRole)
+    : null;
 }
 
 export const { auth, handlers, signIn, signOut } = NextAuth({
@@ -56,43 +58,50 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
   pages: { signIn: "/signin" },
   providers: [
     Credentials({
+      id: "credentials-post-auth",
       credentials: {
-        email: { label: "Email", type: "email" },
-        password: { label: "Password", type: "password" },
+        userId: {},
+        email: {},
+        role: {},
+        mustResetPassword: {},
+        accessToken: {},
+        refreshToken: {},
+        accessTokenExpiresAt: {},
       },
       async authorize(raw) {
+        const userId = typeof raw?.userId === "string" ? raw.userId : "";
         const email = typeof raw?.email === "string" ? raw.email : "";
-        const password = typeof raw?.password === "string" ? raw.password : "";
-        if (!email || !password) {
-          throw new InvalidCredentialsSignin();
+        const role = parseRole(raw?.role);
+        const accessToken =
+          typeof raw?.accessToken === "string" ? raw.accessToken : "";
+        const refreshToken =
+          typeof raw?.refreshToken === "string" ? raw.refreshToken : "";
+        const expiresAtRaw =
+          typeof raw?.accessTokenExpiresAt === "string"
+            ? Number.parseInt(raw.accessTokenExpiresAt, 10)
+            : Number.NaN;
+        const mustResetPassword = raw?.mustResetPassword === "true";
+
+        if (
+          !userId ||
+          !email ||
+          !role ||
+          !accessToken ||
+          !refreshToken ||
+          !Number.isFinite(expiresAtRaw)
+        ) {
+          throw new PostAuthFailedSignin();
         }
 
-        try {
-          const user = await verifyCredentials(email, password);
-          return {
-            id: user.userId,
-            email: user.email,
-            role: user.role,
-            mustResetPassword: user.mustResetPassword,
-          };
-        } catch (err) {
-          if (err instanceof InvalidCredentialsError) {
-            throw new InvalidCredentialsSignin();
-          }
-          if (err instanceof RateLimitedError) {
-            throw new RateLimitedSignin();
-          }
-          if (err instanceof CredentialFieldError) {
-            throw new FieldValidationSignin();
-          }
-          if (err instanceof BackendError) {
-            throw new BackendUnavailableSignin();
-          }
-          if (err instanceof Error && err.name === "TimeoutError") {
-            throw new BackendUnavailableSignin();
-          }
-          throw new BackendUnavailableSignin();
-        }
+        return {
+          id: userId,
+          email,
+          role,
+          mustResetPassword,
+          accessToken,
+          refreshToken,
+          accessTokenExpiresAt: expiresAtRaw,
+        };
       },
     }),
   ],
@@ -103,8 +112,35 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         token.role = user.role;
         token.mustResetPassword = user.mustResetPassword;
         token.email = user.email;
+        token.accessToken = user.accessToken;
+        token.refreshToken = user.refreshToken;
+        token.accessTokenExpiresAt = user.accessTokenExpiresAt;
+        delete token.error;
+        return token;
       }
-      return token;
+
+      if (token.error) return token;
+
+      const now = Math.floor(Date.now() / 1000);
+      const expiresAt = token.accessTokenExpiresAt ?? 0;
+      if (!token.refreshToken || expiresAt - now > REFRESH_SKEW_SECS) {
+        return token;
+      }
+
+      try {
+        const pair = await refreshTokens(token.refreshToken);
+        token.accessToken = pair.accessToken;
+        token.refreshToken = pair.refreshToken;
+        token.accessTokenExpiresAt =
+          readJwtExpSecs(pair.accessToken) ?? now + 60;
+        return token;
+      } catch (err) {
+        token.error =
+          err instanceof RefreshFailedError
+            ? "RefreshFailedError"
+            : "RefreshFailedError";
+        return token;
+      }
     },
     async session({ session, token }) {
       if (!session.user) {
@@ -116,6 +152,7 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       if (token.email) session.user.email = token.email;
       if (token.name) session.user.name = token.name;
       if (token.picture) session.user.image = token.picture;
+      if (token.error) session.error = token.error;
       return session;
     },
   },

--- a/lib/auth/issue.ts
+++ b/lib/auth/issue.ts
@@ -1,0 +1,100 @@
+import { getBackendHmacSecret, getBackendUrl } from "@/lib/config";
+import { MUTATION_TIMEOUT_MS } from "@/lib/http";
+import { signBackendRequest } from "@/lib/auth/hmac";
+
+const USER_ID_MAX = 128;
+
+export type TokenPair = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+};
+
+export class IssueFailedError extends Error {
+  constructor() {
+    super("issue failed");
+    this.name = "IssueFailedError";
+  }
+}
+
+export class IssueValidationError extends Error {
+  constructor(public readonly backendMessage: string) {
+    super(backendMessage);
+    this.name = "IssueValidationError";
+  }
+}
+
+export class IssueBackendError extends Error {
+  constructor(public readonly status: number) {
+    super(`issue failed: ${status}`);
+    this.name = "IssueBackendError";
+  }
+}
+
+function isTokenPair(value: unknown): value is TokenPair {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.accessToken === "string" &&
+    v.accessToken.length > 0 &&
+    typeof v.refreshToken === "string" &&
+    v.refreshToken.length > 0 &&
+    typeof v.expiresAt === "string" &&
+    v.expiresAt.length > 0
+  );
+}
+
+export async function issueTokens(
+  userId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TokenPair> {
+  if (userId.length === 0) {
+    throw new IssueValidationError("userId required");
+  }
+  if (userId.length > USER_ID_MAX) {
+    throw new IssueValidationError("userId too long");
+  }
+
+  const body = JSON.stringify({ userId });
+  const { signature, timestamp } = signBackendRequest(
+    body,
+    getBackendHmacSecret(),
+  );
+
+  const res = await fetchImpl(`${getBackendUrl()}/api/auth/issue`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Timestamp": timestamp,
+      "X-Signature": signature,
+    },
+    body,
+    signal: AbortSignal.timeout(MUTATION_TIMEOUT_MS),
+  });
+
+  if (res.status === 200) {
+    let payload: unknown;
+    try {
+      payload = await res.json();
+    } catch {
+      throw new IssueBackendError(200);
+    }
+    if (!isTokenPair(payload)) {
+      throw new IssueBackendError(200);
+    }
+    return payload;
+  }
+
+  if (res.status === 400) {
+    const payload = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new IssueValidationError(payload?.error ?? "invalid request");
+  }
+
+  if (res.status === 401) {
+    throw new IssueFailedError();
+  }
+
+  throw new IssueBackendError(res.status);
+}

--- a/lib/auth/issue.ts
+++ b/lib/auth/issue.ts
@@ -61,16 +61,21 @@ export async function issueTokens(
     getBackendHmacSecret(),
   );
 
-  const res = await fetchImpl(`${getBackendUrl()}/api/auth/issue`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Timestamp": timestamp,
-      "X-Signature": signature,
-    },
-    body,
-    signal: AbortSignal.timeout(MUTATION_TIMEOUT_MS),
-  });
+  let res: Response;
+  try {
+    res = await fetchImpl(`${getBackendUrl()}/api/auth/issue`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Timestamp": timestamp,
+        "X-Signature": signature,
+      },
+      body,
+      signal: AbortSignal.timeout(MUTATION_TIMEOUT_MS),
+    });
+  } catch {
+    throw new IssueBackendError(0);
+  }
 
   if (res.status === 200) {
     let payload: unknown;

--- a/lib/auth/jwt-exp.ts
+++ b/lib/auth/jwt-exp.ts
@@ -1,0 +1,13 @@
+export function readJwtExpSecs(jwt: string): number | null {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    const json = Buffer.from(padded, "base64").toString("utf8");
+    const payload = JSON.parse(json) as { exp?: unknown };
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/auth/post-auth-nonce.ts
+++ b/lib/auth/post-auth-nonce.ts
@@ -1,0 +1,81 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Post-auth nonce prevents abuse of the `credentials-post-auth` NextAuth
+ * callback (which is publicly POSTable) by requiring a server-only HMAC over
+ * the identifying fields the server action just minted. Without the nonce a
+ * client could forge a session for an arbitrary userId/role by POSTing to
+ * `/api/auth/callback/credentials-post-auth` directly.
+ */
+
+const NONCE_TTL_SECS = 60;
+
+function getSecret(): string {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret || secret.length < 16) {
+    throw new Error("NEXTAUTH_SECRET must be set to sign post-auth nonces");
+  }
+  return secret;
+}
+
+function canonical(input: {
+  userId: string;
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: string;
+  issuedAt: string;
+}): string {
+  return [
+    input.userId,
+    input.accessToken,
+    input.refreshToken,
+    input.accessTokenExpiresAt,
+    input.issuedAt,
+  ].join("\n");
+}
+
+export type PostAuthNonce = { nonce: string; issuedAt: string };
+
+export function signPostAuthNonce(
+  input: {
+    userId: string;
+    accessToken: string;
+    refreshToken: string;
+    accessTokenExpiresAt: string;
+  },
+  now: () => number = Date.now,
+): PostAuthNonce {
+  const issuedAt = Math.floor(now() / 1000).toString();
+  const digest = createHmac("sha256", getSecret())
+    .update(canonical({ ...input, issuedAt }), "utf8")
+    .digest("hex");
+  return { nonce: digest, issuedAt };
+}
+
+export function verifyPostAuthNonce(
+  input: {
+    userId: string;
+    accessToken: string;
+    refreshToken: string;
+    accessTokenExpiresAt: string;
+    issuedAt: string;
+    nonce: string;
+  },
+  now: () => number = Date.now,
+): boolean {
+  const issuedAtSecs = Number.parseInt(input.issuedAt, 10);
+  if (!Number.isFinite(issuedAtSecs)) return false;
+
+  const nowSecs = Math.floor(now() / 1000);
+  if (nowSecs - issuedAtSecs > NONCE_TTL_SECS) return false;
+  if (issuedAtSecs - nowSecs > NONCE_TTL_SECS) return false;
+
+  const expected = createHmac("sha256", getSecret())
+    .update(canonical(input), "utf8")
+    .digest("hex");
+
+  const provided = Buffer.from(input.nonce, "hex");
+  const expectedBuf = Buffer.from(expected, "hex");
+  if (provided.length !== expectedBuf.length) return false;
+  return timingSafeEqual(provided, expectedBuf);
+}

--- a/lib/auth/post-auth-nonce.ts
+++ b/lib/auth/post-auth-nonce.ts
@@ -20,6 +20,9 @@ function getSecret(): string {
 
 function canonical(input: {
   userId: string;
+  email: string;
+  role: string;
+  mustResetPassword: string;
   accessToken: string;
   refreshToken: string;
   accessTokenExpiresAt: string;
@@ -27,6 +30,9 @@ function canonical(input: {
 }): string {
   return [
     input.userId,
+    input.email,
+    input.role,
+    input.mustResetPassword,
     input.accessToken,
     input.refreshToken,
     input.accessTokenExpiresAt,
@@ -39,6 +45,9 @@ export type PostAuthNonce = { nonce: string; issuedAt: string };
 export function signPostAuthNonce(
   input: {
     userId: string;
+    email: string;
+    role: string;
+    mustResetPassword: string;
     accessToken: string;
     refreshToken: string;
     accessTokenExpiresAt: string;
@@ -55,6 +64,9 @@ export function signPostAuthNonce(
 export function verifyPostAuthNonce(
   input: {
     userId: string;
+    email: string;
+    role: string;
+    mustResetPassword: string;
     accessToken: string;
     refreshToken: string;
     accessTokenExpiresAt: string;

--- a/lib/auth/refresh.ts
+++ b/lib/auth/refresh.ts
@@ -1,0 +1,61 @@
+import { getBackendUrl } from "@/lib/config";
+import { MUTATION_TIMEOUT_MS } from "@/lib/http";
+import type { TokenPair } from "@/lib/auth/issue";
+
+export class RefreshFailedError extends Error {
+  constructor() {
+    super("refresh failed");
+    this.name = "RefreshFailedError";
+  }
+}
+
+function isTokenPair(value: unknown): value is TokenPair {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.accessToken === "string" &&
+    v.accessToken.length > 0 &&
+    typeof v.refreshToken === "string" &&
+    v.refreshToken.length > 0 &&
+    typeof v.expiresAt === "string" &&
+    v.expiresAt.length > 0
+  );
+}
+
+export async function refreshTokens(
+  refreshToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TokenPair> {
+  if (!refreshToken) {
+    throw new RefreshFailedError();
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${getBackendUrl()}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+      signal: AbortSignal.timeout(MUTATION_TIMEOUT_MS),
+    });
+  } catch {
+    throw new RefreshFailedError();
+  }
+
+  if (res.status !== 200) {
+    throw new RefreshFailedError();
+  }
+
+  let payload: unknown;
+  try {
+    payload = await res.json();
+  } catch {
+    throw new RefreshFailedError();
+  }
+
+  if (!isTokenPair(payload)) {
+    throw new RefreshFailedError();
+  }
+
+  return payload;
+}

--- a/tests/unit/issue.test.ts
+++ b/tests/unit/issue.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  IssueBackendError,
+  IssueFailedError,
+  IssueValidationError,
+  issueTokens,
+} from "@/lib/auth/issue";
+
+const SECRET = "x".repeat(32);
+
+beforeEach(() => {
+  process.env.NEXTAUTH_BACKEND_SECRET = SECRET;
+  process.env.BACKEND_URL = "http://backend.test";
+});
+
+afterEach(() => {
+  delete process.env.NEXTAUTH_BACKEND_SECRET;
+  delete process.env.BACKEND_URL;
+});
+
+function mockFetch(response: Partial<Response>): typeof fetch {
+  return vi.fn(async () => response as Response) as unknown as typeof fetch;
+}
+
+describe("issueTokens", () => {
+  it("returns the token pair on 200", async () => {
+    const pair = {
+      accessToken: "eyJ.a.b",
+      refreshToken: "opaque-refresh",
+      expiresAt: "2026-04-15T12:34:56Z",
+    };
+    const fetchImpl = mockFetch({
+      status: 200,
+      json: async () => pair,
+    });
+
+    const result = await issueTokens("abcd", fetchImpl);
+    expect(result).toEqual(pair);
+  });
+
+  it("throws IssueBackendError when 200 body is missing fields", async () => {
+    const fetchImpl = mockFetch({
+      status: 200,
+      json: async () => ({ accessToken: "a" }),
+    });
+    await expect(issueTokens("abcd", fetchImpl)).rejects.toBeInstanceOf(
+      IssueBackendError,
+    );
+  });
+
+  it("throws IssueBackendError when 200 body is not JSON", async () => {
+    const fetchImpl = mockFetch({
+      status: 200,
+      json: async () => {
+        throw new Error("not json");
+      },
+    });
+    await expect(issueTokens("abcd", fetchImpl)).rejects.toBeInstanceOf(
+      IssueBackendError,
+    );
+  });
+
+  it("signs the request with HMAC headers and posts JSON body", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          status: 200,
+          json: async () => ({
+            accessToken: "a",
+            refreshToken: "r",
+            expiresAt: "2026-04-15T00:00:00Z",
+          }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+
+    await issueTokens("abcd", fetchImpl);
+
+    const [url, init] = (
+      fetchImpl as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://backend.test/api/auth/issue");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["X-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+    expect(headers["X-Timestamp"]).toMatch(/^\d+$/);
+    expect(init.body).toBe(JSON.stringify({ userId: "abcd" }));
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("throws IssueValidationError with backend message on 400", async () => {
+    const fetchImpl = mockFetch({
+      status: 400,
+      json: async () => ({ error: "userId too long" }),
+    });
+    try {
+      await issueTokens("abcd", fetchImpl);
+      expect.fail("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(IssueValidationError);
+      expect((err as IssueValidationError).backendMessage).toBe(
+        "userId too long",
+      );
+    }
+  });
+
+  it("pre-checks empty userId without calling the backend", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    await expect(issueTokens("", fetchImpl)).rejects.toBeInstanceOf(
+      IssueValidationError,
+    );
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ).toHaveLength(0);
+  });
+
+  it("pre-checks over-cap userId without calling the backend", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    await expect(
+      issueTokens("a".repeat(129), fetchImpl),
+    ).rejects.toBeInstanceOf(IssueValidationError);
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ).toHaveLength(0);
+  });
+
+  it("throws IssueFailedError on 401", async () => {
+    const fetchImpl = mockFetch({
+      status: 401,
+      json: async () => ({ error: "unauthorized" }),
+    });
+    await expect(issueTokens("abcd", fetchImpl)).rejects.toBeInstanceOf(
+      IssueFailedError,
+    );
+  });
+
+  it("throws IssueBackendError on 500", async () => {
+    const fetchImpl = mockFetch({ status: 500 });
+    await expect(issueTokens("abcd", fetchImpl)).rejects.toBeInstanceOf(
+      IssueBackendError,
+    );
+  });
+});

--- a/tests/unit/jwt-exp.test.ts
+++ b/tests/unit/jwt-exp.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
+
+function encodeJwt(payload: object): string {
+  const head = Buffer.from('{"alg":"RS256","typ":"JWT"}').toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${head}.${body}.sig`;
+}
+
+describe("readJwtExpSecs", () => {
+  it("extracts a numeric exp claim", () => {
+    const jwt = encodeJwt({ sub: "user:abc", exp: 1700000900, iat: 1700000000 });
+    expect(readJwtExpSecs(jwt)).toBe(1700000900);
+  });
+
+  it("returns null when exp is missing", () => {
+    const jwt = encodeJwt({ sub: "user:abc" });
+    expect(readJwtExpSecs(jwt)).toBeNull();
+  });
+
+  it("returns null when exp is not a number", () => {
+    const jwt = encodeJwt({ sub: "user:abc", exp: "soon" });
+    expect(readJwtExpSecs(jwt)).toBeNull();
+  });
+
+  it("returns null when the JWT is not three parts", () => {
+    expect(readJwtExpSecs("not.a.jwt.at.all")).toBeNull();
+    expect(readJwtExpSecs("onlyone")).toBeNull();
+  });
+
+  it("returns null when the payload is not valid JSON", () => {
+    const jwt = `aGVhZA.$$.sig`;
+    expect(readJwtExpSecs(jwt)).toBeNull();
+  });
+});

--- a/tests/unit/post-auth-nonce.test.ts
+++ b/tests/unit/post-auth-nonce.test.ts
@@ -6,6 +6,9 @@ import {
 
 const payload = {
   userId: "u1",
+  email: "u1@example.com",
+  role: "super_admin",
+  mustResetPassword: "false",
   accessToken: "a.b.c",
   refreshToken: "r1",
   accessTokenExpiresAt: "1700000900",
@@ -36,6 +39,39 @@ describe("post-auth nonce", () => {
     expect(
       verifyPostAuthNonce(
         { ...payload, userId: "someone-else", nonce, issuedAt },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a tampered role", () => {
+    const now = () => 1_700_000_000_000;
+    const { nonce, issuedAt } = signPostAuthNonce(payload, now);
+    expect(
+      verifyPostAuthNonce(
+        { ...payload, role: "member", nonce, issuedAt },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a tampered email", () => {
+    const now = () => 1_700_000_000_000;
+    const { nonce, issuedAt } = signPostAuthNonce(payload, now);
+    expect(
+      verifyPostAuthNonce(
+        { ...payload, email: "evil@example.com", nonce, issuedAt },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a tampered mustResetPassword", () => {
+    const now = () => 1_700_000_000_000;
+    const { nonce, issuedAt } = signPostAuthNonce(payload, now);
+    expect(
+      verifyPostAuthNonce(
+        { ...payload, mustResetPassword: "true", nonce, issuedAt },
         now,
       ),
     ).toBe(false);

--- a/tests/unit/post-auth-nonce.test.ts
+++ b/tests/unit/post-auth-nonce.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  signPostAuthNonce,
+  verifyPostAuthNonce,
+} from "@/lib/auth/post-auth-nonce";
+
+const payload = {
+  userId: "u1",
+  accessToken: "a.b.c",
+  refreshToken: "r1",
+  accessTokenExpiresAt: "1700000900",
+};
+
+const originalSecret = process.env.NEXTAUTH_SECRET;
+
+beforeEach(() => {
+  process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
+});
+
+afterEach(() => {
+  process.env.NEXTAUTH_SECRET = originalSecret;
+});
+
+describe("post-auth nonce", () => {
+  it("signs and verifies a matching payload", () => {
+    const now = () => 1_700_000_000_000;
+    const { nonce, issuedAt } = signPostAuthNonce(payload, now);
+    expect(verifyPostAuthNonce({ ...payload, nonce, issuedAt }, now)).toBe(
+      true,
+    );
+  });
+
+  it("rejects a tampered userId", () => {
+    const now = () => 1_700_000_000_000;
+    const { nonce, issuedAt } = signPostAuthNonce(payload, now);
+    expect(
+      verifyPostAuthNonce(
+        { ...payload, userId: "someone-else", nonce, issuedAt },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a tampered accessToken", () => {
+    const now = () => 1_700_000_000_000;
+    const { nonce, issuedAt } = signPostAuthNonce(payload, now);
+    expect(
+      verifyPostAuthNonce(
+        { ...payload, accessToken: "x.y.z", nonce, issuedAt },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects an expired nonce", () => {
+    const signedAt = () => 1_700_000_000_000;
+    const { nonce, issuedAt } = signPostAuthNonce(payload, signedAt);
+    const later = () => 1_700_000_000_000 + 120_000;
+    expect(
+      verifyPostAuthNonce({ ...payload, nonce, issuedAt }, later),
+    ).toBe(false);
+  });
+
+  it("rejects a malformed nonce", () => {
+    const now = () => 1_700_000_000_000;
+    const { issuedAt } = signPostAuthNonce(payload, now);
+    expect(
+      verifyPostAuthNonce(
+        { ...payload, nonce: "not-hex", issuedAt },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("throws when NEXTAUTH_SECRET is missing", () => {
+    delete process.env.NEXTAUTH_SECRET;
+    expect(() => signPostAuthNonce(payload)).toThrow(/NEXTAUTH_SECRET/);
+  });
+});

--- a/tests/unit/refresh.test.ts
+++ b/tests/unit/refresh.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RefreshFailedError, refreshTokens } from "@/lib/auth/refresh";
+
+beforeEach(() => {
+  process.env.BACKEND_URL = "http://backend.test";
+});
+
+afterEach(() => {
+  delete process.env.BACKEND_URL;
+});
+
+function mockFetch(response: Partial<Response>): typeof fetch {
+  return vi.fn(async () => response as Response) as unknown as typeof fetch;
+}
+
+describe("refreshTokens", () => {
+  it("returns the new token pair on 200", async () => {
+    const pair = {
+      accessToken: "eyJ.new.access",
+      refreshToken: "new-opaque",
+      expiresAt: "2026-04-16T00:00:00Z",
+    };
+    const fetchImpl = mockFetch({ status: 200, json: async () => pair });
+
+    const result = await refreshTokens("old-refresh", fetchImpl);
+    expect(result).toEqual(pair);
+  });
+
+  it("posts refreshToken in JSON body without HMAC headers", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          status: 200,
+          json: async () => ({
+            accessToken: "a",
+            refreshToken: "r",
+            expiresAt: "2026-04-16T00:00:00Z",
+          }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+
+    await refreshTokens("old-refresh", fetchImpl);
+
+    const [url, init] = (
+      fetchImpl as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://backend.test/api/auth/refresh");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["X-Signature"]).toBeUndefined();
+    expect(headers["X-Timestamp"]).toBeUndefined();
+    expect(init.body).toBe(JSON.stringify({ refreshToken: "old-refresh" }));
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("throws RefreshFailedError on 401", async () => {
+    const fetchImpl = mockFetch({
+      status: 401,
+      json: async () => ({ error: "unauthorized" }),
+    });
+    await expect(refreshTokens("bad", fetchImpl)).rejects.toBeInstanceOf(
+      RefreshFailedError,
+    );
+  });
+
+  it("throws RefreshFailedError on any non-200 status", async () => {
+    const fetchImpl = mockFetch({ status: 500 });
+    await expect(refreshTokens("bad", fetchImpl)).rejects.toBeInstanceOf(
+      RefreshFailedError,
+    );
+  });
+
+  it("throws RefreshFailedError on network failure", async () => {
+    const fetchImpl = (vi.fn(async () => {
+      throw new TypeError("network");
+    }) as unknown) as typeof fetch;
+    await expect(refreshTokens("any", fetchImpl)).rejects.toBeInstanceOf(
+      RefreshFailedError,
+    );
+  });
+
+  it("throws RefreshFailedError when 200 body is malformed JSON", async () => {
+    const fetchImpl = mockFetch({
+      status: 200,
+      json: async () => {
+        throw new Error("not json");
+      },
+    });
+    await expect(refreshTokens("any", fetchImpl)).rejects.toBeInstanceOf(
+      RefreshFailedError,
+    );
+  });
+
+  it("throws RefreshFailedError when 200 body is missing fields", async () => {
+    const fetchImpl = mockFetch({
+      status: 200,
+      json: async () => ({ accessToken: "a" }),
+    });
+    await expect(refreshTokens("any", fetchImpl)).rejects.toBeInstanceOf(
+      RefreshFailedError,
+    );
+  });
+
+  it("rejects empty refresh token without calling the backend", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    await expect(refreshTokens("", fetchImpl)).rejects.toBeInstanceOf(
+      RefreshFailedError,
+    );
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ).toHaveLength(0);
+  });
+});

--- a/tests/unit/signin-action.test.ts
+++ b/tests/unit/signin-action.test.ts
@@ -42,6 +42,7 @@ function makeAccessJwt(expSecs: number): string {
 }
 
 beforeEach(() => {
+  process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
   verifyMock.mockReset();
   issueMock.mockReset();
   signInMock.mockReset();
@@ -82,6 +83,8 @@ describe("signInAction", () => {
         role: "super_admin",
         mustResetPassword: "false",
         accessTokenExpiresAt: String(exp),
+        postAuthNonce: expect.stringMatching(/^[0-9a-f]{64}$/),
+        postAuthIssuedAt: expect.stringMatching(/^\d+$/),
         redirect: false,
       }),
     );

--- a/tests/unit/signin-action.test.ts
+++ b/tests/unit/signin-action.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/auth", () => ({
+  signIn: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/auth/verify-credentials", async (orig) => {
+  const actual = await orig<typeof import("@/lib/auth/verify-credentials")>();
+  return {
+    ...actual,
+    verifyCredentials: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/auth/issue", async (orig) => {
+  const actual = await orig<typeof import("@/lib/auth/issue")>();
+  return {
+    ...actual,
+    issueTokens: vi.fn(),
+  };
+});
+
+import { signIn } from "@/auth";
+import {
+  InvalidCredentialsError,
+  RateLimitedError,
+  CredentialFieldError,
+  BackendError,
+  verifyCredentials,
+} from "@/lib/auth/verify-credentials";
+import { issueTokens, IssueFailedError } from "@/lib/auth/issue";
+import { signInAction } from "@/app/signin/actions";
+
+const verifyMock = verifyCredentials as unknown as ReturnType<typeof vi.fn>;
+const issueMock = issueTokens as unknown as ReturnType<typeof vi.fn>;
+const signInMock = signIn as unknown as ReturnType<typeof vi.fn>;
+
+function makeAccessJwt(expSecs: number): string {
+  const head = Buffer.from('{"alg":"RS256"}').toString("base64url");
+  const body = Buffer.from(JSON.stringify({ exp: expSecs })).toString("base64url");
+  return `${head}.${body}.sig`;
+}
+
+beforeEach(() => {
+  verifyMock.mockReset();
+  issueMock.mockReset();
+  signInMock.mockReset();
+  signInMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("signInAction", () => {
+  it("returns ok:true with redirect on happy path", async () => {
+    verifyMock.mockResolvedValue({
+      userId: "abcd",
+      email: "a@b.c",
+      role: "super_admin",
+      mustResetPassword: false,
+    });
+    const exp = Math.floor(Date.now() / 1000) + 900;
+    issueMock.mockResolvedValue({
+      accessToken: makeAccessJwt(exp),
+      refreshToken: "r",
+      expiresAt: "2026-04-16T00:00:00Z",
+    });
+
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: "/admin",
+    });
+
+    expect(result).toEqual({ ok: true, redirectTo: "/admin" });
+    expect(signInMock).toHaveBeenCalledWith(
+      "credentials-post-auth",
+      expect.objectContaining({
+        userId: "abcd",
+        email: "a@b.c",
+        role: "super_admin",
+        mustResetPassword: "false",
+        accessTokenExpiresAt: String(exp),
+        redirect: false,
+      }),
+    );
+  });
+
+  it("falls back to root when callbackUrl is external", async () => {
+    verifyMock.mockResolvedValue({
+      userId: "abcd",
+      email: "a@b.c",
+      role: "super_admin",
+      mustResetPassword: false,
+    });
+    const exp = Math.floor(Date.now() / 1000) + 900;
+    issueMock.mockResolvedValue({
+      accessToken: makeAccessJwt(exp),
+      refreshToken: "r",
+      expiresAt: "2026-04-16T00:00:00Z",
+    });
+
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: "https://evil.example.com/",
+    });
+
+    expect(result).toEqual({ ok: true, redirectTo: "/" });
+  });
+
+  it("returns invalid_credentials when email or password is empty", async () => {
+    const result = await signInAction({
+      email: "",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({ ok: false, code: "invalid_credentials" });
+    expect(verifyMock).not.toHaveBeenCalled();
+  });
+
+  it("maps InvalidCredentialsError → invalid_credentials", async () => {
+    verifyMock.mockRejectedValue(new InvalidCredentialsError());
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({ ok: false, code: "invalid_credentials" });
+  });
+
+  it("maps RateLimitedError and threads retryAfterSecs", async () => {
+    verifyMock.mockRejectedValue(new RateLimitedError(42));
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({
+      ok: false,
+      code: "rate_limited",
+      retryAfterSecs: 42,
+    });
+  });
+
+  it("RateLimitedError with null retry-after omits the field", async () => {
+    verifyMock.mockRejectedValue(new RateLimitedError(null));
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({ ok: false, code: "rate_limited" });
+  });
+
+  it("maps CredentialFieldError → field_validation", async () => {
+    verifyMock.mockRejectedValue(new CredentialFieldError("email too long"));
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({ ok: false, code: "field_validation" });
+  });
+
+  it("maps BackendError → backend_unavailable", async () => {
+    verifyMock.mockRejectedValue(new BackendError(500));
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({ ok: false, code: "backend_unavailable" });
+  });
+
+  it("maps IssueFailedError → backend_unavailable", async () => {
+    verifyMock.mockResolvedValue({
+      userId: "abcd",
+      email: "a@b.c",
+      role: "super_admin",
+      mustResetPassword: false,
+    });
+    issueMock.mockRejectedValue(new IssueFailedError());
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({ ok: false, code: "backend_unavailable" });
+  });
+
+  it("returns backend_unavailable when access token has no exp", async () => {
+    verifyMock.mockResolvedValue({
+      userId: "abcd",
+      email: "a@b.c",
+      role: "super_admin",
+      mustResetPassword: false,
+    });
+    issueMock.mockResolvedValue({
+      accessToken: "not.a.jwt",
+      refreshToken: "r",
+      expiresAt: "2026-04-16T00:00:00Z",
+    });
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({ ok: false, code: "backend_unavailable" });
+  });
+
+  it("returns post_auth_failed when signIn throws", async () => {
+    verifyMock.mockResolvedValue({
+      userId: "abcd",
+      email: "a@b.c",
+      role: "super_admin",
+      mustResetPassword: false,
+    });
+    const exp = Math.floor(Date.now() / 1000) + 900;
+    issueMock.mockResolvedValue({
+      accessToken: makeAccessJwt(exp),
+      refreshToken: "r",
+      expiresAt: "2026-04-16T00:00:00Z",
+    });
+    signInMock.mockRejectedValue(new Error("nextauth boom"));
+    const result = await signInAction({
+      email: "a@b.c",
+      password: "pw",
+      callbackUrl: null,
+    });
+    expect(result).toEqual({ ok: false, code: "post_auth_failed" });
+  });
+});

--- a/tests/unit/signin-action.test.ts
+++ b/tests/unit/signin-action.test.ts
@@ -41,6 +41,8 @@ function makeAccessJwt(expSecs: number): string {
   return `${head}.${body}.sig`;
 }
 
+const originalSecret = process.env.NEXTAUTH_SECRET;
+
 beforeEach(() => {
   process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
   verifyMock.mockReset();
@@ -50,6 +52,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  process.env.NEXTAUTH_SECRET = originalSecret;
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

- New typed clients `lib/auth/issue.ts` (HMAC → `POST /api/auth/issue`) and `lib/auth/refresh.ts` (`POST /api/auth/refresh`) plus `lib/auth/jwt-exp.ts` to parse `exp` from the RS256 access token.
- New server action `app/signin/actions.ts` runs `verifyCredentials → issueTokens → signIn("credentials-post-auth")` on the server and returns a discriminated union. The client sign-in form no longer depends on NextAuth's `code`-only error shape, so it can surface `retryAfterSecs` from 429s directly (issue #21). A server-only HMAC nonce (`lib/auth/post-auth-nonce.ts`, signed with `NEXTAUTH_SECRET`, 60s TTL, binds `userId` + access/refresh tokens + `accessTokenExpiresAt` + `email` + `role` + `mustResetPassword`) is attached so a direct POST to `/api/auth/callback/credentials-post-auth` cannot forge a session.
- `auth.ts` gains a second Credentials provider (`credentials-post-auth`) that verifies the nonce and writes the token triple into the NextAuth JWT, plus a `jwt` callback that silently refreshes when the access token has **≤ 360s (6 min) remaining**. The 360s window matches a proven production refresh pattern from a prior Next.js deploy — see `wiki/poolpay/architecture/jwt-ttl-fe-refresh-coupling.md` for the BE/FE coupling invariant. Refresh failures clear `accessToken`/`refreshToken`/`accessTokenExpiresAt` and set `session.error = "RefreshFailedError"` so downstream consumers can force re-auth. Tokens stay server-only (HttpOnly NextAuth session cookie) — never exposed to client JS.

## Out of scope

Wiring `session.error` into middleware (FE-7), logout (FE-5), social providers (FE-4), change-password (FE-6), attaching the bearer to admin action calls (FE-7). `ADMIN_TOKEN` and `lib/admin-actions.ts` untouched for now.

## Test plan

- [x] `yarn test` — 151 passing (up from 109; +42 new tests across issue / refresh / jwt-exp / signin-action / post-auth-nonce)
- [x] `yarn build` — clean
- [ ] Manual: sign in with valid creds; inspect NextAuth session cookie via server component — `accessToken` / `refreshToken` populated, `session.user` carries no token fields
- [ ] Manual: set `JWT_ACCESS_TTL_SECS=400` on backend (just above the 360s skew), sign in, hit a server-rendered page after ~40s — expect `/api/auth/refresh` call in backend logs and rotated tokens in the cookie
- [ ] Manual: issue #21 — set `AUTH_CREDENTIAL_FAILURE_LIMIT=2`, fail two logins; third attempt's 429 shows "Try again in N seconds" with the real `Retry-After`
- [ ] Manual: tamper with refresh token in the session cookie → protected page should clear the session and redirect to `/signin`

Closes #21.