### PR TITLE
[FEAT] - FE-5: Wire sign-out to /api/auth/logout

### DIFF
--- a/app/admin/_components/admin-nav.tsx
+++ b/app/admin/_components/admin-nav.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
 import { ChevronLeft } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
+import { SignOutButton } from '@/components/dashboard/signout-button';
 
 export function AdminNav() {
   return (
     <div className="mb-8">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <Link
           href="/"
           className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -15,6 +16,7 @@ export function AdminNav() {
           Dashboard
         </Link>
         <h1 className="text-2xl font-semibold tracking-tighter text-foreground">Admin</h1>
+        <SignOutButton />
       </div>
       <Separator className="mt-6 bg-border" />
     </div>

--- a/app/signout/actions.ts
+++ b/app/signout/actions.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { signOut } from "@/auth";
+import { getServerToken } from "@/lib/auth/server-token";
+import { revokeRefreshFamily } from "@/lib/auth/logout";
+
+/**
+ * Server action wiring the sign-out button to the backend logout contract.
+ *
+ * Flow:
+ *   1. Read the current session JWT (may be absent after an earlier silent
+ *      refresh failure — treat as "already signed out locally").
+ *   2. Best-effort call to `/api/auth/logout` to revoke the refresh-token
+ *      family on the backend. All failures are swallowed — see fail-open
+ *      rule below.
+ *   3. Clear the NextAuth HttpOnly session cookie.
+ *   4. Redirect to `/signin`.
+ *
+ * Fail-open: cookie clear + redirect always run, even if the backend call or
+ * cookie read throws. A dead backend must not trap the user in a signed-in
+ * UI state. Worst case is a narrow window where the refresh family is still
+ * valid until its TTL expires.
+ */
+export async function signOutAction(): Promise<void> {
+  let refreshToken: string | undefined;
+  try {
+    const token = await getServerToken();
+    refreshToken = token?.refreshToken;
+  } catch {
+    refreshToken = undefined;
+  }
+
+  if (refreshToken) {
+    try {
+      await revokeRefreshFamily(refreshToken);
+    } catch {
+      // Fail-open — backend revoke is best-effort; local cookie clear below
+      // is what actually signs the user out of the UI.
+    }
+  }
+
+  await signOut({ redirect: false });
+  redirect("/signin");
+}

--- a/app/signout/actions.ts
+++ b/app/signout/actions.ts
@@ -40,6 +40,13 @@ export async function signOutAction(): Promise<void> {
     }
   }
 
-  await signOut({ redirect: false });
+  try {
+    await signOut({ redirect: false });
+  } catch {
+    // Fail-open — if NextAuth cookie clearing throws (e.g. header mutation
+    // edge cases), we still redirect below so the user is not trapped in a
+    // signed-in UI state.
+  }
+
   redirect("/signin");
 }

--- a/components/dashboard/header.tsx
+++ b/components/dashboard/header.tsx
@@ -3,6 +3,7 @@ import { Users } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { ThemeToggle } from '@/components/dashboard/theme-toggle';
+import { SignOutButton } from '@/components/dashboard/signout-button';
 import { GroupSelector } from '@/components/dashboard/group-selector';
 import type { CycleSummary, Group } from '@/lib/types';
 
@@ -57,6 +58,7 @@ export function DashboardHeader({ activeCycle, groups, selectedGroupId }: Dashbo
             Admin
           </Link>
           <ThemeToggle />
+          <SignOutButton />
         </div>
       </div>
 

--- a/components/dashboard/signout-button.tsx
+++ b/components/dashboard/signout-button.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { LogOut } from 'lucide-react';
+import { signOutAction } from '@/app/signout/actions';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export function SignOutButton() {
+  return (
+    <form action={signOutAction}>
+      <button
+        type="submit"
+        className={cn(buttonVariants({ variant: 'ghost', size: 'icon' }))}
+        aria-label="Sign out"
+        title="Sign out"
+      >
+        <LogOut className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </form>
+  );
+}

--- a/components/dashboard/signout-button.tsx
+++ b/components/dashboard/signout-button.tsx
@@ -5,7 +5,10 @@ import { signOutAction } from '@/app/signout/actions';
 // inlined rather than pulled from `buttonVariants()` because the button
 // primitive is marked `"use client"`, and importing a client helper into a
 // server component trips a Turbopack resolver bug under dev HMR. The class
-// string here mirrors `buttonVariants({ variant: "ghost", size: "icon" })`.
+// string here is a hand-maintained approximation of
+// `buttonVariants({ variant: "ghost", size: "icon" })` — it intentionally
+// omits a few rarely-triggered states (e.g. `aria-invalid:*`,
+// `aria-expanded:*`) that don't apply to this icon-only sign-out control.
 const BUTTON_CLASSES = [
   'group/button inline-flex shrink-0 cursor-pointer items-center justify-center',
   'rounded-lg border border-transparent bg-clip-padding text-sm font-medium',

--- a/components/dashboard/signout-button.tsx
+++ b/components/dashboard/signout-button.tsx
@@ -1,16 +1,28 @@
-'use client';
-
 import { LogOut } from 'lucide-react';
 import { signOutAction } from '@/app/signout/actions';
-import { buttonVariants } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+
+// Server Component — pure markup + server-action form. Tailwind classes are
+// inlined rather than pulled from `buttonVariants()` because the button
+// primitive is marked `"use client"`, and importing a client helper into a
+// server component trips a Turbopack resolver bug under dev HMR. The class
+// string here mirrors `buttonVariants({ variant: "ghost", size: "icon" })`.
+const BUTTON_CLASSES = [
+  'group/button inline-flex shrink-0 cursor-pointer items-center justify-center',
+  'rounded-lg border border-transparent bg-clip-padding text-sm font-medium',
+  'whitespace-nowrap transition-all outline-none select-none',
+  'focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50',
+  'active:translate-y-px disabled:pointer-events-none disabled:opacity-50',
+  'hover:bg-muted hover:text-foreground dark:hover:bg-muted/50',
+  'size-8',
+  '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+].join(' ');
 
 export function SignOutButton() {
   return (
     <form action={signOutAction}>
       <button
         type="submit"
-        className={cn(buttonVariants({ variant: 'ghost', size: 'icon' }))}
+        className={BUTTON_CLASSES}
         aria-label="Sign out"
         title="Sign out"
       >

--- a/lib/auth/backend-fetch.ts
+++ b/lib/auth/backend-fetch.ts
@@ -12,6 +12,7 @@ import {
 import { readJwtExpSecs } from "@/lib/auth/jwt-exp";
 import { refreshTokens, RefreshFailedError } from "@/lib/auth/refresh";
 import { getServerToken } from "@/lib/auth/server-token";
+import { isTransportError } from "@/lib/auth/transport-error";
 
 export type BackendUnauthorizedReason =
   | "no_session"
@@ -99,27 +100,6 @@ async function forceJwtRefresh(current: JWT): Promise<JWT> {
 interface ResolvedRequest {
   url: string;
   init: RequestInit;
-}
-
-/**
- * Classify an unknown error thrown from `fetch()` / `executeWithRetry` as a
- * recoverable transport failure vs. a programmer/configuration bug we must
- * fail loudly on.
- *
- * - `TypeError`        → fetch network failure (DNS, connection reset, CORS)
- * - `AbortError`       → `AbortSignal.timeout(...)` fired or caller aborted
- * - `TimeoutError`     → some runtimes throw this name instead of AbortError
- *
- * Anything else (e.g. `getAuthSecret()` throwing on missing env var, or a
- * genuine programming error) propagates so the operator sees the real cause
- * rather than a silent `{ ok: false }` / `{ success: false }` result.
- */
-function isTransportError(err: unknown): boolean {
-  if (err instanceof TypeError) return true;
-  if (err instanceof Error) {
-    return err.name === "AbortError" || err.name === "TimeoutError";
-  }
-  return false;
 }
 
 /**

--- a/lib/auth/logout.ts
+++ b/lib/auth/logout.ts
@@ -1,0 +1,49 @@
+import { getBackendUrl } from "@/lib/config";
+import { MUTATION_TIMEOUT_MS } from "@/lib/http";
+
+export class LogoutFailedError extends Error {
+  constructor() {
+    super("logout failed");
+    this.name = "LogoutFailedError";
+  }
+}
+
+/**
+ * Revoke the refresh-token family bound to the supplied token.
+ *
+ * The backend (`POST /api/auth/logout`) always returns 204, even when the
+ * token is unknown or the body is malformed — logout cannot be used as an
+ * oracle to probe token validity. Callers treat this as fire-and-forget and
+ * always clear the session cookie regardless of the outcome.
+ *
+ * - 204                → resolves `void`.
+ * - Any other status   → throws `LogoutFailedError`.
+ * - Transport failure  → resolves `void` (fail-open; a dead backend must not
+ *                        trap the user in a signed-in UI state).
+ * - Empty token        → throws `LogoutFailedError` without touching the
+ *                        network.
+ */
+export async function revokeRefreshFamily(
+  refreshToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  if (!refreshToken) {
+    throw new LogoutFailedError();
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${getBackendUrl()}/api/auth/logout`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+      signal: AbortSignal.timeout(MUTATION_TIMEOUT_MS),
+    });
+  } catch {
+    return;
+  }
+
+  if (res.status !== 204) {
+    throw new LogoutFailedError();
+  }
+}

--- a/lib/auth/logout.ts
+++ b/lib/auth/logout.ts
@@ -1,29 +1,12 @@
 import { getBackendUrl } from "@/lib/config";
 import { MUTATION_TIMEOUT_MS } from "@/lib/http";
+import { isTransportError } from "@/lib/auth/transport-error";
 
 export class LogoutFailedError extends Error {
   constructor() {
     super("logout failed");
     this.name = "LogoutFailedError";
   }
-}
-
-/**
- * Classify an error thrown from `fetch()` as a recoverable transport failure
- * (dead backend, DNS, timeout) vs. a programmer/configuration bug. Mirrors the
- * same narrowing used by `lib/auth/backend-fetch.ts` so logout fails open for
- * network issues but still surfaces genuine bugs.
- *
- * - `TypeError`    → fetch network failure (DNS, connection reset, CORS)
- * - `AbortError`   → `AbortSignal.timeout(...)` fired or caller aborted
- * - `TimeoutError` → some runtimes throw this name instead of AbortError
- */
-function isTransportError(err: unknown): boolean {
-  if (err instanceof TypeError) return true;
-  if (err instanceof Error) {
-    return err.name === "AbortError" || err.name === "TimeoutError";
-  }
-  return false;
 }
 
 /**

--- a/lib/auth/logout.ts
+++ b/lib/auth/logout.ts
@@ -9,6 +9,24 @@ export class LogoutFailedError extends Error {
 }
 
 /**
+ * Classify an error thrown from `fetch()` as a recoverable transport failure
+ * (dead backend, DNS, timeout) vs. a programmer/configuration bug. Mirrors the
+ * same narrowing used by `lib/auth/backend-fetch.ts` so logout fails open for
+ * network issues but still surfaces genuine bugs.
+ *
+ * - `TypeError`    → fetch network failure (DNS, connection reset, CORS)
+ * - `AbortError`   → `AbortSignal.timeout(...)` fired or caller aborted
+ * - `TimeoutError` → some runtimes throw this name instead of AbortError
+ */
+function isTransportError(err: unknown): boolean {
+  if (err instanceof TypeError) return true;
+  if (err instanceof Error) {
+    return err.name === "AbortError" || err.name === "TimeoutError";
+  }
+  return false;
+}
+
+/**
  * Revoke the refresh-token family bound to the supplied token.
  *
  * The backend (`POST /api/auth/logout`) always returns 204, even when the
@@ -19,7 +37,10 @@ export class LogoutFailedError extends Error {
  * - 204                → resolves `void`.
  * - Any other status   → throws `LogoutFailedError`.
  * - Transport failure  → resolves `void` (fail-open; a dead backend must not
- *                        trap the user in a signed-in UI state).
+ *                        trap the user in a signed-in UI state). Only
+ *                        `TypeError` / `AbortError` / `TimeoutError` are
+ *                        treated as transport failures — anything else
+ *                        propagates so real bugs surface.
  * - Empty token        → throws `LogoutFailedError` without touching the
  *                        network.
  */
@@ -39,7 +60,8 @@ export async function revokeRefreshFamily(
       body: JSON.stringify({ refreshToken }),
       signal: AbortSignal.timeout(MUTATION_TIMEOUT_MS),
     });
-  } catch {
+  } catch (err) {
+    if (!isTransportError(err)) throw err;
     return;
   }
 

--- a/lib/auth/transport-error.ts
+++ b/lib/auth/transport-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Classify an unknown error thrown from `fetch()` as a recoverable transport
+ * failure (dead backend, DNS, timeout) vs. a programmer/configuration bug we
+ * must fail loudly on. Shared between `backend-fetch.ts` and `logout.ts` so
+ * the two call sites can't drift when new runtime error names appear.
+ *
+ * - `TypeError`    → fetch network failure (DNS, connection reset, CORS)
+ * - `AbortError`   → `AbortSignal.timeout(...)` fired or caller aborted
+ * - `TimeoutError` → some runtimes throw this name instead of AbortError
+ *
+ * Anything else (e.g. `getAuthSecret()` throwing on a missing env var, or a
+ * genuine programming error) should propagate so the operator sees the real
+ * cause rather than a silent fallback.
+ */
+export function isTransportError(err: unknown): boolean {
+  if (err instanceof TypeError) return true;
+  if (err instanceof Error) {
+    return err.name === "AbortError" || err.name === "TimeoutError";
+  }
+  return false;
+}

--- a/tests/unit/logout.test.ts
+++ b/tests/unit/logout.test.ts
@@ -64,6 +64,25 @@ describe("revokeRefreshFamily", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("propagates non-transport errors (e.g. programming bugs) instead of swallowing them", async () => {
+    const bug = new RangeError("invalid config");
+    const fetchImpl = vi.fn(async () => {
+      throw bug;
+    }) as unknown as typeof fetch;
+    await expect(revokeRefreshFamily("any", fetchImpl)).rejects.toBe(bug);
+  });
+
+  it("resolves on AbortError (timeout) as a transport failure", async () => {
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    const fetchImpl = vi.fn(async () => {
+      throw abort;
+    }) as unknown as typeof fetch;
+    await expect(
+      revokeRefreshFamily("any", fetchImpl),
+    ).resolves.toBeUndefined();
+  });
+
   it("rejects empty refresh token without calling the backend", async () => {
     const fetchImpl = vi.fn() as unknown as typeof fetch;
     await expect(

--- a/tests/unit/logout.test.ts
+++ b/tests/unit/logout.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LogoutFailedError, revokeRefreshFamily } from "@/lib/auth/logout";
+
+beforeEach(() => {
+  process.env.BACKEND_URL = "http://backend.test";
+});
+
+afterEach(() => {
+  delete process.env.BACKEND_URL;
+});
+
+function mockFetch(response: Partial<Response>): typeof fetch {
+  return vi.fn(async () => response as Response) as unknown as typeof fetch;
+}
+
+describe("revokeRefreshFamily", () => {
+  it("resolves to void on 204", async () => {
+    const fetchImpl = mockFetch({ status: 204 });
+    await expect(
+      revokeRefreshFamily("r-token", fetchImpl),
+    ).resolves.toBeUndefined();
+  });
+
+  it("posts refreshToken in JSON body without HMAC headers", async () => {
+    const fetchImpl = vi.fn(
+      async () => ({ status: 204 }) as Response,
+    ) as unknown as typeof fetch;
+
+    await revokeRefreshFamily("r-token", fetchImpl);
+
+    const [url, init] = (
+      fetchImpl as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://backend.test/api/auth/logout");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["X-Signature"]).toBeUndefined();
+    expect(headers["X-Timestamp"]).toBeUndefined();
+    expect(init.body).toBe(JSON.stringify({ refreshToken: "r-token" }));
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("throws LogoutFailedError on 401", async () => {
+    const fetchImpl = mockFetch({ status: 401 });
+    await expect(
+      revokeRefreshFamily("bad", fetchImpl),
+    ).rejects.toBeInstanceOf(LogoutFailedError);
+  });
+
+  it("throws LogoutFailedError on 500", async () => {
+    const fetchImpl = mockFetch({ status: 500 });
+    await expect(
+      revokeRefreshFamily("bad", fetchImpl),
+    ).rejects.toBeInstanceOf(LogoutFailedError);
+  });
+
+  it("resolves on transport/network failure (fail-open)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("network");
+    }) as unknown as typeof fetch;
+    await expect(
+      revokeRefreshFamily("any", fetchImpl),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects empty refresh token without calling the backend", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    await expect(
+      revokeRefreshFamily("", fetchImpl),
+    ).rejects.toBeInstanceOf(LogoutFailedError);
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ).toHaveLength(0);
+  });
+});

--- a/tests/unit/signout-action.test.ts
+++ b/tests/unit/signout-action.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getServerTokenMock, revokeMock, signOutMock, redirectMock } =
+  vi.hoisted(() => ({
+    getServerTokenMock: vi.fn(),
+    revokeMock: vi.fn(),
+    signOutMock: vi.fn(),
+    redirectMock: vi.fn((): never => {
+      const err = new Error("NEXT_REDIRECT");
+      (err as Error & { digest?: string }).digest = "NEXT_REDIRECT";
+      throw err;
+    }),
+  }));
+
+vi.mock("@/lib/auth/server-token", () => ({
+  getServerToken: getServerTokenMock,
+}));
+
+vi.mock("@/lib/auth/logout", () => ({
+  revokeRefreshFamily: revokeMock,
+  LogoutFailedError: class LogoutFailedError extends Error {},
+}));
+
+vi.mock("@/auth", () => ({
+  signOut: signOutMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+import { signOutAction } from "@/app/signout/actions";
+
+beforeEach(() => {
+  getServerTokenMock.mockReset();
+  revokeMock.mockReset();
+  signOutMock.mockReset();
+  redirectMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("signOutAction", () => {
+  it("revokes the refresh family, clears the cookie, and redirects to /signin", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "a",
+      refreshToken: "r",
+    });
+    revokeMock.mockResolvedValueOnce(undefined);
+    signOutMock.mockResolvedValueOnce(undefined);
+
+    await expect(signOutAction()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(revokeMock).toHaveBeenCalledWith("r");
+    expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    expect(redirectMock).toHaveBeenCalledWith("/signin");
+  });
+
+  it("skips revoke when no refresh token is present but still signs out", async () => {
+    getServerTokenMock.mockResolvedValueOnce(null);
+    signOutMock.mockResolvedValueOnce(undefined);
+
+    await expect(signOutAction()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(revokeMock).not.toHaveBeenCalled();
+    expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    expect(redirectMock).toHaveBeenCalledWith("/signin");
+  });
+
+  it("skips revoke when token is present but has no refreshToken field", async () => {
+    getServerTokenMock.mockResolvedValueOnce({ accessToken: "a" });
+    signOutMock.mockResolvedValueOnce(undefined);
+
+    await expect(signOutAction()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(revokeMock).not.toHaveBeenCalled();
+    expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+  });
+
+  it("still clears the cookie and redirects when revoke throws (fail-open)", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "a",
+      refreshToken: "r",
+    });
+    revokeMock.mockRejectedValueOnce(new Error("boom"));
+    signOutMock.mockResolvedValueOnce(undefined);
+
+    await expect(signOutAction()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(revokeMock).toHaveBeenCalledWith("r");
+    expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    expect(redirectMock).toHaveBeenCalledWith("/signin");
+  });
+
+  it("still redirects when getServerToken throws", async () => {
+    getServerTokenMock.mockRejectedValueOnce(new Error("cookie store boom"));
+    signOutMock.mockResolvedValueOnce(undefined);
+
+    await expect(signOutAction()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(revokeMock).not.toHaveBeenCalled();
+    expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    expect(redirectMock).toHaveBeenCalledWith("/signin");
+  });
+});

--- a/tests/unit/signout-action.test.ts
+++ b/tests/unit/signout-action.test.ts
@@ -94,6 +94,20 @@ describe("signOutAction", () => {
     expect(redirectMock).toHaveBeenCalledWith("/signin");
   });
 
+  it("still redirects when signOut throws (fail-open)", async () => {
+    getServerTokenMock.mockResolvedValueOnce({
+      accessToken: "a",
+      refreshToken: "r",
+    });
+    revokeMock.mockResolvedValueOnce(undefined);
+    signOutMock.mockRejectedValueOnce(new Error("cookie mutate boom"));
+
+    await expect(signOutAction()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    expect(redirectMock).toHaveBeenCalledWith("/signin");
+  });
+
   it("still redirects when getServerToken throws", async () => {
     getServerTokenMock.mockRejectedValueOnce(new Error("cookie store boom"));
     signOutMock.mockResolvedValueOnce(undefined);


### PR DESCRIPTION
## Summary

Plan-3 / FE-5: the sign-out UI now reaches the backend. Before this, `signOut()` only cleared the local NextAuth cookie, leaving the refresh-token family alive on the BE until TTL.

- `lib/auth/logout.ts` — typed `revokeRefreshFamily(refreshToken)` client for `POST /api/auth/logout`. 204 resolves void, non-204 throws `LogoutFailedError`, transport failures swallow (fail-open), empty token rejects without a network call.
- `app/signout/actions.ts` — `signOutAction()` server action: best-effort revoke → `signOut({ redirect: false })` → `redirect('/signin')`. Cookie clear + redirect always run, even when revoke or cookie read throws — dead backend must not trap the user in a signed-in UI state.
- `components/dashboard/signout-button.tsx` — icon-only ghost button matching `ThemeToggle`'s size/variant, wrapping `<form action={signOutAction}>`. Surfaced in the dashboard header and admin nav.

## Test plan

- [x] `npm test` — 209 unit tests pass (11 new across `logout.test.ts` + `signout-action.test.ts`).
- [x] `npm run build` — compiles cleanly.
- [x] Visual check in light + dark on `/` with a live backend — sign-out icon renders in the header cluster, 32×32, tokens switch with theme. Screenshots saved to the vault: `wiki/poolpay/frontend/fe-5-logout-visual.md`.
- [ ] Manual end-to-end: sign in, click sign-out, confirm redirect to `/signin` and BE logs `logout` event for the family.

## Notes

- Fail-open on backend revoke failure is intentional; the refresh family will expire at TTL regardless. Revisit once we have server-side error telemetry.
- Prep note: `wiki/poolpay/frontend/fe-5-logout-prep.md`. BE contract: `wiki/poolpay/architecture/auth-api-contract.md` §`POST /api/auth/logout`.