### PR TITLE
[FEAT] FE-3 — Server-side secureFetch with single 401-retry-via-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Visit `/signin` to log in. Contract lives in the Digital Brain vault: `wiki/pool
 
 **FE-3 — server-side `secureFetch` / `secureAction`.** Use `lib/auth/backend-fetch.ts` (not `apiFetch`/`apiAction`) for any backend route gated by `SuperAdminUser` or `GroupScopedAdmin`. The helpers read the per-session JWT bearer out of the NextAuth cookie via `lib/auth/server-token.ts`, attach `Authorization: Bearer …`, and on a 401 silently rotate the token via `/api/auth/refresh` and retry once. On a second 401 or refresh failure they throw `BackendUnauthorizedError`; the caller should redirect to `/signin?reauth=1`. Server Action / Route Handler only — `cookies().set()` is unavailable in Server Components.
 
-> Note: the auto-generated "Environment Variables" table below is not yet updated for auth-related vars. Treat this Authentication section as the authoritative source for auth configuration until the generator is updated (and `ADMIN_TOKEN` is fully removed in FE-2).
+> Note: the auto-generated "Environment Variables" table below is not yet updated for auth-related vars. Treat this Authentication section as the authoritative source for auth configuration until the generator is updated (and `ADMIN_TOKEN` is fully removed in FE-7).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Sign-in is scaffolded with NextAuth v5 against the `poolpay-api` Credentials end
 
 Visit `/signin` to log in. Contract lives in the Digital Brain vault: `wiki/poolpay/architecture/auth-api-contract.md`.
 
+**FE-3 — server-side `secureFetch` / `secureAction`.** Use `lib/auth/backend-fetch.ts` (not `apiFetch`/`apiAction`) for any backend route gated by `SuperAdminUser` or `GroupScopedAdmin`. The helpers read the per-session JWT bearer out of the NextAuth cookie via `lib/auth/server-token.ts`, attach `Authorization: Bearer …`, and on a 401 silently rotate the token via `/api/auth/refresh` and retry once. On a second 401 or refresh failure they throw `BackendUnauthorizedError`; the caller should redirect to `/signin?reauth=1`. Server Action / Route Handler only — `cookies().set()` is unavailable in Server Components.
+
 > Note: the auto-generated "Environment Variables" table below is not yet updated for auth-related vars. Treat this Authentication section as the authoritative source for auth configuration until the generator is updated (and `ADMIN_TOKEN` is fully removed in FE-2).
 
 ---

--- a/lib/auth/auth-config.ts
+++ b/lib/auth/auth-config.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared NextAuth configuration constants.
+ *
+ * `server-token.ts` and `backend-fetch.ts` both need the raw session-cookie
+ * name and signing secret to decode / re-encode the HttpOnly JWT cookie.
+ * Centralising here prevents drift if the env-var precedence or cookie-prefix
+ * logic ever changes.
+ */
+
+const SECURE_COOKIE_NAME = "__Secure-authjs.session-token";
+const INSECURE_COOKIE_NAME = "authjs.session-token";
+
+function useSecureCookies(): boolean {
+  const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL;
+  if (url) return url.startsWith("https://");
+  return process.env.NODE_ENV === "production";
+}
+
+/**
+ * Returns the active NextAuth session-cookie name.
+ *
+ * Matches `defaultCookies(useSecureCookies)` from
+ * `@auth/core/lib/utils/cookie` — the cookie name doubles as the JWT
+ * encryption salt, so `encode()` / `decode()` callers must use this helper.
+ */
+export function sessionCookieName(): string {
+  return useSecureCookies() ? SECURE_COOKIE_NAME : INSECURE_COOKIE_NAME;
+}
+
+/**
+ * Whether the active cookie is `__Secure-` prefixed and therefore requires
+ * the `secure: true` cookie attribute when written back via `cookies().set()`.
+ */
+export function isSecureSessionCookie(): boolean {
+  return sessionCookieName().startsWith("__Secure-");
+}
+
+/**
+ * Resolves the NextAuth signing secret.
+ *
+ * Throws on misconfiguration — this is a server-boot invariant, not a user
+ * error, so fail loudly rather than silently returning null.
+ */
+export function getAuthSecret(): string {
+  const secret = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET;
+  if (!secret) {
+    throw new Error("NEXTAUTH_SECRET (or AUTH_SECRET) is not set");
+  }
+  return secret;
+}

--- a/lib/auth/auth-config.ts
+++ b/lib/auth/auth-config.ts
@@ -48,3 +48,13 @@ export function getAuthSecret(): string {
   }
   return secret;
 }
+
+/**
+ * NextAuth session / JWT lifetime in seconds.
+ *
+ * Mirrors NextAuth's default `session.maxAge` (30 days). Centralised here so
+ * any helper that re-encodes the session cookie (e.g. `backend-fetch.ts` after
+ * a refresh) stays in lock-step with the NextAuth config — if `auth.ts` ever
+ * overrides `session.maxAge`, update this constant too.
+ */
+export const SESSION_MAX_AGE_SECS = 30 * 24 * 60 * 60;

--- a/lib/auth/backend-fetch.ts
+++ b/lib/auth/backend-fetch.ts
@@ -102,6 +102,27 @@ interface ResolvedRequest {
 }
 
 /**
+ * Classify an unknown error thrown from `fetch()` / `executeWithRetry` as a
+ * recoverable transport failure vs. a programmer/configuration bug we must
+ * fail loudly on.
+ *
+ * - `TypeError`        → fetch network failure (DNS, connection reset, CORS)
+ * - `AbortError`       → `AbortSignal.timeout(...)` fired or caller aborted
+ * - `TimeoutError`     → some runtimes throw this name instead of AbortError
+ *
+ * Anything else (e.g. `getAuthSecret()` throwing on missing env var, or a
+ * genuine programming error) propagates so the operator sees the real cause
+ * rather than a silent `{ ok: false }` / `{ success: false }` result.
+ */
+function isTransportError(err: unknown): boolean {
+  if (err instanceof TypeError) return true;
+  if (err instanceof Error) {
+    return err.name === "AbortError" || err.name === "TimeoutError";
+  }
+  return false;
+}
+
+/**
  * Merge caller-supplied headers (any valid `HeadersInit`: plain object,
  * `Headers` instance, or tuple array) with our required `Authorization` and
  * `Content-Type`. Using `Headers` as the accumulator avoids silently dropping
@@ -204,10 +225,13 @@ export async function secureFetch<T>(
     res = await executeWithRetry(path, opts, FETCH_TIMEOUT_MS);
   } catch (err) {
     // Auth failures are a distinct control-flow signal — caller redirects to
-    // /signin. Transport/timeout failures (TypeError, AbortError) collapse
-    // into the documented `{ ok: false }` fallback shape so callers never see
-    // a raw throw from a read helper.
+    // /signin. Known transport/timeout failures (TypeError, AbortError)
+    // collapse into the documented `{ ok: false }` fallback shape so callers
+    // never see a raw throw from a read helper. Anything else (e.g. missing
+    // auth secret, programmer bug) rethrows so misconfig fails loudly
+    // instead of masquerading as a benign network failure.
     if (err instanceof BackendUnauthorizedError) throw err;
+    if (!isTransportError(err)) throw err;
     return { ok: false, status: 0, data: fallback };
   }
 
@@ -253,10 +277,13 @@ export async function secureAction<T = undefined>(
   try {
     res = await executeWithRetry(path, opts, MUTATION_TIMEOUT_MS);
   } catch (err) {
-    // Auth failures bubble up so callers can redirect to /signin. Other
+    // Auth failures bubble up so callers can redirect to /signin. Known
     // transport errors collapse into the action failure tuple, matching
     // `apiAction`'s behaviour — Server Actions render `error` into form state.
+    // Unexpected errors (misconfig, programmer bug) rethrow so the operator
+    // sees the real cause instead of a user-facing "network_error" lie.
     if (err instanceof BackendUnauthorizedError) throw err;
+    if (!isTransportError(err)) throw err;
     const message = err instanceof Error ? err.message : "network_error";
     return { success: false, error: message };
   }
@@ -273,6 +300,17 @@ export async function secureAction<T = undefined>(
     return { success: true };
   }
 
-  const data = (await res.json().catch(() => undefined)) as T | undefined;
-  return { success: true, data };
+  // A malformed 2xx body is a backend regression — surface as a failure
+  // rather than silently returning `{ success: true, data: undefined }`
+  // and masking the problem downstream.
+  try {
+    const data = (await res.json()) as T;
+    return { success: true, data };
+  } catch {
+    return {
+      success: false,
+      error: "invalid_json_response",
+      status: res.status,
+    };
+  }
 }

--- a/lib/auth/backend-fetch.ts
+++ b/lib/auth/backend-fetch.ts
@@ -7,6 +7,7 @@ import {
   getAuthSecret,
   isSecureSessionCookie,
   sessionCookieName,
+  SESSION_MAX_AGE_SECS,
 } from "@/lib/auth/auth-config";
 import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
 import { refreshTokens, RefreshFailedError } from "@/lib/auth/refresh";
@@ -36,8 +37,6 @@ export type SecureFetchResult<T> =
 export type SecureActionResult<T = undefined> =
   | { success: true; data?: T }
   | { success: false; error: string; status?: number };
-
-const SESSION_MAX_AGE_SECS = 30 * 24 * 60 * 60;
 
 async function writeSessionCookie(token: JWT): Promise<void> {
   const cookieName = sessionCookieName();
@@ -105,8 +104,14 @@ interface ResolvedRequest {
 /**
  * Merge caller-supplied headers (any valid `HeadersInit`: plain object,
  * `Headers` instance, or tuple array) with our required `Authorization` and
- * optional `Content-Type`. Using `Headers` as the accumulator avoids silently
- * dropping entries when a caller passes a non-plain-object shape.
+ * `Content-Type`. Using `Headers` as the accumulator avoids silently dropping
+ * entries when a caller passes a non-plain-object shape.
+ *
+ * When `hasJsonBody` is true we always force `Content-Type: application/json`
+ * — `buildRequest` calls `JSON.stringify(body)` unconditionally, so honouring
+ * a caller-supplied non-JSON Content-Type would ship a mismatched header and
+ * confuse the backend. If a caller ever needs a non-JSON body, they should
+ * reach for `apiFetch` / `apiAction` directly.
  */
 function mergeHeaders(
   provided: HeadersInit | undefined,
@@ -115,7 +120,7 @@ function mergeHeaders(
 ): Headers {
   const merged = new Headers(provided);
   merged.set("Authorization", `Bearer ${token}`);
-  if (hasJsonBody && !merged.has("Content-Type")) {
+  if (hasJsonBody) {
     merged.set("Content-Type", "application/json");
   }
   return merged;
@@ -210,15 +215,21 @@ export async function secureFetch<T>(
     return { ok: false, status: res.status, data: fallback };
   }
 
-  // 204 No Content and empty 2xx bodies are valid responses — treat them as
-  // success with the caller-supplied fallback rather than throwing on JSON
-  // parse.
+  // 204 No Content is a valid success response with no body.
   if (res.status === 204) {
     return { ok: true, status: res.status, data: fallback };
   }
 
-  const data = (await res.json().catch(() => fallback)) as T;
-  return { ok: true, status: res.status, data };
+  // A 2xx body that fails to parse as JSON signals a backend regression
+  // (HTML error page, truncated response, wrong Content-Type). Surface as
+  // `ok: false` with the fallback so callers don't silently render stale
+  // state as if it were fresh data.
+  try {
+    const data = (await res.json()) as T;
+    return { ok: true, status: res.status, data };
+  } catch {
+    return { ok: false, status: res.status, data: fallback };
+  }
 }
 
 /**

--- a/lib/auth/backend-fetch.ts
+++ b/lib/auth/backend-fetch.ts
@@ -100,7 +100,25 @@ async function forceJwtRefresh(current: JWT): Promise<JWT> {
 interface ResolvedRequest {
   url: string;
   init: RequestInit;
-  hasJsonBody: boolean;
+}
+
+/**
+ * Merge caller-supplied headers (any valid `HeadersInit`: plain object,
+ * `Headers` instance, or tuple array) with our required `Authorization` and
+ * optional `Content-Type`. Using `Headers` as the accumulator avoids silently
+ * dropping entries when a caller passes a non-plain-object shape.
+ */
+function mergeHeaders(
+  provided: HeadersInit | undefined,
+  hasJsonBody: boolean,
+  token: string,
+): Headers {
+  const merged = new Headers(provided);
+  merged.set("Authorization", `Bearer ${token}`);
+  if (hasJsonBody && !merged.has("Content-Type")) {
+    merged.set("Content-Type", "application/json");
+  }
+  return merged;
 }
 
 function buildRequest(
@@ -109,13 +127,13 @@ function buildRequest(
   token: string,
   defaultTimeoutMs: number,
 ): ResolvedRequest {
-  const { body, timeoutMs, headers, method, ...rest } = opts;
+  const { body, timeoutMs, headers, method, signal, ...rest } = opts;
   const hasJsonBody = body !== undefined;
-  const finalHeaders: Record<string, string> = {
-    ...(headers as Record<string, string> | undefined),
-    Authorization: `Bearer ${token}`,
-    ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),
-  };
+  const finalHeaders = mergeHeaders(headers, hasJsonBody, token);
+  // Honour a caller-provided signal when present so call sites can cancel
+  // from outside; otherwise fall back to a timeout-bound signal. Matches
+  // `apiFetch`'s override semantics.
+  const finalSignal = signal ?? AbortSignal.timeout(timeoutMs ?? defaultTimeoutMs);
   return {
     url: `${getBackendUrl()}${path}`,
     init: {
@@ -123,10 +141,9 @@ function buildRequest(
       method: method ?? (hasJsonBody ? "POST" : "GET"),
       ...rest,
       headers: finalHeaders,
-      signal: AbortSignal.timeout(timeoutMs ?? defaultTimeoutMs),
+      signal: finalSignal,
       ...(hasJsonBody ? { body: JSON.stringify(body) } : {}),
     },
-    hasJsonBody,
   };
 }
 

--- a/lib/auth/backend-fetch.ts
+++ b/lib/auth/backend-fetch.ts
@@ -177,11 +177,30 @@ export async function secureFetch<T>(
   fallback: T,
   opts: SecureFetchOptions = {},
 ): Promise<SecureFetchResult<T>> {
-  const res = await executeWithRetry(path, opts, FETCH_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await executeWithRetry(path, opts, FETCH_TIMEOUT_MS);
+  } catch (err) {
+    // Auth failures are a distinct control-flow signal — caller redirects to
+    // /signin. Transport/timeout failures (TypeError, AbortError) collapse
+    // into the documented `{ ok: false }` fallback shape so callers never see
+    // a raw throw from a read helper.
+    if (err instanceof BackendUnauthorizedError) throw err;
+    return { ok: false, status: 0, data: fallback };
+  }
+
   if (!res.ok) {
     return { ok: false, status: res.status, data: fallback };
   }
-  const data = (await res.json()) as T;
+
+  // 204 No Content and empty 2xx bodies are valid responses — treat them as
+  // success with the caller-supplied fallback rather than throwing on JSON
+  // parse.
+  if (res.status === 204) {
+    return { ok: true, status: res.status, data: fallback };
+  }
+
+  const data = (await res.json().catch(() => fallback)) as T;
   return { ok: true, status: res.status, data };
 }
 
@@ -202,7 +221,17 @@ export async function secureAction<T = undefined>(
   path: string,
   opts: SecureFetchOptions = {},
 ): Promise<SecureActionResult<T>> {
-  const res = await executeWithRetry(path, opts, MUTATION_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await executeWithRetry(path, opts, MUTATION_TIMEOUT_MS);
+  } catch (err) {
+    // Auth failures bubble up so callers can redirect to /signin. Other
+    // transport errors collapse into the action failure tuple, matching
+    // `apiAction`'s behaviour — Server Actions render `error` into form state.
+    if (err instanceof BackendUnauthorizedError) throw err;
+    const message = err instanceof Error ? err.message : "network_error";
+    return { success: false, error: message };
+  }
 
   if (!res.ok) {
     const payload = await res.json().catch(() => ({}));

--- a/lib/auth/backend-fetch.ts
+++ b/lib/auth/backend-fetch.ts
@@ -1,0 +1,200 @@
+import { cookies } from "next/headers";
+import { encode } from "@auth/core/jwt";
+import type { JWT } from "@auth/core/jwt";
+import { getBackendUrl } from "@/lib/config";
+import { FETCH_TIMEOUT_MS, MUTATION_TIMEOUT_MS } from "@/lib/http";
+import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
+import { refreshTokens, RefreshFailedError } from "@/lib/auth/refresh";
+import { getServerToken, sessionCookieName } from "@/lib/auth/server-token";
+
+export type BackendUnauthorizedReason =
+  | "no_session"
+  | "refresh_failed"
+  | "retry_exhausted";
+
+export class BackendUnauthorizedError extends Error {
+  constructor(public readonly reason: BackendUnauthorizedReason) {
+    super(`backend_unauthorized:${reason}`);
+    this.name = "BackendUnauthorizedError";
+  }
+}
+
+export interface SecureFetchOptions extends Omit<RequestInit, "body"> {
+  body?: unknown;
+  timeoutMs?: number;
+}
+
+export type SecureFetchResult<T> =
+  | { ok: true; status: number; data: T }
+  | { ok: false; status: number; data: T };
+
+export type SecureActionResult<T = undefined> =
+  | { success: true; data?: T }
+  | { success: false; error: string; status?: number };
+
+const SESSION_MAX_AGE_SECS = 30 * 24 * 60 * 60;
+
+function getAuthSecret(): string {
+  const secret = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET;
+  if (!secret) {
+    throw new Error("NEXTAUTH_SECRET (or AUTH_SECRET) is not set");
+  }
+  return secret;
+}
+
+function isSecureCookie(name: string): boolean {
+  return name.startsWith("__Secure-");
+}
+
+async function writeSessionCookie(token: JWT): Promise<void> {
+  const cookieName = sessionCookieName();
+  const encoded = await encode({
+    token,
+    secret: getAuthSecret(),
+    salt: cookieName,
+    maxAge: SESSION_MAX_AGE_SECS,
+  });
+  const store = await cookies();
+  try {
+    store.set(cookieName, encoded, {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      secure: isSecureCookie(cookieName),
+      maxAge: SESSION_MAX_AGE_SECS,
+    });
+  } catch {
+    // cookies().set() throws when called from a Server Component.
+    // secureFetch must run in a Server Action or Route Handler so the rotated
+    // cookie reaches the browser. Surface as refresh_failed so the caller
+    // redirects to /signin instead of silently serving a stale token.
+    throw new BackendUnauthorizedError("refresh_failed");
+  }
+}
+
+async function forceJwtRefresh(current: JWT): Promise<JWT> {
+  if (!current.refreshToken) {
+    throw new BackendUnauthorizedError("refresh_failed");
+  }
+
+  let pair;
+  try {
+    pair = await refreshTokens(current.refreshToken);
+  } catch (err) {
+    if (err instanceof RefreshFailedError) {
+      throw new BackendUnauthorizedError("refresh_failed");
+    }
+    throw err;
+  }
+
+  const newExp = readJwtExpSecs(pair.accessToken);
+  if (!newExp) {
+    throw new BackendUnauthorizedError("refresh_failed");
+  }
+
+  const next: JWT = {
+    ...current,
+    accessToken: pair.accessToken,
+    refreshToken: pair.refreshToken,
+    accessTokenExpiresAt: newExp,
+  };
+  delete next.error;
+
+  await writeSessionCookie(next);
+  return next;
+}
+
+interface ResolvedRequest {
+  url: string;
+  init: RequestInit;
+  hasJsonBody: boolean;
+}
+
+function buildRequest(
+  path: string,
+  opts: SecureFetchOptions,
+  token: string,
+  defaultTimeoutMs: number,
+): ResolvedRequest {
+  const { body, timeoutMs, headers, method, ...rest } = opts;
+  const hasJsonBody = body !== undefined;
+  const finalHeaders: Record<string, string> = {
+    ...(headers as Record<string, string> | undefined),
+    Authorization: `Bearer ${token}`,
+    ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),
+  };
+  return {
+    url: `${getBackendUrl()}${path}`,
+    init: {
+      cache: "no-store",
+      method: method ?? (hasJsonBody ? "POST" : "GET"),
+      ...rest,
+      headers: finalHeaders,
+      signal: AbortSignal.timeout(timeoutMs ?? defaultTimeoutMs),
+      ...(hasJsonBody ? { body: JSON.stringify(body) } : {}),
+    },
+    hasJsonBody,
+  };
+}
+
+async function executeWithRetry(
+  path: string,
+  opts: SecureFetchOptions,
+  defaultTimeoutMs: number,
+): Promise<Response> {
+  let token = await getServerToken();
+  if (!token?.accessToken) {
+    throw new BackendUnauthorizedError("no_session");
+  }
+
+  const first = buildRequest(path, opts, token.accessToken, defaultTimeoutMs);
+  let res = await fetch(first.url, first.init);
+  if (res.status !== 401) return res;
+
+  token = await forceJwtRefresh(token);
+  if (!token.accessToken) {
+    throw new BackendUnauthorizedError("refresh_failed");
+  }
+
+  const retry = buildRequest(path, opts, token.accessToken, defaultTimeoutMs);
+  res = await fetch(retry.url, retry.init);
+  if (res.status === 401) {
+    throw new BackendUnauthorizedError("retry_exhausted");
+  }
+  return res;
+}
+
+export async function secureFetch<T>(
+  path: string,
+  fallback: T,
+  opts: SecureFetchOptions = {},
+): Promise<SecureFetchResult<T>> {
+  const res = await executeWithRetry(path, opts, FETCH_TIMEOUT_MS);
+  if (!res.ok) {
+    return { ok: false, status: res.status, data: fallback };
+  }
+  const data = (await res.json()) as T;
+  return { ok: true, status: res.status, data };
+}
+
+export async function secureAction<T = undefined>(
+  path: string,
+  opts: SecureFetchOptions = {},
+): Promise<SecureActionResult<T>> {
+  const res = await executeWithRetry(path, opts, MUTATION_TIMEOUT_MS);
+
+  if (!res.ok) {
+    const payload = await res.json().catch(() => ({}));
+    const message =
+      (payload as { error?: string }).error ??
+      `${res.status} ${res.statusText}`;
+    return { success: false, error: message, status: res.status };
+  }
+
+  if (res.status === 204) {
+    return { success: true };
+  }
+
+  const data = (await res.json().catch(() => undefined)) as T | undefined;
+  return { success: true, data };
+}

--- a/lib/auth/backend-fetch.ts
+++ b/lib/auth/backend-fetch.ts
@@ -69,7 +69,7 @@ async function forceJwtRefresh(current: JWT): Promise<JWT> {
     throw new BackendUnauthorizedError("refresh_failed");
   }
 
-  let pair;
+  let pair: Awaited<ReturnType<typeof refreshTokens>>;
   try {
     pair = await refreshTokens(current.refreshToken);
   } catch (err) {
@@ -273,9 +273,13 @@ export async function secureAction<T = undefined>(
   path: string,
   opts: SecureFetchOptions = {},
 ): Promise<SecureActionResult<T>> {
+  // Mirror `apiAction`'s POST-by-default: `buildRequest` otherwise falls
+  // back to GET when no body is supplied, which would silently send the
+  // wrong verb for mutation endpoints that expect POST (e.g. logout).
+  const actionOpts: SecureFetchOptions = { method: "POST", ...opts };
   let res: Response;
   try {
-    res = await executeWithRetry(path, opts, MUTATION_TIMEOUT_MS);
+    res = await executeWithRetry(path, actionOpts, MUTATION_TIMEOUT_MS);
   } catch (err) {
     // Auth failures bubble up so callers can redirect to /signin. Known
     // transport errors collapse into the action failure tuple, matching

--- a/lib/auth/backend-fetch.ts
+++ b/lib/auth/backend-fetch.ts
@@ -3,9 +3,14 @@ import { encode } from "@auth/core/jwt";
 import type { JWT } from "@auth/core/jwt";
 import { getBackendUrl } from "@/lib/config";
 import { FETCH_TIMEOUT_MS, MUTATION_TIMEOUT_MS } from "@/lib/http";
+import {
+  getAuthSecret,
+  isSecureSessionCookie,
+  sessionCookieName,
+} from "@/lib/auth/auth-config";
 import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
 import { refreshTokens, RefreshFailedError } from "@/lib/auth/refresh";
-import { getServerToken, sessionCookieName } from "@/lib/auth/server-token";
+import { getServerToken } from "@/lib/auth/server-token";
 
 export type BackendUnauthorizedReason =
   | "no_session"
@@ -34,18 +39,6 @@ export type SecureActionResult<T = undefined> =
 
 const SESSION_MAX_AGE_SECS = 30 * 24 * 60 * 60;
 
-function getAuthSecret(): string {
-  const secret = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET;
-  if (!secret) {
-    throw new Error("NEXTAUTH_SECRET (or AUTH_SECRET) is not set");
-  }
-  return secret;
-}
-
-function isSecureCookie(name: string): boolean {
-  return name.startsWith("__Secure-");
-}
-
 async function writeSessionCookie(token: JWT): Promise<void> {
   const cookieName = sessionCookieName();
   const encoded = await encode({
@@ -60,7 +53,7 @@ async function writeSessionCookie(token: JWT): Promise<void> {
       httpOnly: true,
       sameSite: "lax",
       path: "/",
-      secure: isSecureCookie(cookieName),
+      secure: isSecureSessionCookie(),
       maxAge: SESSION_MAX_AGE_SECS,
     });
   } catch {
@@ -164,6 +157,21 @@ async function executeWithRetry(
   return res;
 }
 
+/**
+ * Server-side backend read helper for JWT-gated endpoints.
+ *
+ * Attaches `Authorization: Bearer <access-token>` from the NextAuth cookie.
+ * On a 401 response, transparently rotates the token via `/api/auth/refresh`,
+ * writes the rotated pair back to the cookie, and retries once. Non-401
+ * errors surface as `{ ok: false, data: fallback }`.
+ *
+ * Throws `BackendUnauthorizedError` when no session exists, refresh fails,
+ * or a second 401 follows refresh — the caller should redirect to
+ * `/signin?reauth=1`.
+ *
+ * Server Action / Route Handler only — `cookies().set()` is unavailable in
+ * Server Components.
+ */
 export async function secureFetch<T>(
   path: string,
   fallback: T,
@@ -177,6 +185,19 @@ export async function secureFetch<T>(
   return { ok: true, status: res.status, data };
 }
 
+/**
+ * Server-side backend mutation helper for JWT-gated endpoints.
+ *
+ * Same Bearer-attach + single-401-retry-via-refresh semantics as
+ * `secureFetch`. Non-ok statuses (other than 401) return
+ * `{ success: false, error, status }` so Server Actions can pipe them into
+ * form state. Unlike `apiAction`, auth failures **throw**
+ * `BackendUnauthorizedError` rather than returning a failure tuple — callers
+ * typically want to redirect to `/signin?reauth=1` for auth errors but
+ * render the `error` string for validation / conflict responses.
+ *
+ * Server Action / Route Handler only.
+ */
 export async function secureAction<T = undefined>(
   path: string,
   opts: SecureFetchOptions = {},

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -1,28 +1,20 @@
 import { cookies } from "next/headers";
 import { decode } from "@auth/core/jwt";
 import type { JWT } from "@auth/core/jwt";
+import { getAuthSecret, sessionCookieName } from "@/lib/auth/auth-config";
 
-const SECURE_COOKIE_NAME = "__Secure-authjs.session-token";
-const INSECURE_COOKIE_NAME = "authjs.session-token";
+export { sessionCookieName };
 
-function useSecureCookies(): boolean {
-  const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL;
-  if (url) return url.startsWith("https://");
-  return process.env.NODE_ENV === "production";
-}
-
-export function sessionCookieName(): string {
-  return useSecureCookies() ? SECURE_COOKIE_NAME : INSECURE_COOKIE_NAME;
-}
-
-function getAuthSecret(): string {
-  const secret = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET;
-  if (!secret) {
-    throw new Error("NEXTAUTH_SECRET (or AUTH_SECRET) is not set");
-  }
-  return secret;
-}
-
+/**
+ * Reads and decodes the NextAuth session JWT from the HttpOnly cookie.
+ *
+ * Returns `null` when the cookie is absent, cannot be decoded, or carries a
+ * `RefreshFailedError` sentinel from FE-2's silent-refresh path. Throws only
+ * on server-boot misconfiguration (missing `NEXTAUTH_SECRET`).
+ *
+ * Server-only — must be called from a Server Component, Server Action, or
+ * Route Handler.
+ */
 export async function getServerToken(): Promise<JWT | null> {
   const cookieName = sessionCookieName();
   const store = await cookies();
@@ -45,6 +37,10 @@ export async function getServerToken(): Promise<JWT | null> {
   }
 }
 
+/**
+ * Convenience wrapper around `getServerToken()` returning just the access
+ * token string, or `null` when no usable session exists.
+ */
 export async function getAccessToken(): Promise<string | null> {
   const token = await getServerToken();
   return token?.accessToken ?? null;

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -10,7 +10,8 @@ export { sessionCookieName };
  *
  * Returns `null` when the cookie is absent, cannot be decoded, or carries a
  * `RefreshFailedError` sentinel from FE-2's silent-refresh path. Throws only
- * on server-boot misconfiguration (missing `NEXTAUTH_SECRET`).
+ * on server-boot misconfiguration — `getAuthSecret()` requires one of
+ * `NEXTAUTH_SECRET` or `AUTH_SECRET` to be set.
  *
  * Server-only — must be called from a Server Component, Server Action, or
  * Route Handler.

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -1,0 +1,51 @@
+import { cookies } from "next/headers";
+import { decode } from "@auth/core/jwt";
+import type { JWT } from "@auth/core/jwt";
+
+const SECURE_COOKIE_NAME = "__Secure-authjs.session-token";
+const INSECURE_COOKIE_NAME = "authjs.session-token";
+
+function useSecureCookies(): boolean {
+  const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL;
+  if (url) return url.startsWith("https://");
+  return process.env.NODE_ENV === "production";
+}
+
+export function sessionCookieName(): string {
+  return useSecureCookies() ? SECURE_COOKIE_NAME : INSECURE_COOKIE_NAME;
+}
+
+function getAuthSecret(): string {
+  const secret = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET;
+  if (!secret) {
+    throw new Error("NEXTAUTH_SECRET (or AUTH_SECRET) is not set");
+  }
+  return secret;
+}
+
+export async function getServerToken(): Promise<JWT | null> {
+  const cookieName = sessionCookieName();
+  const store = await cookies();
+  const raw = store.get(cookieName)?.value;
+  if (!raw) return null;
+
+  const secret = getAuthSecret();
+
+  try {
+    const token = await decode<JWT>({
+      token: raw,
+      secret,
+      salt: cookieName,
+    });
+    if (!token) return null;
+    if (token.error === "RefreshFailedError") return null;
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+export async function getAccessToken(): Promise<string | null> {
+  const token = await getServerToken();
+  return token?.accessToken ?? null;
+}

--- a/tests/unit/auth-config.test.ts
+++ b/tests/unit/auth-config.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getAuthSecret,
+  isSecureSessionCookie,
+  sessionCookieName,
+} from "@/lib/auth/auth-config";
+
+// Pin against the literals from @auth/core/lib/utils/cookie.js `defaultCookies`.
+// If a next-auth upgrade changes either string, this guard fires before the
+// silent-refresh path breaks production.
+const AUTHJS_INSECURE_SESSION_COOKIE = "authjs.session-token";
+const AUTHJS_SECURE_SESSION_COOKIE = "__Secure-authjs.session-token";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  delete process.env.AUTH_URL;
+  delete process.env.NEXTAUTH_URL;
+  delete process.env.NEXTAUTH_SECRET;
+  delete process.env.AUTH_SECRET;
+  process.env.NODE_ENV = "test";
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe("sessionCookieName", () => {
+  it("matches the @auth/core insecure default in dev", () => {
+    expect(sessionCookieName()).toBe(AUTHJS_INSECURE_SESSION_COOKIE);
+  });
+
+  it("matches the @auth/core secure default when AUTH_URL is https", () => {
+    process.env.AUTH_URL = "https://app.example.com";
+    expect(sessionCookieName()).toBe(AUTHJS_SECURE_SESSION_COOKIE);
+  });
+
+  it("uses AUTH_URL precedence over NEXTAUTH_URL", () => {
+    process.env.AUTH_URL = "http://dev.local";
+    process.env.NEXTAUTH_URL = "https://prod.example.com";
+    expect(sessionCookieName()).toBe("authjs.session-token");
+  });
+
+  it("falls back to NEXTAUTH_URL when AUTH_URL is unset", () => {
+    process.env.NEXTAUTH_URL = "https://prod.example.com";
+    expect(sessionCookieName()).toBe("__Secure-authjs.session-token");
+  });
+
+  it("falls back to NODE_ENV=production when no URL is set", () => {
+    process.env.NODE_ENV = "production";
+    expect(sessionCookieName()).toBe("__Secure-authjs.session-token");
+  });
+});
+
+describe("isSecureSessionCookie", () => {
+  it("is false in dev", () => {
+    expect(isSecureSessionCookie()).toBe(false);
+  });
+
+  it("is true when cookie is __Secure- prefixed", () => {
+    process.env.AUTH_URL = "https://app.example.com";
+    expect(isSecureSessionCookie()).toBe(true);
+  });
+});
+
+describe("getAuthSecret", () => {
+  it("reads NEXTAUTH_SECRET", () => {
+    process.env.NEXTAUTH_SECRET = "abc";
+    expect(getAuthSecret()).toBe("abc");
+  });
+
+  it("falls back to AUTH_SECRET", () => {
+    process.env.AUTH_SECRET = "xyz";
+    expect(getAuthSecret()).toBe("xyz");
+  });
+
+  it("prefers NEXTAUTH_SECRET over AUTH_SECRET", () => {
+    process.env.NEXTAUTH_SECRET = "primary";
+    process.env.AUTH_SECRET = "fallback";
+    expect(getAuthSecret()).toBe("primary");
+  });
+
+  it("throws when neither is set", () => {
+    expect(() => getAuthSecret()).toThrow(/NEXTAUTH_SECRET/);
+  });
+});

--- a/tests/unit/auth-config.test.ts
+++ b/tests/unit/auth-config.test.ts
@@ -11,7 +11,18 @@ import {
 const AUTHJS_INSECURE_SESSION_COOKIE = "authjs.session-token";
 const AUTHJS_SECURE_SESSION_COOKIE = "__Secure-authjs.session-token";
 
-const originalEnv = { ...process.env };
+// Keys this suite mutates — restored per-key in afterEach rather than
+// reassigning process.env (which swaps Node's special env proxy).
+const MANAGED_ENV_KEYS = [
+  "AUTH_URL",
+  "NEXTAUTH_URL",
+  "NEXTAUTH_SECRET",
+  "AUTH_SECRET",
+  "NODE_ENV",
+] as const;
+const originalEnv: Record<string, string | undefined> = Object.fromEntries(
+  MANAGED_ENV_KEYS.map((k) => [k, process.env[k]]),
+);
 
 beforeEach(() => {
   delete process.env.AUTH_URL;
@@ -22,7 +33,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.env = { ...originalEnv };
+  for (const key of MANAGED_ENV_KEYS) {
+    const original = originalEnv[key];
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
 });
 
 describe("sessionCookieName", () => {

--- a/tests/unit/backend-fetch.test.ts
+++ b/tests/unit/backend-fetch.test.ts
@@ -99,7 +99,7 @@ describe("secureFetch", () => {
 
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe("http://backend.test/api/admin/groups");
-    expect((init.headers as Record<string, string>).Authorization).toBe(
+    expect((init.headers as Headers).get("Authorization")).toBe(
       "Bearer tok-1",
     );
   });
@@ -126,8 +126,8 @@ describe("secureFetch", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const retryHeaders = (fetchMock.mock.calls[1][1] as RequestInit)
-      .headers as Record<string, string>;
-    expect(retryHeaders.Authorization).toBe("Bearer tok-new");
+      .headers as Headers;
+    expect(retryHeaders.get("Authorization")).toBe("Bearer tok-new");
   });
 
   it("throws retry_exhausted when second call also returns 401", async () => {
@@ -298,7 +298,7 @@ describe("secureAction", () => {
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect(init.method).toBe("POST");
     expect(init.body).toBe(JSON.stringify({ name: "Test" }));
-    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+    expect((init.headers as Headers).get("Content-Type")).toBe(
       "application/json",
     );
   });
@@ -352,5 +352,41 @@ describe("secureAction", () => {
 
     const result = await secureAction("/x", { body: {} });
     expect(result).toEqual({ success: false, error: "network down" });
+  });
+});
+
+describe("buildRequest behaviour", () => {
+  it("preserves caller-supplied Headers instance entries alongside Authorization", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    const headers = new Headers();
+    headers.set("Accept", "application/vnd.poolpay+json");
+    headers.set("If-Match", "etag-42");
+
+    await secureFetch("/x", {}, { headers });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const sent = init.headers as Headers;
+    expect(sent.get("Accept")).toBe("application/vnd.poolpay+json");
+    expect(sent.get("If-Match")).toBe("etag-42");
+    expect(sent.get("Authorization")).toBe("Bearer tok");
+  });
+
+  it("honours a caller-provided AbortSignal instead of the default timeout signal", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    const controller = new AbortController();
+    await secureFetch("/x", {}, { signal: controller.signal });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
   });
 });

--- a/tests/unit/backend-fetch.test.ts
+++ b/tests/unit/backend-fetch.test.ts
@@ -242,7 +242,10 @@ describe("secureFetch", () => {
     expect(result).toEqual({ ok: true, status: 204, data: { fallback: true } });
   });
 
-  it("returns fallback on 2xx with unparseable body", async () => {
+  it("returns ok:false on 2xx with unparseable body", async () => {
+    // A 2xx with malformed JSON (HTML error page, truncated response) is a
+    // backend regression, not a success — surface as ok:false so callers do
+    // not render the fallback as if it were fresh data.
     getServerTokenMock.mockResolvedValueOnce({
       accessToken: "tok",
       refreshToken: "ref",
@@ -257,7 +260,7 @@ describe("secureFetch", () => {
     } as unknown as Response);
 
     const result = await secureFetch<string>("/x", "default");
-    expect(result).toEqual({ ok: true, status: 200, data: "default" });
+    expect(result).toEqual({ ok: false, status: 200, data: "default" });
   });
 
   it("throws refresh_failed when cookie write fails", async () => {
@@ -374,6 +377,27 @@ describe("buildRequest behaviour", () => {
     expect(sent.get("Accept")).toBe("application/vnd.poolpay+json");
     expect(sent.get("If-Match")).toBe("etag-42");
     expect(sent.get("Authorization")).toBe("Bearer tok");
+  });
+
+  it("forces Content-Type: application/json when body is provided, overriding caller-supplied Content-Type", async () => {
+    // buildRequest always JSON.stringify's the body, so honouring a
+    // caller-supplied non-JSON Content-Type would ship a header that
+    // mismatches the wire payload. Force our Content-Type instead.
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    await secureAction("/x", {
+      body: { name: "Test" },
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Headers).get("Content-Type")).toBe(
+      "application/json",
+    );
   });
 
   it("honours a caller-provided AbortSignal instead of the default timeout signal", async () => {

--- a/tests/unit/backend-fetch.test.ts
+++ b/tests/unit/backend-fetch.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  cookieStore,
+  encodeMock,
+  getServerTokenMock,
+  refreshTokensMock,
+  readJwtExpMock,
+} = vi.hoisted(() => ({
+  cookieStore: { get: vi.fn(), set: vi.fn() },
+  encodeMock: vi.fn(async () => "encoded-cookie"),
+  getServerTokenMock: vi.fn(),
+  refreshTokensMock: vi.fn(),
+  readJwtExpMock: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => cookieStore),
+}));
+
+vi.mock("@auth/core/jwt", () => ({
+  encode: encodeMock,
+  decode: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/server-token", () => ({
+  getServerToken: getServerTokenMock,
+  sessionCookieName: () => "authjs.session-token",
+}));
+
+vi.mock("@/lib/auth/refresh", async (orig) => {
+  const actual = await orig<typeof import("@/lib/auth/refresh")>();
+  return {
+    ...actual,
+    refreshTokens: refreshTokensMock,
+  };
+});
+
+vi.mock("@/lib/auth/jwt-exp", () => ({
+  readJwtExpSecs: readJwtExpMock,
+}));
+
+import {
+  BackendUnauthorizedError,
+  secureAction,
+  secureFetch,
+} from "@/lib/auth/backend-fetch";
+import { RefreshFailedError } from "@/lib/auth/refresh";
+
+const fetchMock = vi.fn();
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
+  process.env.BACKEND_URL = "http://backend.test";
+  process.env.NODE_ENV = "test";
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  fetchMock.mockReset();
+  cookieStore.get.mockReset();
+  cookieStore.set.mockReset();
+  encodeMock.mockClear();
+  getServerTokenMock.mockReset();
+  refreshTokensMock.mockReset();
+  readJwtExpMock.mockReset();
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `status ${status}`,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("secureFetch", () => {
+  it("returns data on 200 happy path without invoking refresh", async () => {
+    getServerTokenMock.mockResolvedValueOnce({ accessToken: "tok-1", refreshToken: "ref-1" });
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { hello: "world" }));
+
+    const result = await secureFetch<{ hello: string }>(
+      "/api/admin/groups",
+      { hello: "" },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      data: { hello: "world" },
+    });
+    expect(refreshTokensMock).not.toHaveBeenCalled();
+    expect(cookieStore.set).not.toHaveBeenCalled();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://backend.test/api/admin/groups");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer tok-1",
+    );
+  });
+
+  it("retries once after 401 → refresh success → 200", async () => {
+    getServerTokenMock
+      .mockResolvedValueOnce({ accessToken: "tok-old", refreshToken: "ref-1" });
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: 1 }));
+    refreshTokensMock.mockResolvedValueOnce({
+      accessToken: "tok-new",
+      refreshToken: "ref-2",
+      expiresAt: "2026-04-16T00:00:00Z",
+    });
+    readJwtExpMock.mockReturnValueOnce(2_000_000_000);
+
+    const result = await secureFetch<{ ok: number }>("/api/admin/groups", { ok: 0 });
+
+    expect(result).toEqual({ ok: true, status: 200, data: { ok: 1 } });
+    expect(refreshTokensMock).toHaveBeenCalledOnce();
+    expect(cookieStore.set).toHaveBeenCalledOnce();
+    expect(encodeMock).toHaveBeenCalledOnce();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryHeaders = (fetchMock.mock.calls[1][1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(retryHeaders.Authorization).toBe("Bearer tok-new");
+  });
+
+  it("throws retry_exhausted when second call also returns 401", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok-old",
+      refreshToken: "ref-1",
+    });
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }))
+      .mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }));
+    refreshTokensMock.mockResolvedValueOnce({
+      accessToken: "tok-new",
+      refreshToken: "ref-2",
+      expiresAt: "x",
+    });
+    readJwtExpMock.mockReturnValueOnce(2_000_000_000);
+
+    await expect(secureFetch("/api/admin/groups", null)).rejects.toMatchObject({
+      name: "BackendUnauthorizedError",
+      reason: "retry_exhausted",
+    });
+  });
+
+  it("throws refresh_failed when refresh throws RefreshFailedError", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok-old",
+      refreshToken: "ref-1",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }));
+    refreshTokensMock.mockRejectedValueOnce(new RefreshFailedError());
+
+    await expect(secureFetch("/api/admin/groups", null)).rejects.toMatchObject({
+      name: "BackendUnauthorizedError",
+      reason: "refresh_failed",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("throws refresh_failed when rotated access token has no exp", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok-old",
+      refreshToken: "ref-1",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }));
+    refreshTokensMock.mockResolvedValueOnce({
+      accessToken: "tok-new",
+      refreshToken: "ref-2",
+      expiresAt: "x",
+    });
+    readJwtExpMock.mockReturnValueOnce(null);
+
+    await expect(secureFetch("/api/admin/groups", null)).rejects.toMatchObject({
+      reason: "refresh_failed",
+    });
+  });
+
+  it("throws no_session when getServerToken returns null", async () => {
+    getServerTokenMock.mockResolvedValueOnce(null);
+
+    await expect(secureFetch("/api/admin/groups", null)).rejects.toMatchObject({
+      reason: "no_session",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws no_session when token has no accessToken", async () => {
+    getServerTokenMock.mockResolvedValueOnce({ refreshToken: "r" });
+    await expect(secureFetch("/api/admin/groups", null)).rejects.toMatchObject({
+      reason: "no_session",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false with fallback on non-401 error status", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: "boom" }));
+
+    const result = await secureFetch("/x", { fallback: true });
+    expect(result).toEqual({ ok: false, status: 500, data: { fallback: true } });
+    expect(refreshTokensMock).not.toHaveBeenCalled();
+  });
+
+  it("throws refresh_failed when cookie write fails", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok-old",
+      refreshToken: "ref-1",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }));
+    refreshTokensMock.mockResolvedValueOnce({
+      accessToken: "tok-new",
+      refreshToken: "ref-2",
+      expiresAt: "x",
+    });
+    readJwtExpMock.mockReturnValueOnce(2_000_000_000);
+    cookieStore.set.mockImplementationOnce(() => {
+      throw new Error("cookies().set() called from RSC");
+    });
+
+    await expect(secureFetch("/x", null)).rejects.toMatchObject({
+      reason: "refresh_failed",
+    });
+  });
+});
+
+describe("secureAction", () => {
+  it("returns success: true and parses JSON body", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { id: "g1" }));
+
+    const result = await secureAction<{ id: string }>("/api/admin/groups", {
+      body: { name: "Test" },
+    });
+    expect(result).toEqual({ success: true, data: { id: "g1" } });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ name: "Test" }));
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+  });
+
+  it("returns success on 204 with no body", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      json: async () => {
+        throw new Error("no body");
+      },
+    } as unknown as Response);
+
+    const result = await secureAction("/api/admin/groups/g1", { method: "DELETE" });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("returns success: false with backend error message on non-ok", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce(jsonResponse(409, { error: "conflict" }));
+
+    const result = await secureAction("/api/admin/groups", { body: {} });
+    expect(result).toEqual({
+      success: false,
+      error: "conflict",
+      status: 409,
+    });
+  });
+
+  it("propagates BackendUnauthorizedError from no_session", async () => {
+    getServerTokenMock.mockResolvedValueOnce(null);
+    await expect(secureAction("/x", { body: {} })).rejects.toBeInstanceOf(
+      BackendUnauthorizedError,
+    );
+  });
+});

--- a/tests/unit/backend-fetch.test.ts
+++ b/tests/unit/backend-fetch.test.ts
@@ -55,7 +55,7 @@ beforeEach(() => {
   process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
   process.env.BACKEND_URL = "http://backend.test";
   process.env.NODE_ENV = "test";
-  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
   fetchMock.mockReset();
   cookieStore.get.mockReset();
   cookieStore.set.mockReset();
@@ -67,6 +67,7 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env = { ...originalEnv };
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -263,6 +264,19 @@ describe("secureFetch", () => {
     expect(result).toEqual({ ok: false, status: 200, data: "default" });
   });
 
+  it("rethrows unexpected non-transport errors so misconfig fails loudly", async () => {
+    // A programmer/config error (e.g. getServerToken() throwing when the
+    // auth secret is missing) must not be masked as a benign `{ ok: false }`
+    // fallback — the operator needs to see the real cause.
+    getServerTokenMock.mockRejectedValueOnce(
+      new Error("NEXTAUTH_SECRET is not set"),
+    );
+
+    await expect(secureFetch("/x", null)).rejects.toThrow(
+      "NEXTAUTH_SECRET is not set",
+    );
+  });
+
   it("throws refresh_failed when cookie write fails", async () => {
     getServerTokenMock.mockResolvedValueOnce({
       accessToken: "tok-old",
@@ -355,6 +369,40 @@ describe("secureAction", () => {
 
     const result = await secureAction("/x", { body: {} });
     expect(result).toEqual({ success: false, error: "network down" });
+  });
+
+  it("rethrows unexpected non-transport errors so misconfig fails loudly", async () => {
+    getServerTokenMock.mockRejectedValueOnce(
+      new Error("NEXTAUTH_SECRET is not set"),
+    );
+
+    await expect(secureAction("/x", { body: {} })).rejects.toThrow(
+      "NEXTAUTH_SECRET is not set",
+    );
+  });
+
+  it("returns invalid_json_response when a 2xx body fails to parse", async () => {
+    // A malformed 2xx body is a backend regression — surface as failure
+    // instead of returning { success: true, data: undefined } and masking it.
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => {
+        throw new SyntaxError("unexpected end of JSON input");
+      },
+    } as unknown as Response);
+
+    const result = await secureAction("/x", { body: {} });
+    expect(result).toEqual({
+      success: false,
+      error: "invalid_json_response",
+      status: 200,
+    });
   });
 });
 

--- a/tests/unit/backend-fetch.test.ts
+++ b/tests/unit/backend-fetch.test.ts
@@ -213,6 +213,53 @@ describe("secureFetch", () => {
     expect(refreshTokensMock).not.toHaveBeenCalled();
   });
 
+  it("returns ok:false with fallback when fetch throws a transport error", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockRejectedValueOnce(new TypeError("network down"));
+
+    const result = await secureFetch("/x", { fallback: true });
+    expect(result).toEqual({ ok: false, status: 0, data: { fallback: true } });
+  });
+
+  it("returns ok:true with fallback on 204 No Content", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      json: async () => {
+        throw new Error("no body");
+      },
+    } as unknown as Response);
+
+    const result = await secureFetch("/x", { fallback: true });
+    expect(result).toEqual({ ok: true, status: 204, data: { fallback: true } });
+  });
+
+  it("returns fallback on 2xx with unparseable body", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => {
+        throw new SyntaxError("unexpected end of JSON input");
+      },
+    } as unknown as Response);
+
+    const result = await secureFetch<string>("/x", "default");
+    expect(result).toEqual({ ok: true, status: 200, data: "default" });
+  });
+
   it("throws refresh_failed when cookie write fails", async () => {
     getServerTokenMock.mockResolvedValueOnce({
       accessToken: "tok-old",
@@ -294,5 +341,16 @@ describe("secureAction", () => {
     await expect(secureAction("/x", { body: {} })).rejects.toBeInstanceOf(
       BackendUnauthorizedError,
     );
+  });
+
+  it("returns success:false with error message when fetch throws a transport error", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockRejectedValueOnce(new TypeError("network down"));
+
+    const result = await secureAction("/x", { body: {} });
+    expect(result).toEqual({ success: false, error: "network down" });
   });
 });

--- a/tests/unit/backend-fetch.test.ts
+++ b/tests/unit/backend-fetch.test.ts
@@ -320,6 +320,28 @@ describe("secureAction", () => {
     );
   });
 
+  it("defaults to POST when neither method nor body is supplied", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "tok",
+      refreshToken: "ref",
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      json: async () => {
+        throw new Error("no body");
+      },
+    } as unknown as Response);
+
+    const result = await secureAction("/api/auth/logout");
+    expect(result).toEqual({ success: true });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeUndefined();
+  });
+
   it("returns success on 204 with no body", async () => {
     getServerTokenMock.mockResolvedValueOnce({
       accessToken: "tok",

--- a/tests/unit/server-token.test.ts
+++ b/tests/unit/server-token.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { cookieStore, decodeMock } = vi.hoisted(() => ({
+  cookieStore: { get: vi.fn() },
+  decodeMock: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => cookieStore),
+}));
+
+vi.mock("@auth/core/jwt", () => ({
+  decode: decodeMock,
+}));
+
+import {
+  getAccessToken,
+  getServerToken,
+  sessionCookieName,
+} from "@/lib/auth/server-token";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
+  process.env.NODE_ENV = "test";
+  delete process.env.AUTH_URL;
+  delete process.env.NEXTAUTH_URL;
+  cookieStore.get.mockReset();
+  decodeMock.mockReset();
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+describe("sessionCookieName", () => {
+  it("returns insecure name in dev", () => {
+    expect(sessionCookieName()).toBe("authjs.session-token");
+  });
+
+  it("returns secure name when AUTH_URL is https", () => {
+    process.env.AUTH_URL = "https://app.example.com";
+    expect(sessionCookieName()).toBe("__Secure-authjs.session-token");
+  });
+
+  it("returns secure name in production without explicit URL", () => {
+    process.env.NODE_ENV = "production";
+    expect(sessionCookieName()).toBe("__Secure-authjs.session-token");
+  });
+});
+
+describe("getServerToken", () => {
+  it("returns null when cookie is missing", async () => {
+    cookieStore.get.mockReturnValueOnce(undefined);
+    const token = await getServerToken();
+    expect(token).toBeNull();
+    expect(decodeMock).not.toHaveBeenCalled();
+  });
+
+  it("decodes the cookie and returns the JWT", async () => {
+    cookieStore.get.mockReturnValueOnce({ value: "encoded.cookie.value" });
+    decodeMock.mockResolvedValueOnce({
+      userId: "u1",
+      accessToken: "access-token",
+    });
+
+    const token = await getServerToken();
+    expect(token).toEqual({ userId: "u1", accessToken: "access-token" });
+
+    const args = decodeMock.mock.calls[0][0];
+    expect(args.token).toBe("encoded.cookie.value");
+    expect(args.salt).toBe("authjs.session-token");
+    expect(args.secret).toBe("test-secret-0123456789abcdef0123456789abcdef");
+  });
+
+  it("returns null when token has RefreshFailedError", async () => {
+    cookieStore.get.mockReturnValueOnce({ value: "x" });
+    decodeMock.mockResolvedValueOnce({
+      accessToken: "a",
+      error: "RefreshFailedError",
+    });
+    expect(await getServerToken()).toBeNull();
+  });
+
+  it("returns null when decode throws", async () => {
+    cookieStore.get.mockReturnValueOnce({ value: "malformed" });
+    decodeMock.mockRejectedValueOnce(new Error("bad"));
+    expect(await getServerToken()).toBeNull();
+  });
+
+  it("returns null when decode resolves to null", async () => {
+    cookieStore.get.mockReturnValueOnce({ value: "x" });
+    decodeMock.mockResolvedValueOnce(null);
+    expect(await getServerToken()).toBeNull();
+  });
+
+  it("throws when NEXTAUTH_SECRET is missing", async () => {
+    delete process.env.NEXTAUTH_SECRET;
+    delete process.env.AUTH_SECRET;
+    cookieStore.get.mockReturnValueOnce({ value: "x" });
+    await expect(getServerToken()).rejects.toThrow(/NEXTAUTH_SECRET/);
+  });
+});
+
+describe("getAccessToken", () => {
+  it("returns the access token when present", async () => {
+    cookieStore.get.mockReturnValueOnce({ value: "x" });
+    decodeMock.mockResolvedValueOnce({ accessToken: "the-token" });
+    expect(await getAccessToken()).toBe("the-token");
+  });
+
+  it("returns null when token has no accessToken field", async () => {
+    cookieStore.get.mockReturnValueOnce({ value: "x" });
+    decodeMock.mockResolvedValueOnce({ userId: "u1" });
+    expect(await getAccessToken()).toBeNull();
+  });
+
+  it("returns null when getServerToken returns null", async () => {
+    cookieStore.get.mockReturnValueOnce(undefined);
+    expect(await getAccessToken()).toBeNull();
+  });
+});

--- a/tests/unit/server-token.test.ts
+++ b/tests/unit/server-token.test.ts
@@ -19,7 +19,18 @@ import {
   sessionCookieName,
 } from "@/lib/auth/server-token";
 
-const originalEnv = { ...process.env };
+// Keys this suite mutates — restored per-key in afterEach rather than
+// reassigning process.env (which swaps Node's special env proxy).
+const MANAGED_ENV_KEYS = [
+  "NEXTAUTH_SECRET",
+  "AUTH_SECRET",
+  "NODE_ENV",
+  "AUTH_URL",
+  "NEXTAUTH_URL",
+] as const;
+const originalEnv: Record<string, string | undefined> = Object.fromEntries(
+  MANAGED_ENV_KEYS.map((k) => [k, process.env[k]]),
+);
 
 beforeEach(() => {
   process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
@@ -31,7 +42,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.env = { ...originalEnv };
+  for (const key of MANAGED_ENV_KEYS) {
+    const original = originalEnv[key];
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

- Adds `lib/auth/server-token.ts` — `getServerToken()` / `getAccessToken()` decode the NextAuth JWT cookie via `@auth/core/jwt` so server code can reach the per-session access token without leaking it through `session()`.
- Adds `lib/auth/backend-fetch.ts` — `secureFetch` / `secureAction` attach `Authorization: Bearer …`, and on a 401 silently rotate the token (reusing FE-2's `refreshTokens()` + `readJwtExpSecs()`), write the rotated pair back to the cookie via `encode()` + `cookies().set()`, and retry once. A second 401, refresh failure, missing session, or RSC-context cookie write throws `BackendUnauthorizedError` for the caller to redirect to `/signin?reauth=1`.
- 25 new unit tests (151 → 176 passing). Build green.

## Out of scope (deliberate)

- Migrating `lib/admin-actions.ts` off `ADMIN_TOKEN` — FE-7.
- Route-guard middleware — deferred to FE-7.
- `/api/auth/logout`, social providers, change-password — FE-4/5/6.

Plan: `wiki/poolpay/frontend/fe-3-secure-fetch-prep.md`.

## Test plan
- [ ] `yarn test` — 176/176 green
- [ ] `yarn build` — strict mode passes
- [ ] Manual: stub `app/admin/_stub/page.tsx` calling `secureFetch("/api/admin/groups")` returns 200 + JSON
- [ ] Manual: with `JWT_ACCESS_TTL_SECS=60` first call 401, `forceJwtRefresh` runs, retry 200, cookie value changes
- [ ] Manual: bump `token_version` on signed-in user → first 401, refresh succeeds, retry 200
- [ ] Manual: delete refresh-token row → 401 → refresh 401 → `BackendUnauthorizedError("refresh_failed")`
- [ ] Manual: signed-out request to a route handler calling `secureFetch` → `BackendUnauthorizedError("no_session")`