### PR TITLE
chore: resolve tsc and eslint errors on main

### DIFF
--- a/lib/auth/auth-config.ts
+++ b/lib/auth/auth-config.ts
@@ -10,7 +10,7 @@
 const SECURE_COOKIE_NAME = "__Secure-authjs.session-token";
 const INSECURE_COOKIE_NAME = "authjs.session-token";
 
-function useSecureCookies(): boolean {
+function shouldUseSecureCookies(): boolean {
   const url = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL;
   if (url) return url.startsWith("https://");
   return process.env.NODE_ENV === "production";
@@ -24,7 +24,7 @@ function useSecureCookies(): boolean {
  * encryption salt, so `encode()` / `decode()` callers must use this helper.
  */
 export function sessionCookieName(): string {
-  return useSecureCookies() ? SECURE_COOKIE_NAME : INSECURE_COOKIE_NAME;
+  return shouldUseSecureCookies() ? SECURE_COOKIE_NAME : INSECURE_COOKIE_NAME;
 }
 
 /**

--- a/tests/unit/auth-config.test.ts
+++ b/tests/unit/auth-config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getAuthSecret,
   isSecureSessionCookie,
@@ -13,12 +13,12 @@ const AUTHJS_SECURE_SESSION_COOKIE = "__Secure-authjs.session-token";
 
 // Keys this suite mutates — restored per-key in afterEach rather than
 // reassigning process.env (which swaps Node's special env proxy).
+// NODE_ENV is managed via vi.stubEnv because TS types it as read-only.
 const MANAGED_ENV_KEYS = [
   "AUTH_URL",
   "NEXTAUTH_URL",
   "NEXTAUTH_SECRET",
   "AUTH_SECRET",
-  "NODE_ENV",
 ] as const;
 const originalEnv: Record<string, string | undefined> = Object.fromEntries(
   MANAGED_ENV_KEYS.map((k) => [k, process.env[k]]),
@@ -29,10 +29,11 @@ beforeEach(() => {
   delete process.env.NEXTAUTH_URL;
   delete process.env.NEXTAUTH_SECRET;
   delete process.env.AUTH_SECRET;
-  process.env.NODE_ENV = "test";
+  vi.stubEnv("NODE_ENV", "test");
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   for (const key of MANAGED_ENV_KEYS) {
     const original = originalEnv[key];
     if (original === undefined) {
@@ -65,7 +66,7 @@ describe("sessionCookieName", () => {
   });
 
   it("falls back to NODE_ENV=production when no URL is set", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     expect(sessionCookieName()).toBe("__Secure-authjs.session-token");
   });
 });

--- a/tests/unit/backend-fetch.test.ts
+++ b/tests/unit/backend-fetch.test.ts
@@ -54,7 +54,7 @@ const originalEnv = { ...process.env };
 beforeEach(() => {
   process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
   process.env.BACKEND_URL = "http://backend.test";
-  process.env.NODE_ENV = "test";
+  vi.stubEnv("NODE_ENV", "test");
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
   fetchMock.mockReset();
   cookieStore.get.mockReset();
@@ -66,6 +66,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   process.env = { ...originalEnv };
   vi.unstubAllGlobals();
   vi.restoreAllMocks();

--- a/tests/unit/server-token.test.ts
+++ b/tests/unit/server-token.test.ts
@@ -21,10 +21,10 @@ import {
 
 // Keys this suite mutates — restored per-key in afterEach rather than
 // reassigning process.env (which swaps Node's special env proxy).
+// NODE_ENV is managed via vi.stubEnv because TS types it as read-only.
 const MANAGED_ENV_KEYS = [
   "NEXTAUTH_SECRET",
   "AUTH_SECRET",
-  "NODE_ENV",
   "AUTH_URL",
   "NEXTAUTH_URL",
 ] as const;
@@ -34,7 +34,7 @@ const originalEnv: Record<string, string | undefined> = Object.fromEntries(
 
 beforeEach(() => {
   process.env.NEXTAUTH_SECRET = "test-secret-0123456789abcdef0123456789abcdef";
-  process.env.NODE_ENV = "test";
+  vi.stubEnv("NODE_ENV", "test");
   delete process.env.AUTH_URL;
   delete process.env.NEXTAUTH_URL;
   cookieStore.get.mockReset();
@@ -42,6 +42,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   for (const key of MANAGED_ENV_KEYS) {
     const original = originalEnv[key];
     if (original === undefined) {
@@ -64,7 +65,7 @@ describe("sessionCookieName", () => {
   });
 
   it("returns secure name in production without explicit URL", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     expect(sessionCookieName()).toBe("__Secure-authjs.session-token");
   });
 });


### PR DESCRIPTION
## Summary

Clears the 7 TS + 1 ESLint errors that have been sitting on `main` since before the brand work (deferred out of PR #26 to keep that scoped to the logo). No behaviour change — the tests and `auth-config` helper behave identically at runtime.

## Before

```
$ npx tsc --noEmit
tests/unit/auth-config.test.ts(32,15): error TS2540: Cannot assign to 'NODE_ENV'…
tests/unit/auth-config.test.ts(41,19): error TS2540: …
tests/unit/auth-config.test.ts(68,17): error TS2540: …
tests/unit/backend-fetch.test.ts(57,15): error TS2540: …
tests/unit/server-token.test.ts(37,15): error TS2540: …
tests/unit/server-token.test.ts(50,19): error TS2540: …
tests/unit/server-token.test.ts(67,17): error TS2540: …

$ npx eslint .
lib/auth/auth-config.ts
  27:10  error  React Hook "useSecureCookies" is called in function "sessionCookieName"…
```

## After

```
$ npx tsc --noEmit
(clean)

$ npx eslint .
(clean)

$ npx vitest run
 Test Files  19 passed (19)
      Tests  216 passed (216)
```

## Changes

**7× TS2540 on `NODE_ENV` reassignment** — Next's env types declare `NODE_ENV: 'development' | 'production' | 'test'` as read-only. Tests were reassigning `process.env.NODE_ENV` directly, which is type-invalid even though runtime accepts it. Swapped for vitest's `vi.stubEnv("NODE_ENV", …)` + `vi.unstubAllEnvs()` — the tool-blessed API that handles both type safety and cleanup.

Files: `tests/unit/auth-config.test.ts`, `tests/unit/backend-fetch.test.ts`, `tests/unit/server-token.test.ts`

**1× react-hooks/rules-of-hooks** — The private predicate `useSecureCookies()` in `lib/auth/auth-config.ts:13` was flagged because the `use*` prefix tripped the linter into treating it as a React hook called from non-hook code. It's a server-only helper with a single call site, so renamed to `shouldUseSecureCookies()` — reads more naturally as a predicate, no suppression comment needed.

## Test plan

- [x] `npx tsc --noEmit` → clean
- [x] `npx eslint .` → clean
- [x] `npx vitest run` → 216/216 passing
- [x] No behaviour change (rename + stubEnv are pure mechanical swaps)