### PR TITLE
[REFACTOR] Rename change-password `network-error` status kind to `submit-error`

### DIFF
--- a/app/(app)/account/change-password/change-password-form.tsx
+++ b/app/(app)/account/change-password/change-password-form.tsx
@@ -84,7 +84,7 @@ export function ChangePasswordForm() {
       // means `BackendUnauthorizedError` bubbled out (no_session or
       // refresh_failed) — the user's session is truly invalid. Redirect
       // straight to `/signin?reauth=1` without setting a transient status,
-      // so no misleading network-error copy flashes before navigation.
+      // so no misleading submit-error copy flashes before navigation.
       router.replace("/signin?reauth=1");
       return;
     }
@@ -220,7 +220,7 @@ function StatusAlert({
     );
   }
 
-  if (status.kind === "network-error") {
+  if (status.kind === "submit-error") {
     return (
       <Alert variant="destructive">
         <AlertCircle />

--- a/app/(app)/account/change-password/status-machine.ts
+++ b/app/(app)/account/change-password/status-machine.ts
@@ -3,7 +3,7 @@
  *
  * rhf owns field-level validity (zod resolver). This union owns the
  * submission lifecycle: idle → submitting → (auth-error | rate-limited |
- * network-error). On success the form navigates straight to /signin, so
+ * submit-error). On success the form navigates straight to /signin, so
  * there's no intra-page success state.
  *
  * Mirrors the discriminated-union pattern from `app/signin/status-machine.ts`.
@@ -14,7 +14,7 @@ export type Status =
   | { kind: "submitting" }
   | { kind: "auth-error"; message: string }
   | { kind: "rate-limited"; retryAfterSecs: number | null }
-  | { kind: "network-error"; message: string };
+  | { kind: "submit-error"; message: string };
 
 export type ActionErrorCode =
   | "bad_current"
@@ -56,11 +56,11 @@ export function statusFromActionError(
     case "rate_limited":
       return { kind: "rate-limited", retryAfterSecs };
     case "validation":
-      return { kind: "network-error", message: VALIDATION_ERROR_MESSAGE };
+      return { kind: "submit-error", message: VALIDATION_ERROR_MESSAGE };
     case "service":
-      return { kind: "network-error", message: SERVICE_ERROR_MESSAGE };
+      return { kind: "submit-error", message: SERVICE_ERROR_MESSAGE };
     case "backend_unavailable":
     default:
-      return { kind: "network-error", message: NETWORK_ERROR_MESSAGE };
+      return { kind: "submit-error", message: NETWORK_ERROR_MESSAGE };
   }
 }

--- a/tests/unit/change-password-status-machine.test.ts
+++ b/tests/unit/change-password-status-machine.test.ts
@@ -45,26 +45,26 @@ describe("statusFromActionError", () => {
     expect(status).toEqual({ kind: "rate-limited", retryAfterSecs: null });
   });
 
-  it("maps backend_unavailable to network-error", () => {
+  it("maps backend_unavailable to submit-error", () => {
     const status = statusFromActionError("backend_unavailable");
     expect(status).toEqual({
-      kind: "network-error",
+      kind: "submit-error",
       message: NETWORK_ERROR_MESSAGE,
     });
   });
 
-  it("maps validation drift to network-error with validation copy", () => {
+  it("maps validation drift to submit-error with validation copy", () => {
     const status = statusFromActionError("validation");
     expect(status).toEqual({
-      kind: "network-error",
+      kind: "submit-error",
       message: VALIDATION_ERROR_MESSAGE,
     });
   });
 
-  it("maps service errors to network-error with service copy", () => {
+  it("maps service errors to submit-error with service copy", () => {
     const status = statusFromActionError("service");
     expect(status).toEqual({
-      kind: "network-error",
+      kind: "submit-error",
       message: SERVICE_ERROR_MESSAGE,
     });
   });


### PR DESCRIPTION
## Summary

Renames the `network-error` status kind to `submit-error` in the change-password surface. Closes #42.

The kind was carrying three failure classes — only one (`backend_unavailable`) is genuinely transport-level. `validation` and `service` both succeeded at the network layer and only failed downstream. The new name describes the shared trait (the submission failed) without misnaming the cause.

Pure naming refactor — no behaviour change, no copy change, same alert renders under the same conditions.

## Scope

- `app/(app)/account/change-password/status-machine.ts` — union member, `statusFromActionError` mappings, doc comment
- `app/(app)/account/change-password/change-password-form.tsx` — `StatusAlert` branch, one inline comment referencing the old name
- `tests/unit/change-password-status-machine.test.ts` — three assertions on the kind string

13 insertions, 13 deletions.

### Out of scope

Per the issue's "while here, consider" notes:

- Splitting into `{ kind: "submit-error"; cause: "transport" | "validation" | "service" }` — held back; current copy already varies via `message`.
- Same rename on `app/signin/status-machine.ts` — held back as a separate ticket; `/signin` and change-password should be renamed together but that's a wider diff than `size: s`.

## Test plan

- [x] `npm test` — 27 files, 314 tests pass
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: trigger each failure path on `/account/change-password` (bad current password, rate-limit, 5xx) and confirm the same alert copy renders as before