### PR TITLE
[FIX] Match PWA `themeColor` to rendered `--background` hex

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,9 +18,13 @@ const siteUrl =
   (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
 
 export const viewport: Viewport = {
+  // sRGB hex of the rendered `--background` token in app/globals.css —
+  // measured via canvas from the live `lab()` computed style. Matching the
+  // mobile browser status bar to the page background prevents a thin seam
+  // on OLED dark mode. If those tokens change, re-measure and update here.
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+    { media: "(prefers-color-scheme: light)", color: "#fafcfe" },
+    { media: "(prefers-color-scheme: dark)", color: "#05080a" },
   ],
 };
 


### PR DESCRIPTION
## Summary

Closes #30. The PWA `viewport.themeColor` was hand-set to `#ffffff` / `#0a0a0a` in #29 but the rendered body background is `oklch(0.99 0.003 240)` / `oklch(0.13 0.008 240)` — the delta showed up as a thin colour seam between the mobile browser status bar and the page on OLED dark mode.

New values are measured empirically from the live `lab()` computed style via canvas, so they reflect what the browser actually paints rather than a manual conversion.

## What changed

```diff
 export const viewport: Viewport = {
+  // sRGB hex of the rendered `--background` token in app/globals.css —
+  // measured via canvas from the live `lab()` computed style. ...
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+    { media: "(prefers-color-scheme: light)", color: "#fafcfe" },
+    { media: "(prefers-color-scheme: dark)", color: "#05080a" },
   ],
 };
```

## Why these specific hex values

| Scheme | Rendered `lab()` | Measured sRGB | Old (#29) | Issue's suggestion | This PR |
|---|---|---|---|---|---|
| Light | `lab(98.85% -0.50 -0.99)` | `rgb(250, 252, 254)` | `#ffffff` | `#fbfcfd` | `#fafcfe` |
| Dark  | `lab(1.99% -0.46 -1.13)`  | `rgb(5, 8, 10)`     | `#0a0a0a` | `#040506` | `#05080a` |

The issue's documented hex values (`#fbfcfd` / `#040506`) were close but ~1-4 RGB units off the actual canvas-converted sRGB. The dark-mode delta is the more material one. Using the empirical values closes the seam more cleanly.

## Approach

Per the issue's options list, this is **option 1 (hand-match)** with a pointer comment in `layout.tsx` noting the dependency on `--background`. Option 2 (extract to TS constants) was considered but doesn't actually create a single source of truth — the CSS would still hold the canonical `oklch()` and the TS module would still need hand-matched hex. Not worth the indirection for two values.

If `--background` ever changes, re-measure (boot dev server, inspect computed `body` background via canvas) and update.

## Test plan

- [x] `npm test` — 27 files, 314 tests pass
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Verified emitted meta tags via curl on `/signin` after restart:
  - `<meta name="theme-color" media="(prefers-color-scheme: light)" content="#fafcfe"/>`
  - `<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#05080a"/>`
- [ ] Manual: side-load on an OLED Android device in dark mode, confirm seam between status bar and page is gone (per the issue's own verification suggestion — needs hardware I don't have here)

## Note on screenshots

This is an invisible change in standard screenshots — `theme-color` only paints the mobile browser chrome (status bar, address bar background). Skipping inline screenshots since they would only show the unchanged page render; the empirical measurement table above is the real evidence.