### PR TITLE
[STYLE] - Restore receipts gradient and align super-admin backgrounds

### DIFF
--- a/app/(app)/account/_components/identity-strip.tsx
+++ b/app/(app)/account/_components/identity-strip.tsx
@@ -13,7 +13,7 @@ export function IdentityStrip({ email, role }: Props) {
     <div className="flex items-center gap-3 rounded-xl border border-border bg-card p-4">
       <span
         aria-hidden="true"
-        className="inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-ajo-paid-subtle font-semibold text-ajo-paid"
+        className="inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-status-paid-subtle font-semibold text-status-paid"
       >
         {initial}
       </span>

--- a/app/(app)/account/change-password/change-password-form.tsx
+++ b/app/(app)/account/change-password/change-password-form.tsx
@@ -152,7 +152,7 @@ export function ChangePasswordForm() {
           type="submit"
           size="lg"
           disabled={disabled}
-          className="bg-ajo-paid text-white hover:bg-ajo-paid/90 sm:w-auto"
+          className="bg-status-paid text-white hover:bg-status-paid/90 sm:w-auto"
         >
           {submitting ? (
             <>

--- a/app/(app)/account/change-password/password-strength-meter.tsx
+++ b/app/(app)/account/change-password/password-strength-meter.tsx
@@ -16,14 +16,14 @@ const TIER_FILL: Record<StrengthTier, number> = {
 
 const TIER_FILL_CLASS: Record<StrengthTier, string> = {
   weak: "bg-destructive",
-  ok: "bg-ajo-outstanding",
-  strong: "bg-ajo-paid",
+  ok: "bg-status-pending",
+  strong: "bg-status-paid",
 };
 
 const TIER_TEXT_CLASS: Record<StrengthTier, string> = {
   weak: "text-destructive",
-  ok: "text-ajo-outstanding",
-  strong: "text-ajo-paid",
+  ok: "text-status-pending",
+  strong: "text-status-paid",
 };
 
 type Props = {

--- a/app/(app)/admin/receipts/loading.tsx
+++ b/app/(app)/admin/receipts/loading.tsx
@@ -9,10 +9,10 @@ export default function AdminReceiptsLoading() {
       className="flex flex-col gap-4"
     >
       <header className="flex flex-col gap-1">
-        <h1 className="text-[1.5rem] font-semibold tracking-tight text-d2-ink">
+        <h1 className="text-[1.5rem] font-semibold tracking-tight text-ink">
           Receipts queue
         </h1>
-        <p className="text-[13px] text-d2-ink/55">Loading pending receipts…</p>
+        <p className="text-[13px] text-ink/55">Loading pending receipts…</p>
       </header>
       <ReceiptsSkeleton />
     </main>

--- a/app/(app)/inbox/_components/receipt-confirmed-item.tsx
+++ b/app/(app)/inbox/_components/receipt-confirmed-item.tsx
@@ -32,17 +32,17 @@ export function ReceiptConfirmedItem({ item }: ReceiptConfirmedItemProps) {
       className="flex items-start gap-3 rounded-[12px] px-4 py-3"
       style={{
         background: isUnread
-          ? 'var(--ajo-paid-subtle)'
-          : 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
-        border: '1px solid color-mix(in oklch, var(--ajo-paid) 25%, transparent)',
+          ? 'var(--status-paid-subtle)'
+          : 'color-mix(in oklch, var(--ink) 3%, transparent)',
+        border: '1px solid color-mix(in oklch, var(--status-paid) 25%, transparent)',
       }}
     >
       <span
         aria-hidden="true"
         className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px]"
         style={{
-          background: 'var(--ajo-paid-subtle)',
-          color: 'var(--ajo-paid)',
+          background: 'var(--status-paid-subtle)',
+          color: 'var(--status-paid)',
         }}
       >
         <CheckCircle2 size={16} />
@@ -51,8 +51,8 @@ export function ReceiptConfirmedItem({ item }: ReceiptConfirmedItemProps) {
         <h3
           className={
             isUnread
-              ? 'truncate text-[14px] font-semibold text-d2-ink'
-              : 'truncate text-[14px] font-medium text-d2-ink'
+              ? 'truncate text-[14px] font-semibold text-ink'
+              : 'truncate text-[14px] font-medium text-ink'
           }
         >
           {/* React escapes title + body by default, see the comment in
@@ -60,7 +60,7 @@ export function ReceiptConfirmedItem({ item }: ReceiptConfirmedItemProps) {
               anywhere in this tree. */}
           {item.title}
         </h3>
-        <p className="mt-0.5 whitespace-pre-line break-words text-[12.5px] text-d2-ink/65">
+        <p className="mt-0.5 whitespace-pre-line break-words text-[12.5px] text-ink/65">
           {item.body}
         </p>
       </div>

--- a/app/(app)/pools/[poolId]/page.tsx
+++ b/app/(app)/pools/[poolId]/page.tsx
@@ -38,17 +38,17 @@ export default async function PoolDetailPage({ params }: PoolDetailPageProps) {
       >
         <h1
           id="pool-empty-title"
-          className="text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+          className="text-[1.5rem] font-semibold tracking-tight text-ink"
         >
           {group.name}
         </h1>
-        <p className="text-[13px] text-d2-ink/55">
+        <p className="text-[13px] text-ink/55">
           This pool has no active cycle. An admin will start the next cycle when
           ready.
         </p>
         <Link
           href="/home"
-          className="text-[13px] font-medium text-d2-accent"
+          className="text-[13px] font-medium text-accent-primary"
         >
           Back to home
         </Link>

--- a/app/(app)/sys/receipts/loading.tsx
+++ b/app/(app)/sys/receipts/loading.tsx
@@ -9,10 +9,10 @@ export default function SysReceiptsLoading() {
       className="flex flex-col gap-4"
     >
       <header className="flex flex-col gap-1">
-        <h1 className="text-[1.5rem] font-semibold tracking-tight text-d2-ink">
+        <h1 className="text-[1.5rem] font-semibold tracking-tight text-ink">
           Receipts (system-wide)
         </h1>
-        <p className="text-[13px] text-d2-ink/55">Loading queue…</p>
+        <p className="text-[13px] text-ink/55">Loading queue…</p>
       </header>
       <ReceiptsSkeleton />
     </main>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -61,7 +61,7 @@ export default function RootError({ error, reset }: RootErrorProps) {
       headline={
         <>
           Something on{' '}
-          <em className="not-italic text-ajo-paid">our side</em> went wrong,
+          <em className="not-italic text-status-paid">our side</em> went wrong,
           your money is safe.
         </>
       }

--- a/app/globals.css
+++ b/app/globals.css
@@ -365,9 +365,9 @@
 }
 
 /* ─── Shared design-handoff primitives ─────────────────────────────────
-   Lifted from docs/design-handoff/poolpay/shell-styles.css. Used across
-   the d2 shell + role surfaces. The selectors here are name-scoped so
-   they don't collide with shadcn primitives; consume them in JSX as
+   Lifted from the design handoff (vault). Used across the shell + role
+   surfaces. The selectors here are name-scoped so they don't collide
+   with shadcn primitives; consume them in JSX as
    `<span className="kicker-mono">` etc. */
 
 .kicker-mono {

--- a/app/globals.css
+++ b/app/globals.css
@@ -517,9 +517,9 @@
   );
 }
 
-/* Shimmer keyframes for the d2 SkeletonBlock primitive. The d2 prefix
-   keeps the keyframes from colliding with shadcn's own pulse animation
-   in components/ui/skeleton. */
+/* Shimmer keyframes for the SkeletonBlock primitive. The `surface-`
+   prefix keeps the keyframes from colliding with shadcn's own pulse
+   animation in components/ui/skeleton. */
 @keyframes surface-shimmer {
   0% {
     background-position: -200% 0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,11 +25,15 @@
   --tracking-tighter: -0.03em;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --color-ajo-paid: var(--ajo-paid);
-  --color-ajo-paid-subtle: var(--ajo-paid-subtle);
-  --color-ajo-outstanding: var(--ajo-outstanding);
-  --color-ajo-outstanding-subtle: var(--ajo-outstanding-subtle);
-  --color-ajo-active: var(--ajo-active);
+  /* Status palette, semantic ledger states. Used as `bg-status-paid`,
+     `text-status-pending`, etc. Each base tone has a `-subtle` variant
+     (~14% tint) for chip backgrounds and a `-fg` variant where needed
+     for body-copy contrast on the cream surface. */
+  --color-status-paid: var(--status-paid);
+  --color-status-paid-subtle: var(--status-paid-subtle);
+  --color-status-pending: var(--status-pending);
+  --color-status-pending-subtle: var(--status-pending-subtle);
+  --color-status-active: var(--status-active);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -64,17 +68,19 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  /* Direction-2 (consumer-fintech) accents, lifted from
-     docs/design-handoff/poolpay/shell-styles.css §"Direction 2".
-     Surfaced to Tailwind so utility classes (`bg-d2-cream`, `text-d2-ink`)
-     compose with the rest of the system. */
-  --color-d2-warm-bg: var(--d2-warm-bg);
-  --color-d2-cream: var(--d2-cream);
-  --color-d2-ink: var(--d2-ink);
-  --color-d2-accent: var(--d2-accent);
-  --color-d2-accent-soft: var(--d2-accent-soft);
-  --color-d2-coral: var(--d2-coral);
-  --color-d2-lav: var(--d2-lav);
+  /* Brand surface palette, lifted from the design handoff and surfaced to
+     Tailwind so utility classes (`bg-surface-card`, `text-ink`) compose
+     with the rest of the system. The handoff calls these "Direction 2"
+     consumer-fintech tokens; we expose them here under role-named aliases
+     (page, card, ink) so the names describe what they're for, not which
+     iteration of the design canvas they came from. */
+  --color-surface-page: var(--surface-page);
+  --color-surface-card: var(--surface-card);
+  --color-ink: var(--ink);
+  --color-accent-primary: var(--accent-primary);
+  --color-accent-primary-soft: var(--accent-primary-soft);
+  --color-accent-coral: var(--accent-coral);
+  --color-accent-lavender: var(--accent-lavender);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -111,14 +117,18 @@
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
   --radius: 0.625rem;
-  --ajo-paid: oklch(0.696 0.17 162.48);
-  --ajo-paid-subtle: oklch(0.696 0.17 162.48 / 14%);
-  --ajo-outstanding: oklch(0.769 0.188 70.08);
-  --ajo-outstanding-subtle: oklch(0.769 0.188 70.08 / 14%);
-  /* Darker amber, text-on-cream variant of --ajo-outstanding. Used where
+  /* Status palette. Maps directly to the ledger states a row can be in.
+     Naming is kept generic ("paid", "pending", "active") so the same
+     tokens work for non-rotating-savings flows that may land later. */
+  --status-paid: oklch(0.696 0.17 162.48);
+  --status-paid-subtle: oklch(0.696 0.17 162.48 / 14%);
+  --status-pending: oklch(0.769 0.188 70.08);
+  --status-pending-subtle: oklch(0.769 0.188 70.08 / 14%);
+  /* Darker amber, text-on-cream variant of --status-pending. Used where
      the chip-style foreground colour is too light for body-copy contrast. */
-  --ajo-outstanding-fg: oklch(0.5 0.14 70);
-  --ajo-active: oklch(0.696 0.17 162.48);
+  --status-pending-fg: oklch(0.5 0.14 70);
+  /* Currently in-flight cycle indicator, shares the success hue. */
+  --status-active: oklch(0.696 0.17 162.48);
   --warning: oklch(0.769 0.188 70.08);
   /* Super-admin / system brand purple. Used by the sidebar role pill and
      the System nav-section kicker; same hue drives the status-row
@@ -126,32 +136,34 @@
   --accent-violet: oklch(0.55 0.18 265);
   --accent-violet-subtle: oklch(0.55 0.18 265 / 14%);
   /* WhatsApp action green, paired to the brand glyph in the pay flow's
-     "share receipt" CTA. Distinct from --ajo-paid which is the Naira
+     "share receipt" CTA. Distinct from --status-paid which is the Naira
      payments green; keeping them split avoids drift if WhatsApp ever
      rebrands. */
   --accent-whatsapp: oklch(0.72 0.16 145);
-  /* Pool-swatch gradient end-stops, decorative variety for the 4
+  /* Pool-swatch gradient end-stops, decorative variety for the four
      deterministic pool glyph gradients in components/member/pool-swatch.
-     The start-stop is always a d2-* brand token; these supply the
-     paired terminus so the gradient reads as a tonal shift rather than
-     a brand swap. */
+     The start-stop is always a brand token (--accent-coral / --accent-
+     lavender / etc); these supply the paired terminus so the gradient
+     reads as a tonal shift rather than a brand swap. */
   --pool-swatch-teal: oklch(0.55 0.14 190);
   --pool-swatch-coral-deep: oklch(0.65 0.16 38);
   --pool-swatch-lav-deep: oklch(0.6 0.13 280);
   --pool-swatch-aqua: oklch(0.6 0.13 195);
-  /* ─── Direction-2 consumer-fintech tokens ──────────────────────────────
-     Source of truth: docs/design-handoff/poolpay/shell-styles.css.
-     The shell components (PPShell/PPSidebar/PPTopbar) consume these
-     directly; downstream consumer-fintech surfaces (member home, pool
-     detail, pay flow) read them via the d2-* Tailwind utilities mapped
-     in the @theme inline block above. */
-  --d2-warm-bg: oklch(0.98 0.01 75);
-  --d2-cream: oklch(0.97 0.012 75);
-  --d2-ink: oklch(0.18 0.02 260);
-  --d2-accent: oklch(0.62 0.14 160);
-  --d2-accent-soft: oklch(0.62 0.14 160 / 14%);
-  --d2-coral: oklch(0.72 0.13 38);
-  --d2-lav: oklch(0.76 0.08 310);
+  /* ─── Brand surface palette ────────────────────────────────────────────
+     The shell components (PPShell, PPSidebar, PPTopbar) consume these
+     directly; downstream surfaces (member home, pool detail, pay flow,
+     admin tables, super panels) read them via the Tailwind utility
+     classes (`bg-surface-card`, `text-ink`, etc) mapped in the @theme
+     block above. The `.dark` block below flips warm cream surfaces to
+     a deep blue-black and the ink colour to the warm cream so brand
+     contrast stays. */
+  --surface-page: oklch(0.98 0.01 75);  /* warm cream page background */
+  --surface-card: oklch(0.97 0.012 75); /* card / panel background */
+  --ink: oklch(0.18 0.02 260);          /* primary text / foreground */
+  --accent-primary: oklch(0.62 0.14 160);          /* brand green-teal, primary CTA */
+  --accent-primary-soft: oklch(0.62 0.14 160 / 14%); /* 14% tint for chip backgrounds */
+  --accent-coral: oklch(0.72 0.13 38);   /* warm accent, pool-swatch gradients */
+  --accent-lavender: oklch(0.76 0.08 310); /* cool accent, gradients */
   /* Status-row gradient treatment, shared across role tables.
      `--row-tone` is set per-row by `[data-tone="…"]`; the primitive lives
      under `.status-row` below. Tweak `--row-tint-a/b` to dial the
@@ -167,19 +179,19 @@
   --chart-foreground:                var(--foreground);
   --chart-foreground-muted:          var(--muted-foreground);
   --chart-label:                     var(--muted-foreground);
-  --chart-line-primary:              var(--ajo-paid);
-  --chart-line-secondary:            var(--ajo-outstanding);
+  --chart-line-primary:              var(--status-paid);
+  --chart-line-secondary:            var(--status-pending);
   --chart-crosshair:                 var(--border);
   --chart-grid:                      var(--border);
-  --chart-indicator-color:           var(--ajo-paid);
-  --chart-indicator-secondary-color: var(--ajo-outstanding);
+  --chart-indicator-color:           var(--status-paid);
+  --chart-indicator-secondary-color: var(--status-pending);
   --chart-marker-background:         var(--card);
   --chart-marker-border:             var(--border);
   --chart-marker-foreground:         var(--foreground);
   --chart-marker-badge-background:   var(--primary);
   --chart-marker-badge-foreground:   var(--primary-foreground);
-  --chart-segment-background:        var(--ajo-paid);
-  --chart-segment-line:              var(--ajo-paid);
+  --chart-segment-background:        var(--status-paid);
+  --chart-segment-line:              var(--status-paid);
   --chart-tooltip-foreground:        var(--popover-foreground);
   --chart-tooltip-muted:             var(--muted-foreground);
   --sidebar: oklch(0.985 0 0);
@@ -211,19 +223,19 @@
   --foreground: oklch(0.97 0 0);
   --card: oklch(0.175 0.008 240);
   --card-foreground: oklch(0.97 0 0);
-  /* D2 dark tokens, flip the warm cream surfaces to a deep blue-black,
-     and the ink colour to the warm cream so brand contrast stays. */
-  --d2-warm-bg: oklch(0.16 0.02 260);
-  --d2-cream: oklch(0.19 0.018 260);
-  --d2-ink: oklch(0.97 0.01 75);
+  /* Brand surface palette, dark-mode overrides. Warm cream flips to deep
+     blue-black, ink flips to warm cream so the contrast pairing stays. */
+  --surface-page: oklch(0.16 0.02 260);
+  --surface-card: oklch(0.19 0.018 260);
+  --ink: oklch(0.97 0.01 75);
   /* Dark-mode accent flips, same boost-saturation treatment used for the
      status-row tones below so tints stay legible on the deeper surface. */
   --accent-violet: oklch(0.7 0.19 265);
   --accent-violet-subtle: oklch(0.7 0.19 265 / 22%);
   --accent-whatsapp: oklch(0.78 0.17 145);
-  /* Outstanding-fg uses the lighter amber on dark so the text reads as a
+  /* Pending-fg uses the lighter amber on dark so the text reads as a
      warm accent rather than the muddier `0.5` lightness from light mode. */
-  --ajo-outstanding-fg: oklch(0.78 0.17 70);
+  --status-pending-fg: oklch(0.78 0.17 70);
   /* Pool-swatch end-stops, slight lightness lift so the gradients keep
      their tonal contrast against the dark cream surface. */
   --pool-swatch-teal: oklch(0.62 0.14 190);
@@ -336,11 +348,11 @@
   transform: translateY(0.5px);
 }
 .btn-editorial-primary {
-  background: var(--ajo-paid);
+  background: var(--status-paid);
   color: #fff;
 }
 .btn-editorial-primary:hover {
-  background: color-mix(in oklab, var(--ajo-paid) 90%, #000);
+  background: color-mix(in oklab, var(--status-paid) 90%, #000);
 }
 .btn-editorial-outline {
   background: var(--card);
@@ -380,13 +392,13 @@
   border: 1px solid var(--border);
 }
 .pill-paid {
-  color: var(--ajo-paid);
-  background: var(--ajo-paid-subtle);
+  color: var(--status-paid);
+  background: var(--status-paid-subtle);
   border-color: transparent;
 }
 .pill-out {
   color: oklch(0.55 0.14 70);
-  background: var(--ajo-outstanding-subtle);
+  background: var(--status-pending-subtle);
   border-color: transparent;
 }
 
@@ -414,7 +426,7 @@
    Tables across all roles use a left-edge gradient tint keyed by status.
    Variants are switched globally via :root[data-row-style="…"]; ship the
    "gradient" variant by default. Tone palette is pinned to the existing
-   --ajo-* + --destructive tokens so dark-mode flips automatically. */
+   --status-* + --destructive tokens so dark-mode flips automatically. */
 
 .status-row {
   position: relative;
@@ -455,17 +467,17 @@
 :root[data-row-style="none"] .status-row::before { display: none; }
 
 /* Tone palette, pinned to semantic tokens so dark-mode flips for free. */
-.status-row[data-tone="paid"]     { --row-tone: var(--ajo-paid); }
-.status-row[data-tone="pending"]  { --row-tone: var(--ajo-outstanding); }
+.status-row[data-tone="paid"]     { --row-tone: var(--status-paid); }
+.status-row[data-tone="pending"]  { --row-tone: var(--status-pending); }
 .status-row[data-tone="out"]      { --row-tone: var(--destructive); }
-.status-row[data-tone="stale"]    { --row-tone: var(--ajo-outstanding); }
-.status-row[data-tone="linked"]   { --row-tone: var(--ajo-paid); }
+.status-row[data-tone="stale"]    { --row-tone: var(--status-pending); }
+.status-row[data-tone="linked"]   { --row-tone: var(--status-paid); }
 .status-row[data-tone="unlinked"] { --row-tone: var(--destructive); }
-.status-row[data-tone="drift"]    { --row-tone: var(--ajo-outstanding); }
+.status-row[data-tone="drift"]    { --row-tone: var(--status-pending); }
 .status-row[data-tone="orphan"]   { --row-tone: var(--destructive); }
 .status-row[data-tone="inactive"] { --row-tone: oklch(0.6 0.01 250); }
 .status-row[data-tone="system"]   { --row-tone: oklch(0.55 0.18 265); }
-.status-row[data-tone="hot"]      { --row-tone: var(--ajo-outstanding); }
+.status-row[data-tone="hot"]      { --row-tone: var(--status-pending); }
 
 /* Dark mode, boost saturation slightly so tints stay legible against
    the deeper background. */
@@ -491,7 +503,7 @@
   position: relative;
   height: 5px;
   border-radius: 3px;
-  background: color-mix(in oklch, var(--d2-ink) 8%, transparent);
+  background: color-mix(in oklch, var(--ink) 8%, transparent);
   overflow: hidden;
 }
 .health-bar > span {
@@ -508,7 +520,7 @@
 /* Shimmer keyframes for the d2 SkeletonBlock primitive. The d2 prefix
    keeps the keyframes from colliding with shadcn's own pulse animation
    in components/ui/skeleton. */
-@keyframes d2-shimmer {
+@keyframes surface-shimmer {
   0% {
     background-position: -200% 0;
   }
@@ -524,7 +536,7 @@
   }
   /* Stop the shimmer for users who opt out of motion. The static gradient
      still telegraphs "loading", but without the sliding animation. */
-  span[style*="d2-shimmer"] {
+  span[style*="surface-shimmer"] {
     animation: none !important;
   }
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -21,7 +21,7 @@ export default function NotFound() {
       headline={
         <>
           We looked everywhere,{' '}
-          <em className="not-italic text-ajo-paid">
+          <em className="not-italic text-status-paid">
             this route doesn&rsquo;t exist
           </em>{' '}
           on PoolPay.

--- a/app/offline/page.tsx
+++ b/app/offline/page.tsx
@@ -27,7 +27,7 @@ export default function OfflinePage() {
       headline={
         <>
           You appear to be{' '}
-          <em className="not-italic text-ajo-paid">offline</em>, we&rsquo;ll
+          <em className="not-italic text-status-paid">offline</em>, we&rsquo;ll
           catch up when you&rsquo;re back.
         </>
       }

--- a/app/recover/page.tsx
+++ b/app/recover/page.tsx
@@ -32,12 +32,12 @@ export default function RecoverPage() {
         </div>
 
         <div className="relative z-[2] mt-auto max-w-[560px]">
-          <p className="text-ajo-paid font-mono text-[11px] uppercase tracking-[0.18em]">
+          <p className="text-status-paid font-mono text-[11px] uppercase tracking-[0.18em]">
             Reset password
           </p>
           <h2 className="mt-[18px] text-[44px] leading-[1.05] font-semibold tracking-tighter text-balance text-white lg:text-[52px] xl:text-[56px]">
             We&rsquo;ll send a code to your{" "}
-            <em className="text-ajo-paid not-italic">WhatsApp</em>.
+            <em className="text-status-paid not-italic">WhatsApp</em>.
           </h2>
           <p className="mt-[22px] max-w-[460px] text-[14px] leading-[1.55] text-white/70">
             Phone-first recovery is faster than email and matches how groups

--- a/app/recover/verify/page.tsx
+++ b/app/recover/verify/page.tsx
@@ -33,12 +33,12 @@ export default function RecoverVerifyPage() {
         </div>
 
         <div className="relative z-[2] mt-auto max-w-[560px]">
-          <p className="text-ajo-paid font-mono text-[11px] uppercase tracking-[0.18em]">
+          <p className="text-status-paid font-mono text-[11px] uppercase tracking-[0.18em]">
             Verify it&rsquo;s you
           </p>
           <h2 className="mt-[18px] text-[44px] leading-[1.05] font-semibold tracking-tighter text-balance text-white lg:text-[52px] xl:text-[56px]">
             Check your{" "}
-            <em className="text-ajo-paid not-italic">WhatsApp</em>, we just
+            <em className="text-status-paid not-italic">WhatsApp</em>, we just
             sent a 6-digit code.
           </h2>
           <p className="mt-[22px] max-w-[460px] text-[14px] leading-[1.55] text-white/70">

--- a/app/signin/signin-editorial-panel.tsx
+++ b/app/signin/signin-editorial-panel.tsx
@@ -12,7 +12,7 @@ export function SignInEditorialPanel() {
 
       <div className="relative z-[2] mt-auto max-w-[560px]">
         {/* Kicker, handoff: 11px, tracking 0.18em. We use 0.18em to match. */}
-        <p className="text-ajo-paid font-mono text-[11px] tracking-[0.18em] uppercase">
+        <p className="text-status-paid font-mono text-[11px] tracking-[0.18em] uppercase">
           A new kind of ajo
         </p>
         {/*
@@ -24,7 +24,7 @@ export function SignInEditorialPanel() {
         */}
         <h2 className="mt-[18px] text-[44px] leading-[1.05] font-semibold tracking-tighter text-balance text-white lg:text-[52px] xl:text-[56px]">
           Money you pool together{" "}
-          <em className="text-ajo-paid not-italic">should feel</em> like money
+          <em className="text-status-paid not-italic">should feel</em> like money
           you trust together.
         </h2>
         <p className="mt-[22px] max-w-[460px] text-[14px] leading-[1.55] text-white/70">

--- a/app/signin/signin-editorial-panel.tsx
+++ b/app/signin/signin-editorial-panel.tsx
@@ -85,7 +85,7 @@ export function SignInEditorialPanel() {
           fill="none"
           stroke="rgb(255 255 255 / 0.12)"
         />
-        <circle cx="360" cy="360" r="46" className="fill-ajo-paid" />
+        <circle cx="360" cy="360" r="46" className="fill-status-paid" />
       </svg>
     </aside>
   );

--- a/app/signin/signin-form.tsx
+++ b/app/signin/signin-form.tsx
@@ -28,7 +28,7 @@ import { safeCallbackUrl } from "@/lib/auth/safe-callback-url";
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const INVALID_EMAIL_MESSAGE = "Enter a valid email address (e.g. name@company.com).";
 const FOCUS_RING_OVERRIDE =
-  "focus-visible:border-ajo-paid focus-visible:ring-ajo-paid/25";
+  "focus-visible:border-status-paid focus-visible:ring-ajo-paid/25";
 const INPUT_HEIGHT = "h-10";
 
 export function SignInForm() {
@@ -249,7 +249,7 @@ export function SignInForm() {
               id="signin-remember-me"
               type="checkbox"
               disabled={formDisabled}
-              className="border-border text-ajo-paid focus-visible:ring-ajo-paid/25 size-4 rounded-[4px] border accent-[var(--ajo-paid)] focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
+              className="border-border text-status-paid focus-visible:ring-ajo-paid/25 size-4 rounded-[4px] border accent-[var(--status-paid)] focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
             />
             <label
               htmlFor="signin-remember-me"
@@ -264,7 +264,7 @@ export function SignInForm() {
           <Button
             type="submit"
             className={cn(
-              "bg-ajo-paid hover:bg-ajo-paid/90 w-full font-medium text-white",
+              "bg-status-paid hover:bg-status-paid/90 w-full font-medium text-white",
               INPUT_HEIGHT,
             )}
             disabled={formDisabled}
@@ -362,7 +362,7 @@ function StatusAlert({ status, countdown }: StatusAlertProps) {
 
   if (status.kind === "notice") {
     return (
-      <Alert className="mb-4 border-ajo-paid/25 bg-ajo-paid-subtle text-ajo-paid [&>svg]:text-ajo-paid dark:border-ajo-paid/40 dark:bg-ajo-paid/15">
+      <Alert className="mb-4 border-status-paid/25 bg-status-paid-subtle text-status-paid [&>svg]:text-status-paid dark:border-status-paid/40 dark:bg-status-paid/15">
         <CheckCircle2 />
         <AlertTitle>{status.message}</AlertTitle>
       </Alert>

--- a/app/signin/signin-form.tsx
+++ b/app/signin/signin-form.tsx
@@ -28,7 +28,7 @@ import { safeCallbackUrl } from "@/lib/auth/safe-callback-url";
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const INVALID_EMAIL_MESSAGE = "Enter a valid email address (e.g. name@company.com).";
 const FOCUS_RING_OVERRIDE =
-  "focus-visible:border-status-paid focus-visible:ring-ajo-paid/25";
+  "focus-visible:border-status-paid focus-visible:ring-status-paid/25";
 const INPUT_HEIGHT = "h-10";
 
 export function SignInForm() {
@@ -249,7 +249,7 @@ export function SignInForm() {
               id="signin-remember-me"
               type="checkbox"
               disabled={formDisabled}
-              className="border-border text-status-paid focus-visible:ring-ajo-paid/25 size-4 rounded-[4px] border accent-[var(--status-paid)] focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
+              className="border-border text-status-paid focus-visible:ring-status-paid/25 size-4 rounded-[4px] border accent-[var(--status-paid)] focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
             />
             <label
               htmlFor="signin-remember-me"

--- a/app/signup/[inviteToken]/page.tsx
+++ b/app/signup/[inviteToken]/page.tsx
@@ -32,12 +32,12 @@ export default async function SignUpInvitePage({ params }: SignUpInvitePageProps
         </div>
 
         <div className="relative z-[2] mt-auto max-w-[560px]">
-          <p className="text-ajo-paid font-mono text-[11px] uppercase tracking-[0.18em]">
+          <p className="text-status-paid font-mono text-[11px] uppercase tracking-[0.18em]">
             Invited · token {inviteToken.slice(0, 8)}
           </p>
           <h2 className="mt-[18px] text-[44px] leading-[1.05] font-semibold tracking-tighter text-balance text-white lg:text-[52px] xl:text-[56px]">
             You&rsquo;ve been invited to{" "}
-            <em className="text-ajo-paid not-italic">an ajo pool</em>, let&rsquo;s
+            <em className="text-status-paid not-italic">an ajo pool</em>, let&rsquo;s
             get you set up.
           </h2>
           <p className="mt-[22px] max-w-[460px] text-[14px] leading-[1.55] text-white/70">

--- a/components/admin/admin-empty-pill.tsx
+++ b/components/admin/admin-empty-pill.tsx
@@ -27,35 +27,35 @@ export function AdminEmptyPill({ groupCount }: AdminEmptyPillProps) {
       aria-label="Receipts queue is empty"
       className="mb-4 flex items-center gap-3 rounded-[14px] p-3"
       style={{
-        background: 'var(--ajo-paid-subtle)',
-        border: '1px solid color-mix(in oklch, var(--ajo-paid) 30%, transparent)',
+        background: 'var(--status-paid-subtle)',
+        border: '1px solid color-mix(in oklch, var(--status-paid) 30%, transparent)',
       }}
     >
       <span
         aria-hidden="true"
         className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white"
-        style={{ background: 'var(--ajo-paid)' }}
+        style={{ background: 'var(--status-paid)' }}
       >
         <Check size={15} />
       </span>
       <div className="min-w-0 flex-1">
         <div
           className="text-[14px] font-semibold"
-          style={{ color: 'var(--ajo-paid)' }}
+          style={{ color: 'var(--status-paid)' }}
         >
           Receipts queue is empty
         </div>
-        <div className="text-[12px] text-d2-ink/60">
+        <div className="text-[12px] text-ink/60">
           No pending submissions {descriptor}. You{"'"}re seeing this as a
           member now. Receipts link stays available in the sidebar.
         </div>
       </div>
       <Link
         href="/admin/receipts"
-        className="hidden shrink-0 rounded-lg border px-3 py-1.5 text-[12px] font-medium transition-colors hover:bg-d2-ink/5 sm:inline-flex"
+        className="hidden shrink-0 rounded-lg border px-3 py-1.5 text-[12px] font-medium transition-colors hover:bg-ink/5 sm:inline-flex"
         style={{
-          borderColor: 'color-mix(in oklch, var(--ajo-paid) 40%, transparent)',
-          color: 'var(--ajo-paid)',
+          borderColor: 'color-mix(in oklch, var(--status-paid) 40%, transparent)',
+          color: 'var(--status-paid)',
         }}
       >
         Confirmed history →

--- a/components/admin/group-cycles-view.tsx
+++ b/components/admin/group-cycles-view.tsx
@@ -10,16 +10,16 @@ const PILL_STYLE: Record<
   { background: string; color: string }
 > = {
   closed: {
-    background: 'var(--ajo-paid-subtle)',
-    color: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    color: 'var(--status-paid)',
   },
   open: {
-    background: 'var(--ajo-outstanding-subtle)',
-    color: 'var(--ajo-outstanding-fg)',
+    background: 'var(--status-pending-subtle)',
+    color: 'var(--status-pending-fg)',
   },
   future: {
-    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-    color: 'color-mix(in oklch, var(--d2-ink) 70%, transparent)',
+    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
+    color: 'color-mix(in oklch, var(--ink) 70%, transparent)',
   },
 };
 
@@ -48,7 +48,7 @@ export function GroupCyclesView({ rows }: GroupCyclesViewProps) {
           <h3 className="text-[15px] font-semibold tracking-tight">
             Cycles · {rows.length}
           </h3>
-          <p className="text-[12px] text-d2-ink/55">
+          <p className="text-[12px] text-ink/55">
             Weekly rotation · {counts.closed} closed, {counts.open} open,{' '}
             {counts.future} upcoming
           </p>
@@ -61,7 +61,7 @@ export function GroupCyclesView({ rows }: GroupCyclesViewProps) {
           title="Coming soon"
           className="rounded-[10px] px-3 py-1.5 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-70"
           style={{
-            background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+            background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
           }}
         >
           Edit rotation
@@ -72,16 +72,16 @@ export function GroupCyclesView({ rows }: GroupCyclesViewProps) {
         className="overflow-hidden rounded-[14px] border"
         style={{
           borderColor:
-            'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            'color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <div
           role="row"
           className="kicker-mono grid grid-cols-[60px_1.5fr_1fr_1fr_1fr_0.9fr_auto] items-center gap-3.5 px-4 py-2.5 text-[10px]"
           style={{
-            background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
+            background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
             borderBottom:
-              '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <span>Cycle</span>
@@ -98,8 +98,8 @@ export function GroupCyclesView({ rows }: GroupCyclesViewProps) {
             const pill = PILL_STYLE[row.pillLabel];
             const collectedColor =
               row.pillLabel === 'future'
-                ? 'color-mix(in oklch, var(--d2-ink) 40%, transparent)'
-                : 'var(--d2-ink)';
+                ? 'color-mix(in oklch, var(--ink) 40%, transparent)'
+                : 'var(--ink)';
             return (
               <li
                 key={`cycle-${row.cycleNumber}`}
@@ -108,10 +108,10 @@ export function GroupCyclesView({ rows }: GroupCyclesViewProps) {
                 style={{
                   borderBottom: isLast
                     ? 'none'
-                    : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                    : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
                 }}
               >
-                <span className="font-mono text-[12px] text-d2-ink/55">
+                <span className="font-mono text-[12px] text-ink/55">
                   #{row.cycleNumber}
                 </span>
                 <span
@@ -129,7 +129,7 @@ export function GroupCyclesView({ rows }: GroupCyclesViewProps) {
                 >
                   {row.collectedLabel}
                 </span>
-                <span className="font-mono text-[12px] text-d2-ink/55">
+                <span className="font-mono text-[12px] text-ink/55">
                   {row.windowLabel}
                 </span>
                 <span
@@ -146,7 +146,7 @@ export function GroupCyclesView({ rows }: GroupCyclesViewProps) {
                 <ChevronRight
                   size={14}
                   aria-hidden="true"
-                  className="text-d2-ink/40"
+                  className="text-ink/40"
                 />
               </li>
             );

--- a/components/admin/group-members-view.tsx
+++ b/components/admin/group-members-view.tsx
@@ -10,13 +10,13 @@ const PILL_STYLE: Record<
   { background: string; color: string; label: string }
 > = {
   current: {
-    background: 'var(--ajo-paid-subtle)',
-    color: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    color: 'var(--status-paid)',
     label: 'current',
   },
   pending: {
-    background: 'var(--ajo-outstanding-subtle)',
-    color: 'var(--ajo-outstanding-fg)',
+    background: 'var(--status-pending-subtle)',
+    color: 'var(--status-pending-fg)',
     label: 'pending',
   },
   out: {
@@ -41,7 +41,7 @@ export function GroupMembersView({ rows }: GroupMembersViewProps) {
           <h3 className="text-[15px] font-semibold tracking-tight">
             Members · {rows.length}
           </h3>
-          <p className="text-[12px] text-d2-ink/55">
+          <p className="text-[12px] text-ink/55">
             Rotation order determines payout week
           </p>
         </div>
@@ -51,7 +51,7 @@ export function GroupMembersView({ rows }: GroupMembersViewProps) {
           disabled
           aria-label="Invite member (coming soon)"
           title="Coming soon"
-          className="inline-flex items-center gap-1.5 self-start rounded-[10px] bg-d2-ink px-3 py-1.5 text-[13px] font-medium text-d2-warm-bg disabled:cursor-not-allowed disabled:opacity-70 sm:self-auto"
+          className="inline-flex items-center gap-1.5 self-start rounded-[10px] bg-ink px-3 py-1.5 text-[13px] font-medium text-surface-page disabled:cursor-not-allowed disabled:opacity-70 sm:self-auto"
         >
           <Plus size={13} aria-hidden="true" />
           Invite member
@@ -61,16 +61,16 @@ export function GroupMembersView({ rows }: GroupMembersViewProps) {
         className="overflow-hidden rounded-[14px] border"
         style={{
           borderColor:
-            'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            'color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <div
           role="row"
           className="kicker-mono grid grid-cols-[24px_1.6fr_1.3fr_0.6fr_1.1fr_0.8fr_auto] items-center gap-3.5 px-4 py-2.5 text-[10px]"
           style={{
-            background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
+            background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
             borderBottom:
-              '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <span>#</span>
@@ -93,17 +93,17 @@ export function GroupMembersView({ rows }: GroupMembersViewProps) {
                 style={{
                   borderBottom: isLast
                     ? 'none'
-                    : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                    : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
                 }}
               >
-                <span className="font-mono text-d2-ink/55">
+                <span className="font-mono text-ink/55">
                   {row.member.position}
                 </span>
                 <div className="flex min-w-0 items-center gap-2.5">
                   <span
                     aria-hidden="true"
                     className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[12px] font-semibold text-white"
-                    style={{ background: 'var(--d2-coral)' }}
+                    style={{ background: 'var(--accent-coral)' }}
                   >
                     {row.member.name.charAt(0).toUpperCase()}
                   </span>
@@ -115,7 +115,7 @@ export function GroupMembersView({ rows }: GroupMembersViewProps) {
                   <div className="truncate font-mono text-[12px]">
                     {row.member.phone}
                   </div>
-                  <div className="text-[11px] text-d2-ink/55">
+                  <div className="text-[11px] text-ink/55">
                     joined {row.joinedLabel}
                   </div>
                 </div>
@@ -137,7 +137,7 @@ export function GroupMembersView({ rows }: GroupMembersViewProps) {
                     color:
                       row.tone === 'out'
                         ? 'var(--destructive)'
-                        : 'color-mix(in oklch, var(--d2-ink) 60%, transparent)',
+                        : 'color-mix(in oklch, var(--ink) 60%, transparent)',
                   }}
                 >
                   {row.dueLabel}
@@ -157,7 +157,7 @@ export function GroupMembersView({ rows }: GroupMembersViewProps) {
                   type="button"
                   disabled
                   aria-label={`Open actions for ${row.member.name} (coming soon)`}
-                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-d2-ink/55 disabled:cursor-not-allowed disabled:opacity-70"
+                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-ink/55 disabled:cursor-not-allowed disabled:opacity-70"
                 >
                   <MoreHorizontal size={14} aria-hidden="true" />
                 </button>

--- a/components/admin/group-overview-view.tsx
+++ b/components/admin/group-overview-view.tsx
@@ -21,17 +21,17 @@ const TIMELINE_TONE: Record<
   { background: string; color: string; border?: string }
 > = {
   closed: {
-    background: 'var(--ajo-paid-subtle)',
-    color: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    color: 'var(--status-paid)',
   },
   open: {
-    background: 'var(--ajo-outstanding-subtle)',
-    color: 'var(--ajo-outstanding-fg)',
-    border: '1.5px solid var(--ajo-outstanding)',
+    background: 'var(--status-pending-subtle)',
+    color: 'var(--status-pending-fg)',
+    border: '1.5px solid var(--status-pending)',
   },
   upcoming: {
-    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-    color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
+    color: 'color-mix(in oklch, var(--ink) 55%, transparent)',
   },
 };
 
@@ -51,17 +51,17 @@ export function GroupOverviewView({ overview }: GroupOverviewViewProps) {
         {overview.stats.map((s) => (
           <li
             key={s.kicker}
-            className="flex flex-col gap-0.5 rounded-[14px] border bg-d2-cream p-4"
+            className="flex flex-col gap-0.5 rounded-[14px] border bg-surface-card p-4"
             style={{
               borderColor:
-                'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+                'color-mix(in oklch, var(--ink) 7%, transparent)',
             }}
           >
             <span className="kicker-mono text-[10px]">{s.kicker}</span>
             <span className="font-mono text-[1.375rem] font-semibold tabular-nums">
               {s.value}
             </span>
-            <span className="text-[12px] text-d2-ink/55">{s.detail}</span>
+            <span className="text-[12px] text-ink/55">{s.detail}</span>
           </li>
         ))}
       </ul>
@@ -69,10 +69,10 @@ export function GroupOverviewView({ overview }: GroupOverviewViewProps) {
       <div className="grid grid-cols-1 gap-3.5 md:grid-cols-[1.3fr_1fr]">
         <section
           aria-labelledby="overview-timeline-title"
-          className="rounded-[14px] border bg-d2-cream p-4 md:p-5"
+          className="rounded-[14px] border bg-surface-card p-4 md:p-5"
           style={{
             borderColor:
-              'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="mb-3 flex items-center justify-between">
@@ -108,14 +108,14 @@ export function GroupOverviewView({ overview }: GroupOverviewViewProps) {
             })}
           </ol>
           {overview.rotationOrder.length > 0 && (
-            <p className="mt-3.5 text-[12px] text-d2-ink/60">
+            <p className="mt-3.5 text-[12px] text-ink/60">
               Rotation order:{' '}
               {overview.rotationOrder.map((entry, i) => (
                 <span key={`${entry.name}-${i}`}>
                   {i > 0 && ' → '}
                   <span
                     className={
-                      entry.isCurrent ? 'font-semibold text-d2-ink' : undefined
+                      entry.isCurrent ? 'font-semibold text-ink' : undefined
                     }
                   >
                     {entry.name}
@@ -128,10 +128,10 @@ export function GroupOverviewView({ overview }: GroupOverviewViewProps) {
 
         <section
           aria-labelledby="overview-activity-title"
-          className="rounded-[14px] border bg-d2-cream p-4 md:p-5"
+          className="rounded-[14px] border bg-surface-card p-4 md:p-5"
           style={{
             borderColor:
-              'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <h3
@@ -152,13 +152,13 @@ export function GroupOverviewView({ overview }: GroupOverviewViewProps) {
                     className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
                     style={{
                       background:
-                        'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                        'color-mix(in oklch, var(--ink) 6%, transparent)',
                     }}
                   >
                     <Icon size={12} aria-hidden="true" />
                   </span>
                   <span className="min-w-0 flex-1 truncate">{row.title}</span>
-                  <span className="font-mono text-[11px] text-d2-ink/50">
+                  <span className="font-mono text-[11px] text-ink/50">
                     {row.whenLabel}
                   </span>
                 </li>

--- a/components/admin/group-payments-view.tsx
+++ b/components/admin/group-payments-view.tsx
@@ -10,13 +10,13 @@ const PILL_STYLE: Record<
   { background: string; color: string; label: string }
 > = {
   confirmed: {
-    background: 'var(--ajo-paid-subtle)',
-    color: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    color: 'var(--status-paid)',
     label: 'confirmed',
   },
   pending: {
-    background: 'var(--ajo-outstanding-subtle)',
-    color: 'var(--ajo-outstanding-fg)',
+    background: 'var(--status-pending-subtle)',
+    color: 'var(--status-pending-fg)',
     label: 'pending',
   },
   overdue: {
@@ -25,8 +25,8 @@ const PILL_STYLE: Record<
     label: 'overdue',
   },
   payout: {
-    background: 'var(--ajo-paid-subtle)',
-    color: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    color: 'var(--status-paid)',
     label: 'payout',
   },
 };
@@ -44,7 +44,7 @@ export function GroupPaymentsView({ rows }: GroupPaymentsViewProps) {
           <h3 className="text-[15px] font-semibold tracking-tight">
             Payments · {rows.length}
           </h3>
-          <p className="text-[12px] text-d2-ink/55">
+          <p className="text-[12px] text-ink/55">
             Ledger of contributions + payouts
           </p>
         </div>
@@ -58,7 +58,7 @@ export function GroupPaymentsView({ rows }: GroupPaymentsViewProps) {
             className="rounded-[10px] px-3 py-1.5 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-70"
             style={{
               background:
-                'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                'color-mix(in oklch, var(--ink) 6%, transparent)',
             }}
           >
             Filter ▾
@@ -72,7 +72,7 @@ export function GroupPaymentsView({ rows }: GroupPaymentsViewProps) {
             className="rounded-[10px] px-3 py-1.5 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-70"
             style={{
               background:
-                'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                'color-mix(in oklch, var(--ink) 6%, transparent)',
             }}
           >
             Export CSV
@@ -84,16 +84,16 @@ export function GroupPaymentsView({ rows }: GroupPaymentsViewProps) {
         className="overflow-hidden rounded-[14px] border"
         style={{
           borderColor:
-            'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            'color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <div
           role="row"
           className="kicker-mono hidden grid-cols-[24px_1.4fr_1fr_1.1fr_0.9fr_0.8fr] items-center gap-3.5 px-4 py-2.5 text-[10px] md:grid"
           style={{
-            background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
+            background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
             borderBottom:
-              '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <span aria-hidden="true" />
@@ -109,8 +109,8 @@ export function GroupPaymentsView({ rows }: GroupPaymentsViewProps) {
             const pill = PILL_STYLE[row.status];
             const Icon = row.isPayout ? ArrowUpRight : ArrowDownLeft;
             const amountColor = row.isPayout
-              ? 'var(--d2-accent)'
-              : 'var(--d2-ink)';
+              ? 'var(--accent-primary)'
+              : 'var(--ink)';
             const amountPrefix = row.isPayout ? '−' : '+';
             return (
               <li
@@ -120,7 +120,7 @@ export function GroupPaymentsView({ rows }: GroupPaymentsViewProps) {
                 style={{
                   borderBottom: isLast
                     ? 'none'
-                    : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                    : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
                 }}
               >
                 <span
@@ -128,17 +128,17 @@ export function GroupPaymentsView({ rows }: GroupPaymentsViewProps) {
                   style={{
                     background: row.isPayout
                       ? 'var(--accent-violet-subtle)'
-                      : 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                      : 'color-mix(in oklch, var(--ink) 6%, transparent)',
                     color: row.isPayout
                       ? 'var(--accent-violet)'
-                      : 'color-mix(in oklch, var(--d2-ink) 60%, transparent)',
+                      : 'color-mix(in oklch, var(--ink) 60%, transparent)',
                   }}
                 >
                   <Icon size={13} aria-hidden="true" />
                 </span>
                 <div className="min-w-0">
                   <div className="truncate font-medium">{row.whoName}</div>
-                  <div className="font-mono text-[11px] text-d2-ink/55">
+                  <div className="font-mono text-[11px] text-ink/55">
                     {row.cycleLabel}
                   </div>
                 </div>
@@ -148,10 +148,10 @@ export function GroupPaymentsView({ rows }: GroupPaymentsViewProps) {
                 >
                   {amountPrefix} {row.amountLabel}
                 </span>
-                <span className="hidden font-mono text-[12px] text-d2-ink/55 md:inline">
+                <span className="hidden font-mono text-[12px] text-ink/55 md:inline">
                   {row.whenLabel}
                 </span>
-                <span className="hidden font-mono text-[12px] text-d2-ink/55 md:inline">
+                <span className="hidden font-mono text-[12px] text-ink/55 md:inline">
                   {row.confirmedByLabel}
                 </span>
                 <span

--- a/components/admin/group-receipts-view.tsx
+++ b/components/admin/group-receipts-view.tsx
@@ -59,7 +59,7 @@ export function GroupReceiptsView({
         if (result.ok) {
           router.refresh();
           // Safety clear: see receipts-queue-table for the rationale.
-          const timer = window.setTimeout(() => {
+          const timer = setTimeout(() => {
             safetyTimersRef.current.delete(timer);
             clearConfirm(id);
           }, 3000);
@@ -82,10 +82,10 @@ export function GroupReceiptsView({
         <div
           className="flex flex-col items-start gap-2 rounded-[10px] border px-3.5 py-2.5 sm:flex-row sm:items-center sm:gap-3"
           style={{
-            background: 'var(--ajo-outstanding-subtle)',
+            background: 'var(--status-pending-subtle)',
             borderColor:
-              'color-mix(in oklch, var(--ajo-outstanding) 30%, transparent)',
-            color: 'var(--ajo-outstanding-fg)',
+              'color-mix(in oklch, var(--status-pending) 30%, transparent)',
+            color: 'var(--status-pending-fg)',
           }}
           role="status"
         >
@@ -99,8 +99,8 @@ export function GroupReceiptsView({
           </p>
           <Link
             href="/admin/receipts"
-            className="rounded-md bg-d2-cream px-2.5 py-1 text-[12px] font-medium"
-            style={{ color: 'var(--ajo-outstanding-fg)' }}
+            className="rounded-md bg-surface-card px-2.5 py-1 text-[12px] font-medium"
+            style={{ color: 'var(--status-pending-fg)' }}
           >
             Open full queue →
           </Link>
@@ -111,16 +111,16 @@ export function GroupReceiptsView({
           className="overflow-hidden rounded-[14px] border"
           style={{
             borderColor:
-              'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div
             role="row"
             className="kicker-mono grid grid-cols-[1.3fr_1fr_1fr_1.4fr_auto] items-center gap-3.5 px-4 py-2.5 text-[10px]"
             style={{
-              background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
+              background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
               borderBottom:
-                '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+                '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
             }}
           >
             <span>From · cycle</span>
@@ -141,7 +141,7 @@ export function GroupReceiptsView({
                   style={{
                     borderBottom: isLast
                       ? 'none'
-                      : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                      : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
                     opacity: isOptimistic ? 0.55 : 1,
                   }}
                 >
@@ -149,17 +149,17 @@ export function GroupReceiptsView({
                     <div className="truncate font-medium">
                       {row.memberName ?? 'unmatched'}
                     </div>
-                    <div className="font-mono text-[11px] text-d2-ink/55">
+                    <div className="font-mono text-[11px] text-ink/55">
                       {row.cycleLabel}
                     </div>
                   </div>
                   <span className="font-mono font-medium">
                     {row.amountLabel}
                   </span>
-                  <span className="font-mono text-[12px] text-d2-ink/55">
+                  <span className="font-mono text-[12px] text-ink/55">
                     {row.submittedLabel}
                   </span>
-                  <span className="truncate text-[12px] text-d2-ink/65">
+                  <span className="truncate text-[12px] text-ink/65">
                     {row.note}
                   </span>
                   <div className="flex gap-1 justify-self-end">
@@ -169,17 +169,17 @@ export function GroupReceiptsView({
                       disabled={isPending || isOptimistic}
                       aria-label={`Confirm receipt from ${row.memberName ?? 'unmatched sender'}`}
                       className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-                      style={{ background: 'var(--ajo-paid)' }}
+                      style={{ background: 'var(--status-paid)' }}
                     >
                       {isOptimistic ? 'Confirming…' : 'Confirm'}
                     </button>
                     <button
                       type="button"
                       onClick={() => selectReceipt(row.receiptId)}
-                      className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium transition-colors hover:bg-d2-ink/10"
+                      className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium transition-colors hover:bg-ink/10"
                       style={{
                         background:
-                          'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                          'color-mix(in oklch, var(--ink) 6%, transparent)',
                       }}
                     >
                       View
@@ -193,10 +193,10 @@ export function GroupReceiptsView({
       ) : (
         <div
           role="status"
-          className="rounded-[14px] border bg-d2-cream p-6 text-center text-[13px] text-d2-ink/65"
+          className="rounded-[14px] border bg-surface-card p-6 text-center text-[13px] text-ink/65"
           style={{
             borderColor:
-              'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           No receipts pending for this group.

--- a/components/admin/group-settings-view.tsx
+++ b/components/admin/group-settings-view.tsx
@@ -29,7 +29,7 @@ function StaticToggle({ label, detail, checked }: ToggleProps) {
     <div className="grid grid-cols-[1fr_auto] items-center gap-2.5 py-2">
       <div className="min-w-0">
         <div className="text-[13px] font-medium">{label}</div>
-        <div className="text-[11px] text-d2-ink/55">{detail}</div>
+        <div className="text-[11px] text-ink/55">{detail}</div>
       </div>
       {/* TODO(slice-5): wire toggle change handler here */}
       <span
@@ -39,8 +39,8 @@ function StaticToggle({ label, detail, checked }: ToggleProps) {
         className="relative inline-block h-6 w-10 shrink-0 rounded-full"
         style={{
           background: checked
-            ? 'var(--d2-accent)'
-            : 'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+            ? 'var(--accent-primary)'
+            : 'color-mix(in oklch, var(--ink) 12%, transparent)',
         }}
       >
         <span
@@ -75,10 +75,10 @@ export function GroupSettingsView({
     <div className="grid grid-cols-1 gap-3.5 md:grid-cols-2">
       <section
         aria-labelledby="settings-group-title"
-        className="rounded-[14px] border bg-d2-cream p-4 md:p-5"
+        className="rounded-[14px] border bg-surface-card p-4 md:p-5"
         style={{
           borderColor:
-            'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            'color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <h3 id="settings-group-title" className="kicker-mono mb-3 text-[10px]">
@@ -92,11 +92,11 @@ export function GroupSettingsView({
               style={{
                 borderTop:
                   i > 0
-                    ? '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)'
+                    ? '1px solid color-mix(in oklch, var(--ink) 7%, transparent)'
                     : 'none',
               }}
             >
-              <dt className="font-mono text-[12px] text-d2-ink/55">
+              <dt className="font-mono text-[12px] text-ink/55">
                 {row.kicker}
               </dt>
               <dd>{row.value}</dd>
@@ -106,7 +106,7 @@ export function GroupSettingsView({
                 disabled
                 aria-label={`Edit ${row.kicker} (coming soon)`}
                 className="text-[12px] font-medium disabled:cursor-not-allowed disabled:opacity-60"
-                style={{ color: 'var(--d2-accent)' }}
+                style={{ color: 'var(--accent-primary)' }}
               >
                 Edit
               </button>
@@ -117,10 +117,10 @@ export function GroupSettingsView({
 
       <section
         aria-labelledby="settings-wa-title"
-        className="rounded-[14px] border bg-d2-cream p-4 md:p-5"
+        className="rounded-[14px] border bg-surface-card p-4 md:p-5"
         style={{
           borderColor:
-            'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            'color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <h3 id="settings-wa-title" className="kicker-mono mb-3 text-[10px]">
@@ -129,9 +129,9 @@ export function GroupSettingsView({
         <div
           className="mb-3 rounded-lg border p-3"
           style={{
-            background: 'var(--d2-warm-bg)',
+            background: 'var(--surface-page)',
             borderColor:
-              'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="kicker-mono text-[10px]">Linked WhatsApp group</div>
@@ -141,13 +141,13 @@ export function GroupSettingsView({
               className="inline-block h-2 w-2 rounded-full"
               style={{
                 background: whatsappActive
-                  ? 'var(--ajo-paid)'
-                  : 'color-mix(in oklch, var(--d2-ink) 25%, transparent)',
+                  ? 'var(--status-paid)'
+                  : 'color-mix(in oklch, var(--ink) 25%, transparent)',
               }}
             />
             {whatsappGroupLabel}
           </div>
-          <div className="mt-0.5 font-mono text-[11px] text-d2-ink/55">
+          <div className="mt-0.5 font-mono text-[11px] text-ink/55">
             {whatsappGroupId} ·{' '}
             {whatsappActive ? 'bot active' : 'bot inactive'}
           </div>
@@ -161,7 +161,7 @@ export function GroupSettingsView({
         <div
           style={{
             borderTop:
-              '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <StaticToggle
@@ -175,7 +175,7 @@ export function GroupSettingsView({
           className="mt-4 pt-3.5"
           style={{
             borderTop:
-              '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <p

--- a/components/admin/group-tabs-nav.tsx
+++ b/components/admin/group-tabs-nav.tsx
@@ -47,7 +47,7 @@ export function GroupTabsNav({ poolId, active, counts }: GroupTabsNavProps) {
       aria-label="Group sections"
       className="-mx-4 overflow-x-auto px-4 md:mx-0 md:px-0"
       style={{
-        borderBottom: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        borderBottom: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
     >
       <ul className="inline-flex min-w-full gap-0.5 whitespace-nowrap">
@@ -67,11 +67,11 @@ export function GroupTabsNav({ poolId, active, counts }: GroupTabsNavProps) {
                 className="inline-flex items-center gap-1.5 px-3 py-2.5 text-[13px] transition-colors"
                 style={{
                   color: isActive
-                    ? 'var(--d2-ink)'
-                    : 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+                    ? 'var(--ink)'
+                    : 'color-mix(in oklch, var(--ink) 55%, transparent)',
                   fontWeight: isActive ? 600 : 500,
                   borderBottom: isActive
-                    ? '2px solid var(--d2-ink)'
+                    ? '2px solid var(--ink)'
                     : '2px solid transparent',
                   marginBottom: -1,
                 }}
@@ -83,11 +83,11 @@ export function GroupTabsNav({ poolId, active, counts }: GroupTabsNavProps) {
                     style={{
                       padding: '1px 6px',
                       background: tab.hot
-                        ? 'var(--ajo-outstanding-subtle)'
-                        : 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                        ? 'var(--status-pending-subtle)'
+                        : 'color-mix(in oklch, var(--ink) 6%, transparent)',
                       color: tab.hot
-                        ? 'var(--ajo-outstanding-fg)'
-                        : 'color-mix(in oklch, var(--d2-ink) 65%, transparent)',
+                        ? 'var(--status-pending-fg)'
+                        : 'color-mix(in oklch, var(--ink) 65%, transparent)',
                     }}
                   >
                     {count}

--- a/components/admin/group-view.tsx
+++ b/components/admin/group-view.tsx
@@ -134,11 +134,11 @@ export function GroupView({
             </p>
             <h1
               id="group-title"
-              className="truncate text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+              className="truncate text-[1.5rem] font-semibold tracking-tight text-ink"
             >
               {data.header.name}
             </h1>
-            <p className="truncate text-[13px] text-d2-ink/55">
+            <p className="truncate text-[13px] text-ink/55">
               {data.header.metaLine}
             </p>
           </div>
@@ -174,7 +174,7 @@ export function GroupView({
         tabBody
       )}
 
-      <p className="font-mono text-[11px] text-d2-ink/45">
+      <p className="font-mono text-[11px] text-ink/45">
         counts here are scoped to this group · sidebar Receipts ({crossGroupReceiptCount})
         is cross-group
       </p>

--- a/components/admin/mobile-readonly-prompt.tsx
+++ b/components/admin/mobile-readonly-prompt.tsx
@@ -30,27 +30,27 @@ export function MobileReadonlyPrompt({
   return (
     <div
       role="status"
-      className="flex flex-col items-center gap-3 rounded-[14px] border bg-d2-cream px-5 py-7 text-center"
+      className="flex flex-col items-center gap-3 rounded-[14px] border bg-surface-card px-5 py-7 text-center"
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 8%, transparent)',
       }}
     >
       <span
         aria-hidden="true"
         className="inline-flex h-10 w-10 items-center justify-center rounded-full"
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 5%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 5%, transparent)',
         }}
       >
         <MonitorSmartphone size={18} aria-hidden="true" />
       </span>
       <div className="flex flex-col gap-1">
-        <h2 className="text-[14px] font-semibold tracking-tight text-d2-ink">
+        <h2 className="text-[14px] font-semibold tracking-tight text-ink">
           {tabLabel} · desktop only
         </h2>
-        <p className="text-[12.5px] leading-snug text-d2-ink/65">{message}</p>
+        <p className="text-[12.5px] leading-snug text-ink/65">{message}</p>
       </div>
-      <p className="font-mono text-[10px] text-d2-ink/45">
+      <p className="font-mono text-[10px] text-ink/45">
         triage on mobile · configure on desktop
       </p>
     </div>

--- a/components/admin/modal-destructive-confirm.tsx
+++ b/components/admin/modal-destructive-confirm.tsx
@@ -66,10 +66,10 @@ export function ModalDestructiveConfirm({
               setTyped('');
               onClose();
             }}
-            className="rounded-[10px] border bg-transparent px-3.5 py-2 text-[13px] font-medium text-d2-ink"
+            className="rounded-[10px] border bg-transparent px-3.5 py-2 text-[13px] font-medium text-ink"
             style={{
               borderColor:
-                'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+                'color-mix(in oklch, var(--ink) 12%, transparent)',
             }}
           >
             Cancel
@@ -112,7 +112,7 @@ export function ModalDestructiveConfirm({
       <div>
         <label
           htmlFor="destructive-confirm-input"
-          className="mb-1.5 inline-block text-[12px] font-medium text-d2-ink"
+          className="mb-1.5 inline-block text-[12px] font-medium text-ink"
         >
           Type {confirmPhrase} to confirm
         </label>
@@ -123,11 +123,11 @@ export function ModalDestructiveConfirm({
           placeholder={confirmPhrase}
           autoComplete="off"
           spellCheck={false}
-          className="w-full rounded-[10px] border bg-d2-cream px-3 py-2 text-[13px] outline-none"
+          className="w-full rounded-[10px] border bg-surface-card px-3 py-2 text-[13px] outline-none"
           style={{
             borderColor: matches
               ? 'var(--destructive)'
-              : 'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+              : 'color-mix(in oklch, var(--ink) 12%, transparent)',
             boxShadow: matches
               ? '0 0 0 3px color-mix(in oklch, var(--destructive) 14%, transparent)'
               : undefined,

--- a/components/admin/modal-receipt-detail.tsx
+++ b/components/admin/modal-receipt-detail.tsx
@@ -137,7 +137,7 @@ export function ModalReceiptDetail({
         // the next RSC payload. If the BE read momentarily lags the
         // write the row would otherwise stay dimmed; clear after 3s as
         // a guarantee.
-        const timer = window.setTimeout(() => {
+        const timer = setTimeout(() => {
           safetyTimersRef.current.delete(timer);
           clearConfirm(row.receiptId);
         }, 3000);
@@ -174,7 +174,7 @@ export function ModalReceiptDetail({
         closeModal();
         router.refresh();
         // Safety clear, see handleConfirm above for the rationale.
-        const timer = window.setTimeout(() => {
+        const timer = setTimeout(() => {
           safetyTimersRef.current.delete(timer);
           clear(row.receiptId);
         }, 3000);
@@ -231,21 +231,21 @@ export function ModalReceiptDetail({
         onClick={closeModal}
         className="absolute inset-0 backdrop-blur-[3px]"
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 35%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 35%, transparent)',
         }}
       />
       <div
-        className="relative z-10 flex w-full max-w-[620px] flex-col overflow-hidden rounded-[18px] bg-d2-cream"
+        className="relative z-10 flex w-full max-w-[620px] flex-col overflow-hidden rounded-[18px] bg-surface-card"
         style={{
           boxShadow:
-            '0 30px 80px -20px color-mix(in oklch, var(--d2-ink) 35%, transparent), 0 4px 12px color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+            '0 30px 80px -20px color-mix(in oklch, var(--ink) 35%, transparent), 0 4px 12px color-mix(in oklch, var(--ink) 8%, transparent)',
         }}
       >
         <div
           className="flex items-start gap-3 px-6 py-5"
           style={{
             borderBottom:
-              '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="min-w-0 flex-1">
@@ -259,7 +259,7 @@ export function ModalReceiptDetail({
               {row.memberName ?? 'unmatched sender'} → {row.poolName} ·{' '}
               {row.cycleLabel}
             </h3>
-            <p className="mt-1 text-[12.5px] leading-snug text-d2-ink/60">
+            <p className="mt-1 text-[12.5px] leading-snug text-ink/60">
               {row.submittedLabel} · matched on phone {row.memberPhoneMasked}
             </p>
           </div>
@@ -267,7 +267,7 @@ export function ModalReceiptDetail({
             type="button"
             onClick={closeModal}
             aria-label="Close receipt details"
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-d2-ink/60 transition-colors hover:bg-d2-ink/5"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-ink/60 transition-colors hover:bg-ink/5"
           >
             <X size={16} aria-hidden="true" />
           </button>
@@ -275,12 +275,12 @@ export function ModalReceiptDetail({
         <div className="grid grid-cols-1 gap-4 px-6 py-5 md:grid-cols-[180px_1fr]">
           <div
             aria-label="Receipt screenshot placeholder"
-            className="flex aspect-[3/4] flex-col items-center justify-center gap-1.5 rounded-[10px] text-d2-ink/50"
+            className="flex aspect-[3/4] flex-col items-center justify-center gap-1.5 rounded-[10px] text-ink/50"
             style={{
               background:
-                'repeating-linear-gradient(135deg, color-mix(in oklch, var(--d2-ink) 5%, transparent) 0 6px, transparent 6px 12px), color-mix(in oklch, var(--d2-ink) 4%, transparent)',
+                'repeating-linear-gradient(135deg, color-mix(in oklch, var(--ink) 5%, transparent) 0 6px, transparent 6px 12px), color-mix(in oklch, var(--ink) 4%, transparent)',
               border:
-                '1px solid color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+                '1px solid color-mix(in oklch, var(--ink) 8%, transparent)',
             }}
           >
             <ImageIcon size={20} aria-hidden="true" />
@@ -295,7 +295,7 @@ export function ModalReceiptDetail({
                 key={k}
                 className="grid grid-cols-[88px_1fr] gap-2 text-[12.5px]"
               >
-                <dt className="font-mono text-[11px] text-d2-ink/55">{k}</dt>
+                <dt className="font-mono text-[11px] text-ink/55">{k}</dt>
                 <dd>
                   {/* React escapes text content by default, never use
                       dangerouslySetInnerHTML for any of these values; the
@@ -305,7 +305,7 @@ export function ModalReceiptDetail({
                   {note && (
                     <span
                       className="ml-2 font-mono text-[10.5px]"
-                      style={{ color: 'var(--ajo-paid)' }}
+                      style={{ color: 'var(--status-paid)' }}
                     >
                       · {note}
                     </span>
@@ -346,17 +346,17 @@ export function ModalReceiptDetail({
             className="flex flex-col-reverse items-stretch gap-2 px-6 py-3.5 sm:flex-row sm:items-center sm:justify-end"
             style={{
               borderTop:
-                '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
-              background: 'color-mix(in oklch, var(--d2-ink) 2%, transparent)',
+                '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
+              background: 'color-mix(in oklch, var(--ink) 2%, transparent)',
             }}
           >
             <button
               type="button"
               onClick={() => openReasonPrompt('reject')}
               disabled={isPending}
-              className="rounded-[10px] px-3.5 py-1.5 text-[13px] font-medium text-d2-ink transition-colors hover:bg-d2-ink/5 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-[10px] px-3.5 py-1.5 text-[13px] font-medium text-ink transition-colors hover:bg-ink/5 disabled:cursor-not-allowed disabled:opacity-50"
               style={{
-                background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
               }}
             >
               Reject as duplicate
@@ -375,7 +375,7 @@ export function ModalReceiptDetail({
               onClick={handleConfirm}
               disabled={isPending}
               className="rounded-[10px] px-3.5 py-1.5 text-[13px] font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-              style={{ background: 'var(--ajo-paid)' }}
+              style={{ background: 'var(--status-paid)' }}
             >
               {isPending ? 'Working…' : 'Confirm payment'}
             </button>
@@ -423,7 +423,7 @@ function ReasonForm({
       : isPending
         ? 'Flagging…'
         : 'Mark as suspicious';
-  const submitColor = kind === 'reject' ? 'var(--d2-ink)' : 'var(--destructive)';
+  const submitColor = kind === 'reject' ? 'var(--ink)' : 'var(--destructive)';
   const inputId = `receipt-reason-${kind}`;
   const canSubmit = reason.trim().length > 0 && !isPending;
 
@@ -437,13 +437,13 @@ function ReasonForm({
       className="flex flex-col gap-3 px-6 py-4"
       style={{
         borderTop:
-          '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
-        background: 'color-mix(in oklch, var(--d2-ink) 2%, transparent)',
+          '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
+        background: 'color-mix(in oklch, var(--ink) 2%, transparent)',
       }}
     >
       <label
         htmlFor={inputId}
-        className="font-mono text-[11px] tracking-wider text-d2-ink/65"
+        className="font-mono text-[11px] tracking-wider text-ink/65"
       >
         {labelText}
       </label>
@@ -454,9 +454,9 @@ function ReasonForm({
         maxLength={RECEIPT_REASON_MAX_LENGTH}
         rows={2}
         autoFocus
-        className="w-full resize-none rounded-[10px] bg-d2-cream px-3 py-2 text-[13px] outline-none placeholder:text-d2-ink/40 focus-visible:ring-2"
+        className="w-full resize-none rounded-[10px] bg-surface-card px-3 py-2 text-[13px] outline-none placeholder:text-ink/40 focus-visible:ring-2"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 12%, transparent)',
         }}
         placeholder={
           kind === 'reject'
@@ -468,7 +468,7 @@ function ReasonForm({
       <div className="flex items-center justify-between gap-3">
         <span
           id={`${inputId}-count`}
-          className="font-mono text-[10.5px] text-d2-ink/55"
+          className="font-mono text-[10.5px] text-ink/55"
           aria-live="polite"
         >
           {remaining} character{remaining === 1 ? '' : 's'} left
@@ -478,9 +478,9 @@ function ReasonForm({
             type="button"
             onClick={onCancel}
             disabled={isPending}
-            className="rounded-[10px] px-3.5 py-1.5 text-[13px] font-medium text-d2-ink transition-colors hover:bg-d2-ink/5 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-[10px] px-3.5 py-1.5 text-[13px] font-medium text-ink transition-colors hover:bg-ink/5 disabled:cursor-not-allowed disabled:opacity-50"
             style={{
-              background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+              background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
             }}
           >
             Cancel

--- a/components/admin/modal-start-cycle.tsx
+++ b/components/admin/modal-start-cycle.tsx
@@ -67,10 +67,10 @@ export function ModalStartCycle({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-[10px] border bg-transparent px-3.5 py-2 text-[13px] font-medium text-d2-ink"
+            className="rounded-[10px] border bg-transparent px-3.5 py-2 text-[13px] font-medium text-ink"
             style={{
               borderColor:
-                'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+                'color-mix(in oklch, var(--ink) 12%, transparent)',
             }}
           >
             Cancel
@@ -79,8 +79,8 @@ export function ModalStartCycle({
             type="button"
             onClick={onConfirm}
             disabled={pending}
-            className="rounded-[10px] px-3.5 py-2 text-[13px] font-semibold text-d2-warm-bg disabled:cursor-not-allowed disabled:opacity-60"
-            style={{ background: 'var(--d2-ink)' }}
+            className="rounded-[10px] px-3.5 py-2 text-[13px] font-semibold text-surface-page disabled:cursor-not-allowed disabled:opacity-60"
+            style={{ background: 'var(--ink)' }}
           >
             {pending ? 'Starting…' : 'Start cycle'}
           </button>
@@ -93,36 +93,36 @@ export function ModalStartCycle({
       </div>
       <div>
         <div className="mb-1.5 flex items-baseline justify-between">
-          <span className="text-[12px] font-medium text-d2-ink">
+          <span className="text-[12px] font-medium text-ink">
             Recipient · cycle {cycleNumber}
           </span>
-          <span className="font-mono text-[10px] text-d2-ink/55">
+          <span className="font-mono text-[10px] text-ink/55">
             based on draw order
           </span>
         </div>
         <div
-          className="flex items-center gap-2.5 rounded-[10px] border bg-d2-cream px-3 py-2.5"
+          className="flex items-center gap-2.5 rounded-[10px] border bg-surface-card px-3 py-2.5"
           style={{
             borderColor:
-              'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+              'color-mix(in oklch, var(--ink) 12%, transparent)',
           }}
         >
           <span
             className="inline-flex h-9 w-9 items-center justify-center rounded-full text-[13px] font-semibold text-white"
-            style={{ background: recipient.swatch ?? 'var(--d2-lav)' }}
+            style={{ background: recipient.swatch ?? 'var(--accent-lavender)' }}
             aria-hidden="true"
           >
             {recipient.initial}
           </span>
           <div className="flex-1">
             <div className="text-[13px] font-medium">{recipient.name}</div>
-            <div className="font-mono text-[10.5px] text-d2-ink/55">
+            <div className="font-mono text-[10.5px] text-ink/55">
               {recipient.positionLabel}
             </div>
           </div>
           <button
             type="button"
-            className="text-[11.5px] font-semibold text-d2-accent"
+            className="text-[11.5px] font-semibold text-accent-primary"
           >
             Override
           </button>
@@ -133,20 +133,20 @@ export function ModalStartCycle({
           className="flex gap-2.5 rounded-[10px] border px-3 py-2.5"
           style={{
             background:
-              'color-mix(in oklch, var(--ajo-outstanding) 10%, transparent)',
+              'color-mix(in oklch, var(--status-pending) 10%, transparent)',
             borderColor:
-              'color-mix(in oklch, var(--ajo-outstanding) 25%, transparent)',
+              'color-mix(in oklch, var(--status-pending) 25%, transparent)',
           }}
         >
           <AlertCircle
             size={14}
             aria-hidden="true"
             className="mt-0.5 shrink-0"
-            style={{ color: 'var(--ajo-outstanding-fg)' }}
+            style={{ color: 'var(--status-pending-fg)' }}
           />
           <span
             className="text-[12.5px]"
-            style={{ color: 'var(--ajo-outstanding-fg)' }}
+            style={{ color: 'var(--status-pending-fg)' }}
           >
             {outstandingCount} member{outstandingCount === 1 ? '' : 's'} still
             outstanding on the previous cycle. Starting cycle {cycleNumber} will
@@ -161,12 +161,12 @@ export function ModalStartCycle({
 function ReadonlyField({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <div className="mb-1.5 text-[12px] font-medium text-d2-ink">{label}</div>
+      <div className="mb-1.5 text-[12px] font-medium text-ink">{label}</div>
       <div
-        className="rounded-[10px] border bg-d2-cream px-3 py-2 text-[13px]"
+        className="rounded-[10px] border bg-surface-card px-3 py-2 text-[13px]"
         style={{
           borderColor:
-            'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+            'color-mix(in oklch, var(--ink) 12%, transparent)',
         }}
       >
         {value}

--- a/components/admin/pool-glyph.tsx
+++ b/components/admin/pool-glyph.tsx
@@ -2,10 +2,10 @@ import { cn } from '@/lib/utils';
 import type { PoolSwatchSlot } from '@/lib/view-models/admin';
 
 const GLYPH_BACKGROUNDS: Record<PoolSwatchSlot, string> = {
-  a: 'linear-gradient(135deg, var(--d2-accent), var(--pool-swatch-teal))',
-  b: 'linear-gradient(135deg, var(--d2-coral), var(--pool-swatch-coral-deep))',
-  c: 'linear-gradient(135deg, var(--d2-lav), var(--pool-swatch-lav-deep))',
-  d: 'linear-gradient(135deg, var(--pool-swatch-aqua), var(--d2-accent))',
+  a: 'linear-gradient(135deg, var(--accent-primary), var(--pool-swatch-teal))',
+  b: 'linear-gradient(135deg, var(--accent-coral), var(--pool-swatch-coral-deep))',
+  c: 'linear-gradient(135deg, var(--accent-lavender), var(--pool-swatch-lav-deep))',
+  d: 'linear-gradient(135deg, var(--pool-swatch-aqua), var(--accent-primary))',
 };
 
 export interface PoolGlyphProps {

--- a/components/admin/receipts-queue-mobile.tsx
+++ b/components/admin/receipts-queue-mobile.tsx
@@ -50,7 +50,7 @@ export function ReceiptsQueueMobile({ rows }: ReceiptsQueueMobileProps) {
           // Safety clear: see receipts-queue-table for the rationale. The
           // mobile + desktop variants share the same optimistic dimming so
           // they need the same fallback.
-          const timer = window.setTimeout(() => {
+          const timer = setTimeout(() => {
             safetyTimersRef.current.delete(timer);
             clearConfirm(id);
           }, 3000);
@@ -67,9 +67,9 @@ export function ReceiptsQueueMobile({ rows }: ReceiptsQueueMobileProps) {
 
   return (
     <ul
-      className="overflow-hidden rounded-[14px] border bg-d2-cream"
+      className="overflow-hidden rounded-[14px] border bg-surface-card"
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
       aria-label="Receipts list"
     >
@@ -89,7 +89,7 @@ export function ReceiptsQueueMobile({ rows }: ReceiptsQueueMobileProps) {
             style={{
               borderBottom: isLast
                 ? 'none'
-                : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
               opacity: isOptimistic ? 0.55 : 1,
             }}
           >
@@ -101,16 +101,16 @@ export function ReceiptsQueueMobile({ rows }: ReceiptsQueueMobileProps) {
             <div className="min-w-0">
               <div className="flex items-baseline gap-1.5 text-[13px] font-semibold">
                 <span className="truncate">{senderLabel}</span>
-                <span className="shrink-0 font-mono text-[11px] font-normal text-d2-ink/55">
+                <span className="shrink-0 font-mono text-[11px] font-normal text-ink/55">
                   · {row.amountLabel}
                 </span>
               </div>
-              <div className="truncate text-[11px] text-d2-ink/55">
+              <div className="truncate text-[11px] text-ink/55">
                 {subline}
               </div>
             </div>
             <div className="flex flex-col items-end gap-1">
-              <span className="font-mono text-[10px] text-d2-ink/50">
+              <span className="font-mono text-[10px] text-ink/50">
                 {compactWhen}
               </span>
               <div className="flex gap-1">
@@ -120,16 +120,16 @@ export function ReceiptsQueueMobile({ rows }: ReceiptsQueueMobileProps) {
                   disabled={isPending || isOptimistic}
                   aria-label={`Confirm receipt from ${senderLabel}`}
                   className="rounded-md px-2 py-1 text-[11px] font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-                  style={{ background: 'var(--ajo-paid)' }}
+                  style={{ background: 'var(--status-paid)' }}
                 >
                   {isOptimistic ? '…' : '✓'}
                 </button>
                 <button
                   type="button"
                   onClick={() => selectReceipt(row.receiptId)}
-                  className="rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-d2-ink/10"
+                  className="rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-ink/10"
                   style={{
-                    background: 'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+                    background: 'color-mix(in oklch, var(--ink) 8%, transparent)',
                   }}
                 >
                   View

--- a/components/admin/receipts-queue-signals.tsx
+++ b/components/admin/receipts-queue-signals.tsx
@@ -14,13 +14,13 @@ interface SignalCard {
 
 const TONE_STYLE: Record<SignalTone, { background: string; borderColor: string; valueColor?: string }> = {
   pending: {
-    background: 'var(--ajo-outstanding-subtle)',
-    borderColor: 'color-mix(in oklch, var(--ajo-outstanding) 30%, transparent)',
-    valueColor: 'var(--ajo-outstanding-fg)',
+    background: 'var(--status-pending-subtle)',
+    borderColor: 'color-mix(in oklch, var(--status-pending) 30%, transparent)',
+    valueColor: 'var(--status-pending-fg)',
   },
   muted: {
-    background: 'color-mix(in oklch, var(--d2-ink) 4%, var(--d2-cream))',
-    borderColor: 'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+    background: 'color-mix(in oklch, var(--ink) 4%, var(--surface-card))',
+    borderColor: 'color-mix(in oklch, var(--ink) 8%, transparent)',
   },
   out: {
     background: 'color-mix(in oklch, var(--destructive) 10%, transparent)',
@@ -28,9 +28,9 @@ const TONE_STYLE: Record<SignalTone, { background: string; borderColor: string; 
     valueColor: 'var(--destructive)',
   },
   paid: {
-    background: 'var(--ajo-paid-subtle)',
-    borderColor: 'color-mix(in oklch, var(--ajo-paid) 30%, transparent)',
-    valueColor: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    borderColor: 'color-mix(in oklch, var(--status-paid) 30%, transparent)',
+    valueColor: 'var(--status-paid)',
   },
 };
 

--- a/components/admin/receipts-queue-table.tsx
+++ b/components/admin/receipts-queue-table.tsx
@@ -11,15 +11,6 @@ export interface ReceiptsQueueTableProps {
   rows: ReadonlyArray<ReceiptQueueRow>;
 }
 
-type RowTone = ReceiptQueueRow['tone'];
-
-const TONE_BG: Record<RowTone, string> = {
-  paid: 'transparent',
-  pending: 'transparent',
-  stale: 'color-mix(in oklch, var(--destructive) 4%, transparent)',
-  out: 'color-mix(in oklch, var(--destructive) 6%, transparent)',
-};
-
 /**
  * Desktop receipts queue table. Renders the joined queue rows produced
  * by `toReceiptQueueRow` with confirm + view affordances. The view
@@ -114,9 +105,8 @@ export function ReceiptsQueueTable({ rows }: ReceiptsQueueTableProps) {
               key={row.receiptId}
               role="row"
               data-tone={row.tone}
-              className="grid grid-cols-[1fr_auto] items-center gap-3.5 px-4 py-3 text-[13px] md:grid-cols-[24px_1.4fr_1.2fr_0.8fr_1fr_1.1fr_auto]"
+              className="status-row grid grid-cols-[1fr_auto] items-center gap-3.5 px-4 py-3 text-[13px] md:grid-cols-[24px_1.4fr_1.2fr_0.8fr_1fr_1.1fr_auto]"
               style={{
-                background: TONE_BG[row.tone],
                 borderBottom: isLast
                   ? 'none'
                   : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',

--- a/components/admin/receipts-queue-table.tsx
+++ b/components/admin/receipts-queue-table.tsx
@@ -58,7 +58,7 @@ export function ReceiptsQueueTable({ rows }: ReceiptsQueueTableProps) {
           // off the queue filter). If the BE read momentarily lags the
           // write the row could otherwise stay dimmed indefinitely. The
           // 3s window is well past any plausible same-region BE latency.
-          const timer = window.setTimeout(() => {
+          const timer = setTimeout(() => {
             safetyTimersRef.current.delete(timer);
             clearConfirm(id);
           }, 3000);
@@ -77,15 +77,15 @@ export function ReceiptsQueueTable({ rows }: ReceiptsQueueTableProps) {
     <div
       className="overflow-hidden rounded-[14px] border"
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
     >
       <div
         role="row"
         className="kicker-mono hidden grid-cols-[24px_1.4fr_1.2fr_0.8fr_1fr_1.1fr_auto] items-center gap-3.5 px-4 py-2.5 text-[10px] md:grid"
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
-          borderBottom: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
+          borderBottom: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <span aria-hidden="true" />
@@ -109,7 +109,7 @@ export function ReceiptsQueueTable({ rows }: ReceiptsQueueTableProps) {
               style={{
                 borderBottom: isLast
                   ? 'none'
-                  : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                  : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
                 opacity: isOptimistic ? 0.55 : 1,
               }}
             >
@@ -117,7 +117,7 @@ export function ReceiptsQueueTable({ rows }: ReceiptsQueueTableProps) {
                 <input
                   type="checkbox"
                   aria-label={`Select receipt ${row.receiptId} (coming soon)`}
-                  className="h-[15px] w-[15px] cursor-pointer accent-d2-ink"
+                  className="h-[15px] w-[15px] cursor-pointer accent-ink"
                   disabled
                 />
               </span>
@@ -125,24 +125,24 @@ export function ReceiptsQueueTable({ rows }: ReceiptsQueueTableProps) {
                 <PoolGlyph initial={row.poolInitial} swatch={row.poolSwatch} />
                 <div className="min-w-0">
                   <div className="truncate font-medium">{row.poolName}</div>
-                  <div className="font-mono text-[11px] text-d2-ink/55">
+                  <div className="font-mono text-[11px] text-ink/55">
                     {row.cycleLabel}
                   </div>
                 </div>
               </div>
               <div className="hidden min-w-0 md:block">
                 <div className="truncate">{row.memberName ?? 'unmatched'}</div>
-                <div className="font-mono text-[11px] text-d2-ink/55">
+                <div className="font-mono text-[11px] text-ink/55">
                   {row.memberPhoneMasked}
                 </div>
               </div>
               <span className="hidden font-mono font-medium md:inline">
                 {row.amountLabel}
               </span>
-              <span className="hidden font-mono text-[12px] text-d2-ink/55 md:inline">
+              <span className="hidden font-mono text-[12px] text-ink/55 md:inline">
                 {row.submittedLabel}
               </span>
-              <span className="hidden truncate text-[12px] text-d2-ink/65 md:inline">
+              <span className="hidden truncate text-[12px] text-ink/65 md:inline">
                 {row.note}
               </span>
               <div className="flex items-center gap-1 justify-self-end">
@@ -152,16 +152,16 @@ export function ReceiptsQueueTable({ rows }: ReceiptsQueueTableProps) {
                   disabled={isPending || isOptimistic}
                   aria-label={`Confirm receipt from ${row.memberName ?? 'unmatched sender'}`}
                   className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-                  style={{ background: 'var(--ajo-paid)' }}
+                  style={{ background: 'var(--status-paid)' }}
                 >
                   {isOptimistic ? 'Confirming…' : 'Confirm'}
                 </button>
                 <button
                   type="button"
                   onClick={() => selectReceipt(row.receiptId)}
-                  className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium transition-colors hover:bg-d2-ink/10"
+                  className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium transition-colors hover:bg-ink/10"
                   style={{
-                    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
                   }}
                 >
                   View

--- a/components/admin/receipts-skeleton.tsx
+++ b/components/admin/receipts-skeleton.tsx
@@ -15,14 +15,14 @@ export function ReceiptsSkeleton() {
       aria-label="Loading receipts queue"
       className="overflow-hidden rounded-[14px] border"
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 8%, transparent)',
       }}
     >
       <div
         className="flex items-center justify-between gap-3 px-4 py-3"
         style={{
           borderBottom:
-            '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <SkeletonBlock w={140} h={14} />
@@ -36,7 +36,7 @@ export function ReceiptsSkeleton() {
             borderBottom:
               i === ROWS.length - 1
                 ? 'none'
-                : '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+                : '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="flex items-center gap-2.5">

--- a/components/admin/receipts-view.tsx
+++ b/components/admin/receipts-view.tsx
@@ -49,11 +49,11 @@ export function ReceiptsView({ rows, aggregates, groupCount }: ReceiptsViewProps
       <header className="flex flex-col gap-1">
         <h1
           id="receipts-title"
-          className="text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+          className="text-[1.5rem] font-semibold tracking-tight text-ink"
         >
           Receipts queue
         </h1>
-        <p className="text-[13px] text-d2-ink/55">{subLine}</p>
+        <p className="text-[13px] text-ink/55">{subLine}</p>
       </header>
 
       <ReceiptsQueueSignals aggregates={aggregates} />
@@ -70,10 +70,10 @@ export function ReceiptsView({ rows, aggregates, groupCount }: ReceiptsViewProps
       ) : (
         <div
           role="status"
-          className="rounded-[14px] border p-8 text-center text-[13px] text-d2-ink/65"
+          className="rounded-[14px] border p-8 text-center text-[13px] text-ink/65"
           style={{
-            background: 'var(--d2-cream)',
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            background: 'var(--surface-card)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           No receipts in the queue right now. New WhatsApp submissions land
@@ -81,7 +81,7 @@ export function ReceiptsView({ rows, aggregates, groupCount }: ReceiptsViewProps
         </div>
       )}
 
-      <p className="text-center font-mono text-[11px] text-d2-ink/45 md:text-left">
+      <p className="text-center font-mono text-[11px] text-ink/45 md:text-left">
         triage on mobile · configure groups on desktop
       </p>
 

--- a/components/brand/poolpay-logo.tsx
+++ b/components/brand/poolpay-logo.tsx
@@ -42,7 +42,7 @@ interface PoolPayLogoProps {
  * (reduces to a single ring + core at ≤16 px or when `tiny` is set).
  *
  * Rings inherit `currentColor` so the mark flips with light/dark automatically.
- * Core uses `var(--ajo-paid)` which is theme-invariant (defined in globals.css).
+ * Core uses `var(--status-paid)` which is theme-invariant (defined in globals.css).
  */
 export function PoolPayLogo({
   variant = "symbol",
@@ -86,7 +86,7 @@ export function PoolPayLogo({
               stroke="currentColor"
               strokeWidth="3.5"
             />
-            <circle cx="20" cy="20" r="6" fill="var(--ajo-paid)" />
+            <circle cx="20" cy="20" r="6" fill="var(--status-paid)" />
           </>
         ) : (
           <>
@@ -108,7 +108,7 @@ export function PoolPayLogo({
               strokeWidth="2.2"
               strokeOpacity="0.55"
             />
-            <circle cx="20" cy="20" r="5" fill="var(--ajo-paid)" />
+            <circle cx="20" cy="20" r="5" fill="var(--status-paid)" />
           </>
         )}
       </svg>

--- a/components/dashboard/active-cycle-card.tsx
+++ b/components/dashboard/active-cycle-card.tsx
@@ -30,7 +30,7 @@ export function ActiveCycleCard({ summary }: ActiveCycleCardProps) {
           <h2 className="text-lg font-semibold tracking-tight text-foreground">
             Cycle {cycle.cycleNumber}
           </h2>
-          <Badge className="shrink-0 bg-ajo-paid-subtle text-ajo-paid border-transparent text-xs font-medium">
+          <Badge className="shrink-0 bg-status-paid-subtle text-status-paid border-transparent text-xs font-medium">
             Active
           </Badge>
         </div>

--- a/components/dashboard/collection-progress.tsx
+++ b/components/dashboard/collection-progress.tsx
@@ -35,7 +35,7 @@ export function CollectionProgress({
         className="h-2 w-full overflow-hidden rounded-full bg-muted"
       >
         <div
-          className="h-full rounded-full bg-ajo-paid transition-all duration-700 ease-out"
+          className="h-full rounded-full bg-status-paid transition-all duration-700 ease-out"
           style={{ width: `${percent}%` }}
         />
       </div>

--- a/components/dashboard/cycle-performance-chart.tsx
+++ b/components/dashboard/cycle-performance-chart.tsx
@@ -13,10 +13,10 @@ import {
 } from '@/components/ui/area-chart';
 
 // SVG gradient stop-color doesn't resolve CSS custom property chains reliably.
-// These hex values are the resolved equivalents of --ajo-paid and --ajo-outstanding
+// These hex values are the resolved equivalents of --status-paid and --status-pending
 // and are consistent across light and dark mode (brand colours don't invert).
-const TEAL = '#00bc7d'; // oklch(0.696 0.17 162.48), --ajo-paid
-const GOLD = '#e8970a'; // oklch(0.769 0.188 70.08), --ajo-outstanding
+const TEAL = '#00bc7d'; // oklch(0.696 0.17 162.48), --status-paid
+const GOLD = '#e8970a'; // oklch(0.769 0.188 70.08), --status-pending
 
 type ChartView = 'per-cycle' | 'cumulative';
 

--- a/components/dashboard/header.tsx
+++ b/components/dashboard/header.tsx
@@ -43,7 +43,7 @@ export function DashboardHeader({ activeCycle, groups, selectedGroupId }: Dashbo
           )}
           {activeCycle && (
             <Badge
-              className="shrink-0 bg-ajo-paid-subtle text-ajo-paid border-transparent text-xs font-medium px-2.5 py-1"
+              className="shrink-0 bg-status-paid-subtle text-status-paid border-transparent text-xs font-medium px-2.5 py-1"
               aria-label={`Active cycle: Cycle ${activeCycle.cycle.cycleNumber}`}
             >
               Cycle {activeCycle.cycle.cycleNumber} · Active

--- a/components/dashboard/kpi-stats.tsx
+++ b/components/dashboard/kpi-stats.tsx
@@ -20,14 +20,14 @@ interface StatTileProps {
 function StatTile({ label, value, sub, icon, accent = 'default' }: StatTileProps) {
   const accentClass = {
     default: 'text-muted-foreground',
-    paid: 'text-ajo-paid',
-    outstanding: 'text-ajo-outstanding',
+    paid: 'text-status-paid',
+    outstanding: 'text-status-pending',
   }[accent];
 
   const iconBg = {
     default: 'bg-muted',
-    paid: 'bg-ajo-paid-subtle',
-    outstanding: 'bg-ajo-outstanding-subtle',
+    paid: 'bg-status-paid-subtle',
+    outstanding: 'bg-status-pending-subtle',
   }[accent];
 
   return (
@@ -72,14 +72,14 @@ export function KpiStats({ totalKobo, collectedKobo, paidCount, totalMembers }: 
         label="Collected"
         value={formatNgn(collectedKobo)}
         sub={`${paidCount} of ${totalMembers} paid`}
-        icon={<TrendingUp className="h-4 w-4 text-ajo-paid" />}
+        icon={<TrendingUp className="h-4 w-4 text-status-paid" />}
         accent="paid"
       />
       <StatTile
         label="Outstanding"
         value={formatNgn(outstandingKobo)}
         sub={`${outstandingCount} member${outstandingCount !== 1 ? 's' : ''} pending`}
-        icon={<Users className="h-4 w-4 text-ajo-outstanding" />}
+        icon={<Users className="h-4 w-4 text-status-pending" />}
         accent={outstandingCount > 0 ? 'outstanding' : 'default'}
       />
     </div>

--- a/components/dashboard/outstanding-alert.tsx
+++ b/components/dashboard/outstanding-alert.tsx
@@ -19,15 +19,15 @@ export function OutstandingAlert({
     <div
       role="alert"
       aria-label={`${outstanding.length} member${outstanding.length > 1 ? 's' : ''} with outstanding payments`}
-      className="rounded-xl border border-ajo-outstanding/20 bg-ajo-outstanding-subtle px-4 py-4"
+      className="rounded-xl border border-status-pending/20 bg-status-pending-subtle px-4 py-4"
     >
       <div className="flex items-start gap-3">
         <AlertTriangle
-          className="mt-0.5 h-4 w-4 shrink-0 text-ajo-outstanding"
+          className="mt-0.5 h-4 w-4 shrink-0 text-status-pending"
           aria-hidden="true"
         />
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-ajo-outstanding">
+          <p className="text-sm font-medium text-status-pending">
             {outstanding.length} outstanding payment{outstanding.length > 1 ? 's' : ''}
           </p>
 

--- a/components/dashboard/payment-status-badge.tsx
+++ b/components/dashboard/payment-status-badge.tsx
@@ -12,24 +12,24 @@ interface PaymentStatusBadgeProps {
 export function PaymentStatusBadge({ hasPaid, variant = 'row' }: PaymentStatusBadgeProps) {
   if (variant === 'tile') {
     return hasPaid ? (
-      <div className="flex-1 flex items-center justify-center rounded-md bg-ajo-paid/15 border border-ajo-paid/30 px-2 py-1">
-        <span className="text-xs font-semibold text-ajo-paid">Paid</span>
+      <div className="flex-1 flex items-center justify-center rounded-md bg-status-paid/15 border border-status-paid/30 px-2 py-1">
+        <span className="text-xs font-semibold text-status-paid">Paid</span>
       </div>
     ) : (
-      <div className="flex-1 flex items-center justify-center rounded-md bg-ajo-outstanding/15 border border-ajo-outstanding/30 px-2 py-1">
-        <span className="text-xs font-semibold text-ajo-outstanding">Outstanding</span>
+      <div className="flex-1 flex items-center justify-center rounded-md bg-status-pending/15 border border-status-pending/30 px-2 py-1">
+        <span className="text-xs font-semibold text-status-pending">Outstanding</span>
       </div>
     );
   }
 
   return hasPaid ? (
-    <div className="px-3 py-1.5 rounded-lg bg-ajo-paid/10 border border-ajo-paid/30 flex items-center gap-1.5">
-      <span className="text-ajo-paid text-sm font-medium">Paid</span>
-      <CheckCircle2 className="h-3.5 w-3.5 text-ajo-paid" aria-hidden="true" />
+    <div className="px-3 py-1.5 rounded-lg bg-status-paid/10 border border-status-paid/30 flex items-center gap-1.5">
+      <span className="text-status-paid text-sm font-medium">Paid</span>
+      <CheckCircle2 className="h-3.5 w-3.5 text-status-paid" aria-hidden="true" />
     </div>
   ) : (
-    <div className="px-3 py-1.5 rounded-lg bg-ajo-outstanding/10 border border-ajo-outstanding/30">
-      <span className="text-ajo-outstanding text-sm font-medium">Outstanding</span>
+    <div className="px-3 py-1.5 rounded-lg bg-status-pending/10 border border-status-pending/30">
+      <span className="text-status-pending text-sm font-medium">Outstanding</span>
     </div>
   );
 }

--- a/components/dashboard/payment-toggle-button.tsx
+++ b/components/dashboard/payment-toggle-button.tsx
@@ -53,8 +53,8 @@ export function PaymentToggleButton({
         className={cn(
           'cursor-pointer transition-colors',
           hasPaid
-            ? 'border-ajo-outstanding text-ajo-outstanding hover:bg-ajo-outstanding/10 hover:text-ajo-outstanding'
-            : 'border-ajo-paid text-ajo-paid hover:bg-ajo-paid/10 hover:text-ajo-paid',
+            ? 'border-status-pending text-status-pending hover:bg-status-pending/10 hover:text-status-pending'
+            : 'border-status-paid text-status-paid hover:bg-status-paid/10 hover:text-status-paid',
         )}
       >
         {isPending ? (

--- a/components/feedback/banner.tsx
+++ b/components/feedback/banner.tsx
@@ -49,38 +49,38 @@ const TONE_STYLES: Record<
 > = {
   success: {
     background:
-      'color-mix(in oklch, var(--ajo-paid) 12%, var(--d2-cream))',
+      'color-mix(in oklch, var(--status-paid) 12%, var(--surface-card))',
     border:
-      '1px solid color-mix(in oklch, var(--ajo-paid) 30%, transparent)',
-    foreground: 'var(--ajo-paid)',
+      '1px solid color-mix(in oklch, var(--status-paid) 30%, transparent)',
+    foreground: 'var(--status-paid)',
   },
   info: {
     background:
-      'color-mix(in oklch, var(--d2-accent) 8%, var(--d2-cream))',
+      'color-mix(in oklch, var(--accent-primary) 8%, var(--surface-card))',
     border:
-      '1px solid color-mix(in oklch, var(--d2-accent) 25%, transparent)',
-    foreground: 'var(--d2-accent)',
+      '1px solid color-mix(in oklch, var(--accent-primary) 25%, transparent)',
+    foreground: 'var(--accent-primary)',
   },
   warning: {
     background:
-      'color-mix(in oklch, var(--ajo-outstanding) 12%, var(--d2-cream))',
+      'color-mix(in oklch, var(--status-pending) 12%, var(--surface-card))',
     border:
-      '1px solid color-mix(in oklch, var(--ajo-outstanding) 30%, transparent)',
-    foreground: 'var(--ajo-outstanding-fg)',
+      '1px solid color-mix(in oklch, var(--status-pending) 30%, transparent)',
+    foreground: 'var(--status-pending-fg)',
   },
   error: {
     background:
-      'color-mix(in oklch, var(--destructive) 10%, var(--d2-cream))',
+      'color-mix(in oklch, var(--destructive) 10%, var(--surface-card))',
     border:
       '1px solid color-mix(in oklch, var(--destructive) 28%, transparent)',
     foreground: 'var(--destructive)',
   },
   sparkle: {
     background:
-      'color-mix(in oklch, var(--d2-accent) 8%, var(--d2-cream))',
+      'color-mix(in oklch, var(--accent-primary) 8%, var(--surface-card))',
     border:
-      '1px solid color-mix(in oklch, var(--d2-accent) 25%, transparent)',
-    foreground: 'var(--d2-accent)',
+      '1px solid color-mix(in oklch, var(--accent-primary) 25%, transparent)',
+    foreground: 'var(--accent-primary)',
   },
 };
 
@@ -89,8 +89,8 @@ const TONE_STYLES: Record<
  * page, not over it. For transient feedback over a route boundary use
  * `<Toast>` from the same module.
  *
- * Tone palette is pinned to existing tokens (--ajo-paid, --ajo-outstanding,
- * --destructive, --d2-accent) so dark-mode flips automatically without
+ * Tone palette is pinned to existing tokens (--status-paid, --status-pending,
+ * --destructive, --accent-primary) so dark-mode flips automatically without
  * adding new variables.
  */
 export function Banner({
@@ -124,11 +124,11 @@ export function Banner({
         className="mt-0.5 shrink-0"
         style={{ color: styles.foreground }}
       />
-      <div className="min-w-0 flex-1 text-[12.5px] leading-[1.45] text-d2-ink/75">
+      <div className="min-w-0 flex-1 text-[12.5px] leading-[1.45] text-ink/75">
         {title && (
           <div
-            className="mb-0.5 text-[13px] font-semibold text-d2-ink"
-            style={{ color: 'var(--d2-ink)' }}
+            className="mb-0.5 text-[13px] font-semibold text-ink"
+            style={{ color: 'var(--ink)' }}
           >
             {title}
           </div>
@@ -145,7 +145,7 @@ export function Banner({
           type="button"
           onClick={onDismiss}
           aria-label={dismissLabel}
-          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-d2-ink/50 transition-colors hover:bg-d2-ink/5"
+          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-ink/50 transition-colors hover:bg-ink/5"
         >
           <X size={13} aria-hidden="true" />
         </button>

--- a/components/feedback/dark-error-frame.tsx
+++ b/components/feedback/dark-error-frame.tsx
@@ -13,7 +13,7 @@ export interface DarkErrorFrameProps {
   glyph: ReactNode;
   /**
    * Headline. Accepts nodes so callers can wrap the accent phrase in
-   * `<em className="text-ajo-paid not-italic">…</em>`.
+   * `<em className="text-status-paid not-italic">…</em>`.
    */
   headline: ReactNode;
   /** Body paragraph below the headline. Optional. */
@@ -57,10 +57,10 @@ export function DarkErrorFrame({
             aria-hidden="true"
           >
             {glyph}
-            <span className="bg-ajo-paid mt-1.5 block h-0.5 w-11 md:h-[3px] md:w-16" />
+            <span className="bg-status-paid mt-1.5 block h-0.5 w-11 md:h-[3px] md:w-16" />
           </div>
 
-          <p className="text-ajo-paid mb-3.5 font-mono text-[10.5px] uppercase tracking-[0.1em] md:mb-4 md:text-[11px] md:tracking-[0.08em]">
+          <p className="text-status-paid mb-3.5 font-mono text-[10.5px] uppercase tracking-[0.1em] md:mb-4 md:text-[11px] md:tracking-[0.08em]">
             {kicker}
           </p>
 
@@ -90,7 +90,7 @@ export function DarkErrorFrame({
 function StatusPill({ children }: { children: ReactNode }) {
   return (
     <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-2.5 py-[5px] font-mono text-[11px] tracking-[0.04em] text-muted-foreground dark:border-white/[0.12] dark:bg-white/[0.04] dark:text-[oklch(0.7_0_0)]">
-      <span className="h-1.5 w-1.5 rounded-full bg-ajo-paid" />
+      <span className="h-1.5 w-1.5 rounded-full bg-status-paid" />
       {children}
     </span>
   );

--- a/components/feedback/dark-error-frame.tsx
+++ b/components/feedback/dark-error-frame.tsx
@@ -167,7 +167,7 @@ function RingPaths() {
         strokeWidth="1"
         strokeOpacity="0.22"
       />
-      <circle cx="360" cy="360" r="46" className="fill-ajo-paid" />
+      <circle cx="360" cy="360" r="46" className="fill-status-paid" />
     </>
   );
 }

--- a/components/feedback/empty-state.tsx
+++ b/components/feedback/empty-state.tsx
@@ -42,20 +42,20 @@ export interface EmptyStateProps {
 
 const ICON_TILE_STYLES: Record<EmptyStateTone, string> = {
   gradient:
-    'h-[72px] w-[72px] rounded-[18px] text-white shadow-[0_12px_30px_-8px_color-mix(in_oklch,var(--d2-accent)_50%,transparent)]',
-  muted: 'h-14 w-14 rounded-[14px] text-d2-ink/60',
-  dashed: 'h-12 w-12 rounded-[12px] text-d2-ink/55',
+    'h-[72px] w-[72px] rounded-[18px] text-white shadow-[0_12px_30px_-8px_color-mix(in_oklch,var(--accent-primary)_50%,transparent)]',
+  muted: 'h-14 w-14 rounded-[14px] text-ink/60',
+  dashed: 'h-12 w-12 rounded-[12px] text-ink/55',
 };
 
 const ICON_TILE_BG: Record<EmptyStateTone, string> = {
-  gradient: 'linear-gradient(135deg, var(--d2-accent), var(--d2-lav))',
-  muted: 'color-mix(in oklch, var(--d2-ink) 5%, transparent)',
+  gradient: 'linear-gradient(135deg, var(--accent-primary), var(--accent-lavender))',
+  muted: 'color-mix(in oklch, var(--ink) 5%, transparent)',
   dashed: 'transparent',
 };
 
 const TITLE_STYLES: Record<'h2' | 'h3', string> = {
-  h2: 'text-[22px] font-semibold tracking-tight text-d2-ink',
-  h3: 'text-[17px] font-semibold text-d2-ink',
+  h2: 'text-[22px] font-semibold tracking-tight text-ink',
+  h3: 'text-[17px] font-semibold text-ink',
 };
 
 /**
@@ -96,7 +96,7 @@ export function EmptyState({
       style={
         isDashed
           ? {
-              border: '1px dashed color-mix(in oklch, var(--d2-ink) 18%, transparent)',
+              border: '1px dashed color-mix(in oklch, var(--ink) 18%, transparent)',
             }
           : undefined
       }
@@ -113,7 +113,7 @@ export function EmptyState({
           {title}
         </HeadingTag>
         {description && (
-          <p className="mb-5 text-[13.5px] leading-[1.5] text-d2-ink/60">
+          <p className="mb-5 text-[13.5px] leading-[1.5] text-ink/60">
             {description}
           </p>
         )}

--- a/components/feedback/empty-state.tsx
+++ b/components/feedback/empty-state.tsx
@@ -66,9 +66,9 @@ const TITLE_STYLES: Record<'h2' | 'h3', string> = {
  *
  * Why this lives in `components/feedback/` and not `components/ui/`:
  * `components/ui/` is the shadcn scaffold. The empty-state shape is
- * project-specific (the d2 tokens, the gradient tile, the dashed border
- * tone), so it sits one layer above the shadcn primitives without
- * extending or replacing them.
+ * project-specific (surface and accent tokens, the gradient tile, the
+ * dashed border tone), so it sits one layer above the shadcn primitives
+ * without extending or replacing them.
  */
 export function EmptyState({
   icon,

--- a/components/feedback/form-field.tsx
+++ b/components/feedback/form-field.tsx
@@ -22,24 +22,24 @@ const STATE_BORDER_BACKGROUND: Record<
   { border: string; background: string; boxShadow?: string }
 > = {
   default: {
-    border: '1px solid color-mix(in oklch, var(--d2-ink) 12%, transparent)',
-    background: 'var(--d2-cream)',
+    border: '1px solid color-mix(in oklch, var(--ink) 12%, transparent)',
+    background: 'var(--surface-card)',
   },
   focus: {
-    border: '1.5px solid var(--d2-accent)',
-    background: 'var(--d2-cream)',
+    border: '1.5px solid var(--accent-primary)',
+    background: 'var(--surface-card)',
     boxShadow:
-      '0 0 0 3px color-mix(in oklch, var(--d2-accent) 18%, transparent)',
+      '0 0 0 3px color-mix(in oklch, var(--accent-primary) 18%, transparent)',
   },
   error: {
     border: '1.5px solid var(--destructive)',
-    background: 'var(--d2-cream)',
+    background: 'var(--surface-card)',
     boxShadow:
       '0 0 0 3px color-mix(in oklch, var(--destructive) 14%, transparent)',
   },
   disabled: {
-    border: '1px solid color-mix(in oklch, var(--d2-ink) 8%, transparent)',
-    background: 'color-mix(in oklch, var(--d2-ink) 4%, transparent)',
+    border: '1px solid color-mix(in oklch, var(--ink) 8%, transparent)',
+    background: 'color-mix(in oklch, var(--ink) 4%, transparent)',
   },
 };
 
@@ -51,7 +51,7 @@ const STATE_BORDER_BACKGROUND: Record<
  * Why this lives in `components/feedback/` and not `components/ui/`:
  * the existing shadcn `<Input>` is a primitive that the project uses
  * for raw text input where chrome control is needed (signin, recover).
- * `<FormField>` is the d2-shaped wrapper that bundles the label + hint
+ * `<FormField>` is the wrapper that bundles the label + hint
  * + icon + help row on top of an input. Surfaces that want the full d2
  * field experience compose this; surfaces that need a bare input
  * (auth, password reveal) keep using shadcn directly.
@@ -86,12 +86,12 @@ export const FormField = forwardRef<HTMLInputElement, FormFieldProps>(
         {(label || hint) && (
           <div className="flex items-baseline justify-between">
             {label && (
-              <label htmlFor={id} className="text-[12px] font-medium text-d2-ink">
+              <label htmlFor={id} className="text-[12px] font-medium text-ink">
                 {label}
               </label>
             )}
             {hint && (
-              <span className="font-mono text-[10px] text-d2-ink/55">
+              <span className="font-mono text-[10px] text-ink/55">
                 {hint}
               </span>
             )}
@@ -112,7 +112,7 @@ export const FormField = forwardRef<HTMLInputElement, FormFieldProps>(
               aria-hidden="true"
               style={{
                 color:
-                  'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+                  'color-mix(in oklch, var(--ink) 55%, transparent)',
               }}
             />
           )}
@@ -123,7 +123,7 @@ export const FormField = forwardRef<HTMLInputElement, FormFieldProps>(
             readOnly={readOnly}
             aria-invalid={isError || undefined}
             aria-describedby={helpId}
-            className="flex-1 bg-transparent text-[14px] outline-none placeholder:text-d2-ink/40 disabled:cursor-not-allowed"
+            className="flex-1 bg-transparent text-[14px] outline-none placeholder:text-ink/40 disabled:cursor-not-allowed"
             onFocus={onFocus}
             onBlur={onBlur}
             {...inputProps}
@@ -136,7 +136,7 @@ export const FormField = forwardRef<HTMLInputElement, FormFieldProps>(
             style={{
               color: isError
                 ? 'var(--destructive)'
-                : 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+                : 'color-mix(in oklch, var(--ink) 55%, transparent)',
             }}
           >
             {isError && <AlertCircle size={11} aria-hidden="true" />}

--- a/components/feedback/modal-shell.tsx
+++ b/components/feedback/modal-shell.tsx
@@ -83,22 +83,22 @@ export function ModalShell({
         className="absolute inset-0 backdrop-blur-[3px]"
         style={{
           background:
-            'color-mix(in oklch, var(--d2-ink) 35%, transparent)',
+            'color-mix(in oklch, var(--ink) 35%, transparent)',
         }}
       />
       <div
-        className="relative z-10 flex w-full flex-col overflow-hidden rounded-[18px] bg-d2-cream"
+        className="relative z-10 flex w-full flex-col overflow-hidden rounded-[18px] bg-surface-card"
         style={{
           maxWidth: width,
           boxShadow:
-            '0 30px 80px -20px color-mix(in oklch, var(--d2-ink) 35%, transparent), 0 4px 12px color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+            '0 30px 80px -20px color-mix(in oklch, var(--ink) 35%, transparent), 0 4px 12px color-mix(in oklch, var(--ink) 8%, transparent)',
         }}
       >
         <header
           className="flex items-start gap-3 px-5 py-4"
           style={{
             borderBottom:
-              '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="min-w-0 flex-1">
@@ -112,7 +112,7 @@ export function ModalShell({
               {title}
             </h3>
             {sub && (
-              <p className="mt-1 text-[12.5px] leading-snug text-d2-ink/60">
+              <p className="mt-1 text-[12.5px] leading-snug text-ink/60">
                 {sub}
               </p>
             )}
@@ -121,7 +121,7 @@ export function ModalShell({
             type="button"
             onClick={onClose}
             aria-label="Close dialog"
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-d2-ink/60 transition-colors hover:bg-d2-ink/5"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-ink/60 transition-colors hover:bg-ink/5"
           >
             <X size={16} aria-hidden="true" />
           </button>
@@ -132,12 +132,12 @@ export function ModalShell({
             className="flex flex-col-reverse items-stretch gap-2 px-5 py-3.5 sm:flex-row sm:items-center sm:justify-between"
             style={{
               borderTop:
-                '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+                '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
               background:
-                'color-mix(in oklch, var(--d2-ink) 2%, transparent)',
+                'color-mix(in oklch, var(--ink) 2%, transparent)',
             }}
           >
-            <div className="text-d2-ink/55">{footerLeft}</div>
+            <div className="text-ink/55">{footerLeft}</div>
             <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
               {footerRight}
             </div>

--- a/components/feedback/skeleton-block.tsx
+++ b/components/feedback/skeleton-block.tsx
@@ -19,7 +19,7 @@ const toCssDimension = (value: string | number | undefined): string | undefined 
 
 /**
  * Shimmer skeleton primitive lifted from the handoff `<Skel>` artboard.
- * Mirrors the d2-ink linear-gradient shimmer rather than the shadcn
+ * Mirrors the ink linear-gradient shimmer rather than the shadcn
  * `<Skeleton>` pulse so the loading state visually matches the rest of
  * the d2 surface. The shadcn primitive stays for chart skeletons and the
  * legacy dashboard loading.tsx; new shell-aware skeletons compose this.
@@ -41,9 +41,9 @@ export function SkeletonBlock({
         height: toCssDimension(h),
         borderRadius: r,
         background:
-          'linear-gradient(90deg, color-mix(in oklch, var(--d2-ink) 6%, transparent) 0%, color-mix(in oklch, var(--d2-ink) 11%, transparent) 50%, color-mix(in oklch, var(--d2-ink) 6%, transparent) 100%)',
+          'linear-gradient(90deg, color-mix(in oklch, var(--ink) 6%, transparent) 0%, color-mix(in oklch, var(--ink) 11%, transparent) 50%, color-mix(in oklch, var(--ink) 6%, transparent) 100%)',
         backgroundSize: '200% 100%',
-        animation: 'd2-shimmer 1.6s ease-in-out infinite',
+        animation: 'surface-shimmer 1.6s ease-in-out infinite',
         ...style,
       }}
     />

--- a/components/feedback/skeleton-block.tsx
+++ b/components/feedback/skeleton-block.tsx
@@ -21,8 +21,9 @@ const toCssDimension = (value: string | number | undefined): string | undefined 
  * Shimmer skeleton primitive lifted from the handoff `<Skel>` artboard.
  * Mirrors the ink linear-gradient shimmer rather than the shadcn
  * `<Skeleton>` pulse so the loading state visually matches the rest of
- * the d2 surface. The shadcn primitive stays for chart skeletons and the
- * legacy dashboard loading.tsx; new shell-aware skeletons compose this.
+ * the brand surface. The shadcn primitive stays for chart skeletons and
+ * the legacy dashboard loading.tsx; new shell-aware skeletons compose
+ * this.
  */
 export function SkeletonBlock({
   w = '100%',

--- a/components/feedback/toast.tsx
+++ b/components/feedback/toast.tsx
@@ -37,38 +37,38 @@ const TONE_STYLES: Record<
 > = {
   success: {
     background:
-      'color-mix(in oklch, var(--ajo-paid) 12%, var(--d2-cream))',
+      'color-mix(in oklch, var(--status-paid) 12%, var(--surface-card))',
     border:
-      '1px solid color-mix(in oklch, var(--ajo-paid) 30%, transparent)',
-    foreground: 'var(--ajo-paid)',
+      '1px solid color-mix(in oklch, var(--status-paid) 30%, transparent)',
+    foreground: 'var(--status-paid)',
   },
   info: {
     background:
-      'color-mix(in oklch, var(--d2-accent) 8%, var(--d2-cream))',
+      'color-mix(in oklch, var(--accent-primary) 8%, var(--surface-card))',
     border:
-      '1px solid color-mix(in oklch, var(--d2-accent) 25%, transparent)',
-    foreground: 'var(--d2-accent)',
+      '1px solid color-mix(in oklch, var(--accent-primary) 25%, transparent)',
+    foreground: 'var(--accent-primary)',
   },
   warning: {
     background:
-      'color-mix(in oklch, var(--ajo-outstanding) 12%, var(--d2-cream))',
+      'color-mix(in oklch, var(--status-pending) 12%, var(--surface-card))',
     border:
-      '1px solid color-mix(in oklch, var(--ajo-outstanding) 30%, transparent)',
-    foreground: 'var(--ajo-outstanding-fg)',
+      '1px solid color-mix(in oklch, var(--status-pending) 30%, transparent)',
+    foreground: 'var(--status-pending-fg)',
   },
   error: {
     background:
-      'color-mix(in oklch, var(--destructive) 10%, var(--d2-cream))',
+      'color-mix(in oklch, var(--destructive) 10%, var(--surface-card))',
     border:
       '1px solid color-mix(in oklch, var(--destructive) 28%, transparent)',
     foreground: 'var(--destructive)',
   },
   sparkle: {
     background:
-      'color-mix(in oklch, var(--d2-accent) 8%, var(--d2-cream))',
+      'color-mix(in oklch, var(--accent-primary) 8%, var(--surface-card))',
     border:
-      '1px solid color-mix(in oklch, var(--d2-accent) 25%, transparent)',
-    foreground: 'var(--d2-accent)',
+      '1px solid color-mix(in oklch, var(--accent-primary) 25%, transparent)',
+    foreground: 'var(--accent-primary)',
   },
 };
 
@@ -105,7 +105,7 @@ export function Toast({
         background: styles.background,
         border: styles.border,
         boxShadow:
-          '0 8px 22px -10px color-mix(in oklch, var(--d2-ink) 15%, transparent)',
+          '0 8px 22px -10px color-mix(in oklch, var(--ink) 15%, transparent)',
       }}
     >
       <Icon
@@ -115,9 +115,9 @@ export function Toast({
         style={{ color: styles.foreground }}
       />
       <div className="min-w-0 flex-1">
-        <div className="text-[13px] font-semibold text-d2-ink">{title}</div>
+        <div className="text-[13px] font-semibold text-ink">{title}</div>
         {description && (
-          <div className="mt-0.5 text-[11.5px] text-d2-ink/60">
+          <div className="mt-0.5 text-[11.5px] text-ink/60">
             {description}
           </div>
         )}
@@ -127,7 +127,7 @@ export function Toast({
           type="button"
           onClick={onDismiss}
           aria-label={dismissLabel}
-          className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-d2-ink/50 transition-colors hover:bg-d2-ink/5"
+          className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-ink/50 transition-colors hover:bg-ink/5"
         >
           <X size={13} aria-hidden="true" />
         </button>

--- a/components/layout/pp-mobile-app-bar.tsx
+++ b/components/layout/pp-mobile-app-bar.tsx
@@ -21,14 +21,14 @@ export interface PPMobileAppBarProps {
 export function PPMobileAppBar({ title, sub, crumb, back }: PPMobileAppBarProps) {
   return (
     <header
-      className="flex shrink-0 items-center gap-2.5 border-b bg-d2-warm-bg px-4 py-2.5 md:hidden"
-      style={{ borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)' }}
+      className="flex shrink-0 items-center gap-2.5 border-b bg-surface-page px-4 py-2.5 md:hidden"
+      style={{ borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)' }}
     >
       {back ? (
         <Link
           href={back.href}
           aria-label={back.label}
-          className="inline-flex h-7 w-7 items-center justify-center rounded-lg text-d2-ink/70"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-lg text-ink/70"
         >
           <ChevronLeft size={18} aria-hidden="true" />
         </Link>
@@ -37,7 +37,7 @@ export function PPMobileAppBar({ title, sub, crumb, back }: PPMobileAppBarProps)
           className="inline-flex h-[22px] w-[22px] items-center justify-center rounded-md text-[11px] font-bold text-white"
           style={{
             background:
-              'linear-gradient(135deg, var(--d2-accent), var(--d2-lav))',
+              'linear-gradient(135deg, var(--accent-primary), var(--accent-lavender))',
           }}
           aria-hidden="true"
         >
@@ -46,14 +46,14 @@ export function PPMobileAppBar({ title, sub, crumb, back }: PPMobileAppBarProps)
       )}
       <div className="min-w-0 flex-1">
         {crumb && (
-          <div className="kicker-mono text-[10px] tracking-[0.06em] text-d2-ink/55">
+          <div className="kicker-mono text-[10px] tracking-[0.06em] text-ink/55">
             {crumb}
           </div>
         )}
-        <div className="truncate text-[15px] font-semibold tracking-tight text-d2-ink">
+        <div className="truncate text-[15px] font-semibold tracking-tight text-ink">
           {title}
         </div>
-        {sub && <div className="text-[11px] text-d2-ink/55">{sub}</div>}
+        {sub && <div className="text-[11px] text-ink/55">{sub}</div>}
       </div>
       {/* TODO(post-redesign): wire the notifications dropdown. */}
       <button
@@ -61,7 +61,7 @@ export function PPMobileAppBar({ title, sub, crumb, back }: PPMobileAppBarProps)
         disabled
         aria-label="Notifications (coming soon)"
         title="Notifications (coming soon)"
-        className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-d2-ink/5 text-d2-ink/65 disabled:cursor-not-allowed disabled:opacity-70"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-ink/5 text-ink/65 disabled:cursor-not-allowed disabled:opacity-70"
       >
         <Bell size={15} aria-hidden="true" />
       </button>

--- a/components/layout/pp-mobile-tab-bar.tsx
+++ b/components/layout/pp-mobile-tab-bar.tsx
@@ -69,8 +69,8 @@ export function PPMobileTabBar({
   return (
     <nav
       aria-label="Primary mobile navigation"
-      className="flex shrink-0 items-stretch border-t bg-d2-warm-bg px-0 py-1.5 md:hidden"
-      style={{ borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)' }}
+      className="flex shrink-0 items-stretch border-t bg-surface-page px-0 py-1.5 md:hidden"
+      style={{ borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)' }}
     >
       {tabs.map((tab) => {
         const isActive = tab.id === current;
@@ -87,7 +87,7 @@ export function PPMobileTabBar({
             aria-current={isActive ? 'page' : undefined}
             className={cn(
               'relative flex flex-1 flex-col items-center justify-center gap-0.5 py-1 text-[10px] font-medium',
-              isActive ? 'text-d2-ink' : 'text-d2-ink/55',
+              isActive ? 'text-ink' : 'text-ink/55',
             )}
           >
             <tab.icon

--- a/components/layout/pp-shell.tsx
+++ b/components/layout/pp-shell.tsx
@@ -65,7 +65,7 @@ export function PPShell({
   };
 
   return (
-    <div className="d2 flex min-h-dvh w-full flex-col bg-surface-page text-ink md:flex-row">
+    <div className="flex min-h-dvh w-full flex-col bg-surface-page text-ink md:flex-row">
       {/* Desktop sidebar, gates itself on `md:flex`, hidden below */}
       <PPSidebar
         role={role}

--- a/components/layout/pp-shell.tsx
+++ b/components/layout/pp-shell.tsx
@@ -29,7 +29,7 @@ export interface PPShellProps
 /**
  * Application shell, D2 sidebar + topbar + content panel on desktop;
  * a mobile top app bar + bottom tab bar below 768px. Both layouts cascade
- * D2 tokens (--d2-warm-bg, --d2-cream, --d2-ink, --d2-accent, etc.)
+ * D2 tokens (--surface-page, --surface-card, --ink, --accent-primary, etc.)
  * through every descendant.
  *
  * Pages mount their content as children; page-level headings (H1, etc.)
@@ -65,7 +65,7 @@ export function PPShell({
   };
 
   return (
-    <div className="d2 flex min-h-dvh w-full flex-col bg-d2-warm-bg text-d2-ink md:flex-row">
+    <div className="d2 flex min-h-dvh w-full flex-col bg-surface-page text-ink md:flex-row">
       {/* Desktop sidebar, gates itself on `md:flex`, hidden below */}
       <PPSidebar
         role={role}
@@ -80,9 +80,9 @@ export function PPShell({
 
       <div className="flex min-w-0 flex-1 flex-col md:p-4 md:pl-0">
         <div
-          className="flex flex-1 flex-col overflow-hidden bg-d2-cream md:rounded-[18px] md:border"
+          className="flex flex-1 flex-col overflow-hidden bg-surface-card md:rounded-[18px] md:border"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           {/* Desktop topbar, gates itself via `hidden md:flex` */}

--- a/components/layout/pp-sidebar.tsx
+++ b/components/layout/pp-sidebar.tsx
@@ -96,13 +96,13 @@ const ROLE_PILL_STYLES: Record<
 > = {
   member: {
     label: 'member',
-    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-    color: 'color-mix(in oklch, var(--d2-ink) 70%, transparent)',
+    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
+    color: 'color-mix(in oklch, var(--ink) 70%, transparent)',
   },
   admin: {
     label: 'admin',
-    background: 'var(--d2-accent-soft)',
-    color: 'var(--d2-accent)',
+    background: 'var(--accent-primary-soft)',
+    color: 'var(--accent-primary)',
   },
   super_admin: {
     label: 'super_admin',
@@ -126,11 +126,11 @@ function NavLink({
       className={cn(
         'flex items-center gap-3 rounded-[10px] px-3 py-2 text-sm font-medium transition-colors',
         isActive
-          ? 'bg-d2-ink text-d2-warm-bg'
-          : 'text-d2-ink/75 hover:bg-d2-ink/5 hover:text-d2-ink',
+          ? 'bg-ink text-surface-page'
+          : 'text-ink/75 hover:bg-ink/5 hover:text-ink',
       )}
     >
-      <item.icon size={17} aria-hidden="true" className={cn(isActive ? 'text-d2-warm-bg' : 'text-d2-ink/60')} />
+      <item.icon size={17} aria-hidden="true" className={cn(isActive ? 'text-surface-page' : 'text-ink/60')} />
       <span className="flex-1">{item.label}</span>
       {item.count != null && (
         <span className="font-mono text-[0.6875rem] opacity-70 tabular-nums">
@@ -157,15 +157,15 @@ export function PPSidebar({
   return (
     <aside
       aria-label="Primary navigation"
-      className="hidden w-[280px] shrink-0 flex-col gap-3.5 bg-d2-warm-bg p-4 md:flex"
+      className="hidden w-[280px] shrink-0 flex-col gap-3.5 bg-surface-page p-4 md:flex"
     >
       {/* Brand */}
       <div className="flex items-center gap-2.5 px-2 py-1 text-[1.0625rem] font-semibold tracking-tight">
         <span
           className="inline-flex h-7 w-7 items-center justify-center rounded-[10px] text-sm font-bold text-white"
           style={{
-            background: 'linear-gradient(135deg, var(--d2-accent), var(--d2-lav))',
-            boxShadow: '0 4px 12px color-mix(in oklch, var(--d2-accent) 35%, transparent)',
+            background: 'linear-gradient(135deg, var(--accent-primary), var(--accent-lavender))',
+            boxShadow: '0 4px 12px color-mix(in oklch, var(--accent-primary) 35%, transparent)',
           }}
           aria-hidden="true"
         >
@@ -177,14 +177,14 @@ export function PPSidebar({
       {/* Active-pool context card */}
       {activeGroup && (
         <div
-          className="flex flex-col gap-2.5 rounded-[14px] bg-d2-cream p-3.5"
+          className="flex flex-col gap-2.5 rounded-[14px] bg-surface-card p-3.5"
           style={{
-            border: '1px solid color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+            border: '1px solid color-mix(in oklch, var(--ink) 8%, transparent)',
           }}
         >
           <div
             className="flex items-center justify-between font-mono text-[0.625rem] uppercase tracking-[0.08em]"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
           >
             <span>Active pool</span>
             {/* TODO(slice 2): wire the pool switcher. */}
@@ -195,8 +195,8 @@ export function PPSidebar({
               title="Switch active pool (coming soon)"
               className="cursor-not-allowed rounded-[4px] px-1.5 py-px font-sans text-xs font-medium normal-case tracking-normal opacity-60"
               style={{
-                background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-                color: 'var(--d2-ink)',
+                background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
+                color: 'var(--ink)',
               }}
             >
               Switch
@@ -211,7 +211,7 @@ export function PPSidebar({
           </div>
           <div
             className="text-xs"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
           >
             {activeGroup.memberCount} {activeGroup.memberCount === 1 ? 'member' : 'members'}
           </div>
@@ -234,7 +234,7 @@ export function PPSidebar({
         <>
           <div
             className="my-1 h-px"
-            style={{ background: 'color-mix(in oklch, var(--d2-ink) 8%, transparent)' }}
+            style={{ background: 'color-mix(in oklch, var(--ink) 8%, transparent)' }}
           />
           <div className="kicker-mono px-3 py-1 text-[0.625rem]">
             Administration
@@ -249,20 +249,20 @@ export function PPSidebar({
               className={cn(
                 'flex items-center gap-3 rounded-[10px] px-3 py-2 text-sm font-medium transition-colors',
                 current === 'receipts'
-                  ? 'bg-d2-ink text-d2-warm-bg'
-                  : 'text-d2-ink/75 hover:bg-d2-ink/5 hover:text-d2-ink',
+                  ? 'bg-ink text-surface-page'
+                  : 'text-ink/75 hover:bg-ink/5 hover:text-ink',
               )}
             >
               <ReceiptText
                 size={17}
                 aria-hidden="true"
-                className={current === 'receipts' ? 'text-d2-warm-bg' : 'text-d2-ink/60'}
+                className={current === 'receipts' ? 'text-surface-page' : 'text-ink/60'}
               />
               <span className="flex-1">Receipts queue</span>
               {showReceiptsBadge && (
                 <span
                   className="font-mono text-[0.6875rem] font-semibold tabular-nums"
-                  style={{ color: 'var(--ajo-outstanding)' }}
+                  style={{ color: 'var(--status-pending)' }}
                 >
                   {pendingReceiptsCount}
                 </span>
@@ -277,7 +277,7 @@ export function PPSidebar({
         <>
           <div
             className="my-1 h-px"
-            style={{ background: 'color-mix(in oklch, var(--d2-ink) 8%, transparent)' }}
+            style={{ background: 'color-mix(in oklch, var(--ink) 8%, transparent)' }}
           />
           <div
             className="kicker-mono px-3 py-1 text-[0.625rem]"
@@ -296,12 +296,12 @@ export function PPSidebar({
       {/* User foot */}
       <div
         className="mt-auto flex items-center gap-2.5 px-2 pt-2.5"
-        style={{ borderTop: '1px solid color-mix(in oklch, var(--d2-ink) 8%, transparent)' }}
+        style={{ borderTop: '1px solid color-mix(in oklch, var(--ink) 8%, transparent)' }}
       >
         <span
           className="inline-flex h-8 w-8 items-center justify-center rounded-full text-[0.8125rem] font-semibold text-white"
           style={{
-            background: 'linear-gradient(135deg, var(--d2-coral), var(--d2-lav))',
+            background: 'linear-gradient(135deg, var(--accent-coral), var(--accent-lavender))',
           }}
           aria-hidden="true"
         >
@@ -319,7 +319,7 @@ export function PPSidebar({
           </span>
           <span
             className="truncate font-mono text-[0.6875rem]"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
           >
             {user.email}
           </span>
@@ -337,8 +337,8 @@ export function PPSidebar({
             type="submit"
             aria-label="Sign out"
             title="Sign out"
-            className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-lg transition-colors hover:bg-d2-ink/5"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 60%, transparent)' }}
+            className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-lg transition-colors hover:bg-ink/5"
+            style={{ color: 'color-mix(in oklch, var(--ink) 60%, transparent)' }}
           >
             <LogOut size={15} aria-hidden="true" />
           </button>

--- a/components/layout/pp-sidebar.tsx
+++ b/components/layout/pp-sidebar.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { signOutAction } from '@/app/signout/actions';
 import { cn } from '@/lib/utils';
+import { SidebarThemeToggle } from '@/components/layout/sidebar-theme-toggle';
 import type { Role } from '@/lib/auth/verify-credentials';
 
 /**
@@ -323,6 +324,7 @@ export function PPSidebar({
             {user.email}
           </span>
         </div>
+        <SidebarThemeToggle />
         {/*
           Sign-out is a server action, not a navigable route. Wrapping a
           submit button in a tiny form invokes `signOutAction` on click,

--- a/components/layout/pp-topbar.tsx
+++ b/components/layout/pp-topbar.tsx
@@ -34,13 +34,13 @@ export function PPTopbar({ title, sub, crumbs, showQuickPay = false, actions }: 
   return (
     <div
       className="hidden h-14 shrink-0 items-center gap-2 px-5 md:flex"
-      style={{ borderBottom: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)' }}
+      style={{ borderBottom: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)' }}
     >
       <div className="min-w-0">
         {crumbs && (
           <div
             className="mb-0.5 font-mono text-[0.6875rem] tracking-[0.03em]"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
           >
             {crumbs}
           </div>
@@ -49,7 +49,7 @@ export function PPTopbar({ title, sub, crumbs, showQuickPay = false, actions }: 
         {sub && (
           <div
             className="text-xs"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
           >
             {sub}
           </div>
@@ -64,8 +64,8 @@ export function PPTopbar({ title, sub, crumbs, showQuickPay = false, actions }: 
         title="Search (coming soon)"
         className="hidden min-w-[200px] items-center gap-2 rounded-full px-3 py-1.5 text-[0.8125rem] sm:inline-flex"
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 4%, transparent)',
-          color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 4%, transparent)',
+          color: 'color-mix(in oklch, var(--ink) 55%, transparent)',
         }}
       >
         <Search size={14} aria-hidden="true" />
@@ -78,7 +78,7 @@ export function PPTopbar({ title, sub, crumbs, showQuickPay = false, actions }: 
         aria-label="Notifications (coming soon)"
         title="Notifications (coming soon)"
         className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-        style={{ color: 'color-mix(in oklch, var(--d2-ink) 65%, transparent)' }}
+        style={{ color: 'color-mix(in oklch, var(--ink) 65%, transparent)' }}
       >
         <Bell size={17} aria-hidden="true" />
       </button>
@@ -90,7 +90,7 @@ export function PPTopbar({ title, sub, crumbs, showQuickPay = false, actions }: 
           disabled
           aria-label="Quick pay (coming soon)"
           title="Quick pay (coming soon)"
-          className="inline-flex items-center gap-1.5 rounded-full bg-d2-ink px-3.5 py-2 text-[0.8125rem] font-semibold text-d2-warm-bg disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex items-center gap-1.5 rounded-full bg-ink px-3.5 py-2 text-[0.8125rem] font-semibold text-surface-page disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Plus size={14} aria-hidden="true" />
           Quick pay

--- a/components/layout/sidebar-theme-toggle.tsx
+++ b/components/layout/sidebar-theme-toggle.tsx
@@ -38,8 +38,8 @@ export function SidebarThemeToggle() {
       aria-label={label}
       title={label}
       onClick={() => setTheme(next)}
-      className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-lg transition-colors hover:bg-d2-ink/5"
-      style={{ color: 'color-mix(in oklch, var(--d2-ink) 60%, transparent)' }}
+      className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-lg transition-colors hover:bg-ink/5"
+      style={{ color: 'color-mix(in oklch, var(--ink) 60%, transparent)' }}
     >
       {isDark ? (
         <Sun size={15} aria-hidden="true" />

--- a/components/layout/sidebar-theme-toggle.tsx
+++ b/components/layout/sidebar-theme-toggle.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+
+const subscribe = () => () => {};
+const getMountedSnapshot = () => true;
+const getMountedServerSnapshot = () => false;
+
+/**
+ * Sidebar-styled theme toggle. Lives next to the sign-out button in the
+ * user-foot block. Cycles light and dark; system mode is honoured on first
+ * paint via next-themes defaults but not exposed as a third click target,
+ * since the sidebar slot is icon-only and a dropdown would visually clash
+ * with the adjacent sign-out icon button.
+ *
+ * Hydration: render a neutral placeholder until mounted so the SSR HTML
+ * (theme unknown server-side) and the first client render agree on icon
+ * choice. `useSyncExternalStore` provides the mounted flag without a
+ * setState-in-effect, satisfying `react-hooks/set-state-in-effect`.
+ */
+export function SidebarThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const mounted = useSyncExternalStore(
+    subscribe,
+    getMountedSnapshot,
+    getMountedServerSnapshot,
+  );
+
+  const isDark = mounted && resolvedTheme === 'dark';
+  const next = isDark ? 'light' : 'dark';
+  const label = mounted ? `Switch to ${next} theme` : 'Toggle theme';
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={() => setTheme(next)}
+      className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-lg transition-colors hover:bg-d2-ink/5"
+      style={{ color: 'color-mix(in oklch, var(--d2-ink) 60%, transparent)' }}
+    >
+      {isDark ? (
+        <Sun size={15} aria-hidden="true" />
+      ) : (
+        <Moon size={15} aria-hidden="true" />
+      )}
+    </button>
+  );
+}

--- a/components/member/empty-pools.tsx
+++ b/components/member/empty-pools.tsx
@@ -30,7 +30,7 @@ export function EmptyPools() {
           type="button"
           disabled
           title="Invite-code redemption lands in a later slice"
-          className="rounded-[10px] bg-d2-ink px-4 py-2.5 text-[13.5px] font-semibold text-d2-warm-bg disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-[10px] bg-ink px-4 py-2.5 text-[13.5px] font-semibold text-surface-page disabled:cursor-not-allowed disabled:opacity-60"
         >
           Join with invite code
         </button>
@@ -40,9 +40,9 @@ export function EmptyPools() {
           type="button"
           disabled
           title="Invite request lands in a later slice"
-          className="rounded-[10px] border border-d2-ink/12 px-4 py-2.5 text-[13.5px] font-medium text-d2-ink disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-[10px] border border-ink/12 px-4 py-2.5 text-[13.5px] font-medium text-ink disabled:cursor-not-allowed disabled:opacity-60"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 12%, transparent)',
           }}
         >
           Ask to be invited
@@ -50,15 +50,15 @@ export function EmptyPools() {
       }
       footer={
         <div
-          className="flex gap-2.5 rounded-[12px] px-4 py-3.5 text-left text-[12px] leading-[1.5] text-d2-ink/65"
+          className="flex gap-2.5 rounded-[12px] px-4 py-3.5 text-left text-[12px] leading-[1.5] text-ink/65"
           style={{
-            background: 'color-mix(in oklch, var(--d2-ink) 4%, transparent)',
+            background: 'color-mix(in oklch, var(--ink) 4%, transparent)',
           }}
         >
           <MessageSquare
             size={16}
             aria-hidden="true"
-            className="mt-0.5 shrink-0 text-d2-accent"
+            className="mt-0.5 shrink-0 text-accent-primary"
           />
           <span>
             Already part of an ajo on WhatsApp? Ask the admin to link your

--- a/components/member/home-skeleton.tsx
+++ b/components/member/home-skeleton.tsx
@@ -30,7 +30,7 @@ export function HomeSkeleton() {
             className="flex flex-col gap-2 rounded-[14px] border p-4"
             style={{
               borderColor:
-                'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+                'color-mix(in oklch, var(--ink) 8%, transparent)',
             }}
           >
             <SkeletonBlock w="50%" h={10} />
@@ -48,7 +48,7 @@ export function HomeSkeleton() {
             className="flex flex-col gap-2.5 rounded-[14px] border p-3.5"
             style={{
               borderColor:
-                'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+                'color-mix(in oklch, var(--ink) 8%, transparent)',
             }}
           >
             <div className="flex items-center gap-2.5">

--- a/components/member/home-view.tsx
+++ b/components/member/home-view.tsx
@@ -31,16 +31,16 @@ const STAT_TINTS: Record<
   { background: string; borderColor: string }
 > = {
   collected: {
-    background: 'color-mix(in oklch, var(--d2-accent) 8%, var(--d2-cream))',
-    borderColor: 'color-mix(in oklch, var(--d2-accent) 22%, transparent)',
+    background: 'color-mix(in oklch, var(--accent-primary) 8%, var(--surface-card))',
+    borderColor: 'color-mix(in oklch, var(--accent-primary) 22%, transparent)',
   },
   outstanding: {
-    background: 'color-mix(in oklch, var(--d2-coral) 10%, var(--d2-cream))',
-    borderColor: 'color-mix(in oklch, var(--d2-coral) 22%, transparent)',
+    background: 'color-mix(in oklch, var(--accent-coral) 10%, var(--surface-card))',
+    borderColor: 'color-mix(in oklch, var(--accent-coral) 22%, transparent)',
   },
   'next-payout': {
-    background: 'color-mix(in oklch, var(--d2-lav) 12%, var(--d2-cream))',
-    borderColor: 'color-mix(in oklch, var(--d2-lav) 22%, transparent)',
+    background: 'color-mix(in oklch, var(--accent-lavender) 12%, var(--surface-card))',
+    borderColor: 'color-mix(in oklch, var(--accent-lavender) 22%, transparent)',
   },
 };
 
@@ -58,7 +58,7 @@ function HomeStatCard({ kicker, icon, value, detail }: HomeStatCardProps) {
       <span className="font-mono text-[1.625rem] font-semibold tracking-tight tabular-nums">
         {value}
       </span>
-      <span className="text-[11px] text-d2-ink/55">{detail}</span>
+      <span className="text-[11px] text-ink/55">{detail}</span>
     </div>
   );
 }
@@ -82,16 +82,16 @@ export function HomeView({
     <main id="main-content" aria-labelledby="home-title" className="flex flex-col gap-6">
       {/* Mobile hero, full-bleed dark ink card */}
       <section
-        className="rounded-[14px] bg-d2-ink p-4 text-d2-warm-bg md:hidden"
+        className="rounded-[14px] bg-ink p-4 text-surface-page md:hidden"
         aria-label="This month summary"
       >
-        <div className="kicker-mono text-[10px] text-d2-warm-bg/70">
+        <div className="kicker-mono text-[10px] text-surface-page/70">
           This month · on track
         </div>
         <div className="mt-1 font-mono text-[1.875rem] font-semibold leading-none tracking-tighter tabular-nums">
           {formatNgn(aggregates.expectedKobo)}
         </div>
-        <div className="mt-1 text-[12px] text-d2-warm-bg/70">
+        <div className="mt-1 text-[12px] text-surface-page/70">
           across {aggregates.poolCount} pools · {collectedPctOfExpected}% collected
         </div>
         <div className="mt-3 flex gap-2">
@@ -101,7 +101,7 @@ export function HomeView({
             disabled
             aria-label="Pay contribution (coming soon)"
             title="Pay contribution (coming soon)"
-            className="flex-1 rounded-[10px] bg-d2-accent py-2 text-[13px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-90"
+            className="flex-1 rounded-[10px] bg-accent-primary py-2 text-[13px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-90"
           >
             Pay contribution
           </button>
@@ -111,7 +111,7 @@ export function HomeView({
             disabled
             aria-label="Request (coming soon)"
             title="Request (coming soon)"
-            className="rounded-[10px] px-3.5 py-2 text-[13px] font-medium text-d2-warm-bg disabled:cursor-not-allowed disabled:opacity-90"
+            className="rounded-[10px] px-3.5 py-2 text-[13px] font-medium text-surface-page disabled:cursor-not-allowed disabled:opacity-90"
             style={{ background: 'color-mix(in oklch, white 12%, transparent)' }}
           >
             Request
@@ -124,14 +124,14 @@ export function HomeView({
         <p className="kicker-mono text-[11px]">This month</p>
         <h1
           id="home-title"
-          className="mt-2 text-[2rem] font-semibold leading-tight tracking-tighter text-d2-ink"
+          className="mt-2 text-[2rem] font-semibold leading-tight tracking-tighter text-ink"
         >
           You{"'"}re on track to collect
           <br />
           <span className="font-mono">{formatNgn(aggregates.expectedKobo)}</span>{' '}
           across {aggregates.poolCount} pools.
         </h1>
-        <p className="mt-2 text-[13px] text-d2-ink/55">{todayLabel}</p>
+        <p className="mt-2 text-[13px] text-ink/55">{todayLabel}</p>
       </header>
 
       <h1 className="sr-only md:hidden" id="home-title">
@@ -170,7 +170,7 @@ export function HomeView({
         <div className="flex items-center justify-between">
           <h2
             id="home-pools-title"
-            className="text-[15px] font-semibold tracking-tight text-d2-ink"
+            className="text-[15px] font-semibold tracking-tight text-ink"
           >
             Your pools
           </h2>

--- a/components/member/inbox-filter-chips.tsx
+++ b/components/member/inbox-filter-chips.tsx
@@ -34,7 +34,7 @@ export function InboxFilterChips() {
       aria-label="Filter inbox"
       className="flex gap-1 rounded-[10px] p-1"
       style={{
-        background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+        background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
       }}
     >
       {CHIPS.map((chip) => {
@@ -48,8 +48,8 @@ export function InboxFilterChips() {
             className={cn(
               'rounded-[8px] px-3 py-1 text-[12px] font-medium transition-colors',
               active
-                ? 'bg-d2-cream text-d2-ink shadow-sm'
-                : 'text-d2-ink/60 hover:text-d2-ink',
+                ? 'bg-surface-card text-ink shadow-sm'
+                : 'text-ink/60 hover:text-ink',
             )}
           >
             {chip.label}

--- a/components/member/inbox-list.tsx
+++ b/components/member/inbox-list.tsx
@@ -34,24 +34,24 @@ const KIND_TONE: Record<InboxItemKind, InboxTone> = {
 
 const TONE_STYLES: Record<InboxTone, { background: string; color: string }> = {
   paid: {
-    background: 'var(--ajo-paid-subtle)',
-    color: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    color: 'var(--status-paid)',
   },
   pending: {
-    background: 'var(--ajo-outstanding-subtle)',
-    color: 'var(--ajo-outstanding)',
+    background: 'var(--status-pending-subtle)',
+    color: 'var(--status-pending)',
   },
   out: {
     background: 'color-mix(in oklch, var(--destructive) 12%, transparent)',
     color: 'var(--destructive)',
   },
   accent: {
-    background: 'var(--d2-accent-soft)',
-    color: 'var(--d2-accent)',
+    background: 'var(--accent-primary-soft)',
+    color: 'var(--accent-primary)',
   },
   muted: {
-    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-    color: 'color-mix(in oklch, var(--d2-ink) 70%, transparent)',
+    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
+    color: 'color-mix(in oklch, var(--ink) 70%, transparent)',
   },
 };
 
@@ -90,9 +90,9 @@ export function InboxList({ items }: InboxListProps) {
   if (visible.length === 0) {
     return (
       <div
-        className="rounded-[14px] bg-d2-cream p-6 text-center text-[13px] text-d2-ink/65"
+        className="rounded-[14px] bg-surface-card p-6 text-center text-[13px] text-ink/65"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         Nothing to show. Switch filter, or check back later.
@@ -102,9 +102,9 @@ export function InboxList({ items }: InboxListProps) {
 
   return (
     <div
-      className="overflow-hidden rounded-[14px] bg-d2-cream"
+      className="overflow-hidden rounded-[14px] bg-surface-card"
       style={{
-        border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
     >
       <ul aria-label="Inbox" className="flex flex-col">
@@ -125,7 +125,7 @@ export function InboxList({ items }: InboxListProps) {
               )}
               style={{
                 borderColor:
-                  'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                  'color-mix(in oklch, var(--ink) 6%, transparent)',
               }}
             >
               <span
@@ -144,11 +144,11 @@ export function InboxList({ items }: InboxListProps) {
                 >
                   {item.title}
                 </div>
-                <div className="truncate text-[12px] text-d2-ink/55">
+                <div className="truncate text-[12px] text-ink/55">
                   {item.body}
                 </div>
               </div>
-              <span className="font-mono text-[11px] text-d2-ink/50">
+              <span className="font-mono text-[11px] text-ink/50">
                 {formatRelative(item.createdAt)}
               </span>
             </li>

--- a/components/member/inbox-view.tsx
+++ b/components/member/inbox-view.tsx
@@ -29,11 +29,11 @@ export function InboxView({ items }: InboxViewProps) {
         <p className="kicker-mono hidden text-[10px] md:block">Notifications</p>
         <h1
           id="inbox-title"
-          className="text-[1.5rem] font-semibold tracking-tight text-d2-ink max-md:sr-only md:mt-1"
+          className="text-[1.5rem] font-semibold tracking-tight text-ink max-md:sr-only md:mt-1"
         >
           Inbox
         </h1>
-        <p className="hidden text-[13px] text-d2-ink/55 md:mt-1 md:block">
+        <p className="hidden text-[13px] text-ink/55 md:mt-1 md:block">
           {items.length} {items.length === 1 ? 'item' : 'items'} · {unreadCount}{' '}
           unread
         </p>

--- a/components/member/member-status-row.tsx
+++ b/components/member/member-status-row.tsx
@@ -12,12 +12,12 @@ const PILL_STYLES: Record<
   { background: string; color: string }
 > = {
   paid: {
-    background: 'var(--ajo-paid-subtle)',
-    color: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    color: 'var(--status-paid)',
   },
   pending: {
-    background: 'var(--ajo-outstanding-subtle)',
-    color: 'var(--ajo-outstanding)',
+    background: 'var(--status-pending-subtle)',
+    color: 'var(--status-pending)',
   },
   overdue: {
     background: 'color-mix(in oklch, var(--destructive) 14%, transparent)',
@@ -46,13 +46,13 @@ export function MemberStatusRow({ row, isLast }: MemberStatusRowProps) {
       )}
       data-tone={tone}
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 6%, transparent)',
       }}
     >
       <span
         className="avatar"
         style={{
-          background: 'var(--d2-coral)',
+          background: 'var(--accent-coral)',
           color: 'white',
           border: 'none',
         }}
@@ -60,14 +60,14 @@ export function MemberStatusRow({ row, isLast }: MemberStatusRowProps) {
         {initial}
       </span>
       <div className="min-w-0">
-        <div className="truncate font-medium text-d2-ink">
+        <div className="truncate font-medium text-ink">
           {member.name}
           {isPayoutRecipient && (
             <span
               className="ml-2 inline-block rounded px-1.5 py-px font-mono text-[10px] font-medium"
               style={{
-                background: 'var(--d2-accent-soft)',
-                color: 'var(--d2-accent)',
+                background: 'var(--accent-primary-soft)',
+                color: 'var(--accent-primary)',
               }}
             >
               payout this cycle
@@ -81,7 +81,7 @@ export function MemberStatusRow({ row, isLast }: MemberStatusRowProps) {
       >
         {label}
       </span>
-      <span className="hidden font-mono text-[12px] text-d2-ink/55 tabular-nums md:inline">
+      <span className="hidden font-mono text-[12px] text-ink/55 tabular-nums md:inline">
         {amountLabel}
       </span>
     </div>

--- a/components/member/modal-pay-confirm.tsx
+++ b/components/member/modal-pay-confirm.tsx
@@ -74,10 +74,10 @@ export function ModalPayConfirm({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-[10px] border bg-transparent px-3.5 py-2 text-[13px] font-medium text-d2-ink"
+            className="rounded-[10px] border bg-transparent px-3.5 py-2 text-[13px] font-medium text-ink"
             style={{
               borderColor:
-                'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+                'color-mix(in oklch, var(--ink) 12%, transparent)',
             }}
           >
             Cancel
@@ -86,8 +86,8 @@ export function ModalPayConfirm({
             type="button"
             onClick={onConfirm}
             disabled={pending}
-            className="rounded-[10px] px-3.5 py-2 text-[13px] font-semibold text-d2-warm-bg disabled:cursor-not-allowed disabled:opacity-60"
-            style={{ background: 'var(--d2-ink)' }}
+            className="rounded-[10px] px-3.5 py-2 text-[13px] font-semibold text-surface-page disabled:cursor-not-allowed disabled:opacity-60"
+            style={{ background: 'var(--ink)' }}
           >
             {pending ? 'Confirming…' : 'Confirm & upload receipt'}
           </button>
@@ -98,9 +98,9 @@ export function ModalPayConfirm({
         className="flex items-center justify-between rounded-[12px] border px-4 py-3.5"
         style={{
           background:
-            'color-mix(in oklch, var(--d2-accent) 8%, transparent)',
+            'color-mix(in oklch, var(--accent-primary) 8%, transparent)',
           borderColor:
-            'color-mix(in oklch, var(--d2-accent) 25%, transparent)',
+            'color-mix(in oklch, var(--accent-primary) 25%, transparent)',
         }}
       >
         <div>
@@ -108,7 +108,7 @@ export function ModalPayConfirm({
           <div className="mt-0.5 text-[14.5px] font-semibold">
             {recipientName}
           </div>
-          <div className="mt-0.5 font-mono text-[12px] text-d2-ink/70">
+          <div className="mt-0.5 font-mono text-[12px] text-ink/70">
             {recipientAccount}
           </div>
         </div>
@@ -123,17 +123,17 @@ export function ModalPayConfirm({
         <div className="mb-1.5 flex items-baseline justify-between">
           <label
             htmlFor="pay-memo"
-            className="text-[12px] font-medium text-d2-ink"
+            className="text-[12px] font-medium text-ink"
           >
             Reference / memo
           </label>
-          <span className="font-mono text-[10px] text-d2-ink/55">optional</span>
+          <span className="font-mono text-[10px] text-ink/55">optional</span>
         </div>
         <div
-          className="rounded-[10px] border bg-d2-cream px-3 py-2 text-[13px]"
+          className="rounded-[10px] border bg-surface-card px-3 py-2 text-[13px]"
           style={{
             borderColor:
-              'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+              'color-mix(in oklch, var(--ink) 12%, transparent)',
           }}
         >
           <input
@@ -145,17 +145,17 @@ export function ModalPayConfirm({
         </div>
       </div>
       <label
-        className="flex items-center gap-2 rounded-[10px] px-3 py-2.5 text-[12.5px] text-d2-ink/70"
+        className="flex items-center gap-2 rounded-[10px] px-3 py-2.5 text-[12.5px] text-ink/70"
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 4%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 4%, transparent)',
         }}
       >
         <span
           aria-hidden="true"
           className="inline-flex h-4 w-4 items-center justify-center rounded-[4px] border"
           style={{
-            background: notifyWhatsApp ? 'var(--d2-accent)' : 'transparent',
-            borderColor: 'var(--d2-accent)',
+            background: notifyWhatsApp ? 'var(--accent-primary)' : 'transparent',
+            borderColor: 'var(--accent-primary)',
           }}
         >
           {notifyWhatsApp && (

--- a/components/member/pay-view.tsx
+++ b/components/member/pay-view.tsx
@@ -22,16 +22,16 @@ export function PayView({ detail }: PayViewProps) {
       className="mx-auto flex max-w-[560px] flex-col gap-3"
     >
       <header
-        className="rounded-[14px] bg-d2-cream p-5"
+        className="rounded-[14px] bg-surface-card p-5"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <div className="kicker-mono text-[10px]">Amount due</div>
-        <div className="font-mono text-[2.5rem] font-semibold leading-none tracking-tighter tabular-nums text-d2-ink">
+        <div className="font-mono text-[2.5rem] font-semibold leading-none tracking-tighter tabular-nums text-ink">
           {detail.cycle.contributionLabel}
         </div>
-        <div className="mt-1 text-[13px] text-d2-ink/55">
+        <div className="mt-1 text-[13px] text-ink/55">
           to {detail.pool.name} · cycle {detail.cycle.index} payout →{' '}
           {detail.cycle.recipient.name}
         </div>
@@ -42,9 +42,9 @@ export function PayView({ detail }: PayViewProps) {
 
       <section
         aria-labelledby="pay-step-1"
-        className="rounded-[14px] bg-d2-cream p-4"
+        className="rounded-[14px] bg-surface-card p-4"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <h2 id="pay-step-1" className="kicker-mono mb-2 text-[10px]">
@@ -54,16 +54,16 @@ export function PayView({ detail }: PayViewProps) {
           <div
             className="rounded-[10px] p-3 font-mono text-[13px]"
             style={{
-              background: 'var(--d2-warm-bg)',
+              background: 'var(--surface-page)',
               border:
-                '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+                '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
             }}
           >
-            <div className="text-[10px] text-d2-ink/55">Bank · {BANK_NAME}</div>
+            <div className="text-[10px] text-ink/55">Bank · {BANK_NAME}</div>
             <div className="mt-0.5 text-[14px] font-semibold tracking-wide">
               {BANK_ACCOUNT}
             </div>
-            <div className="text-[11px] text-d2-ink/55">
+            <div className="text-[11px] text-ink/55">
               PoolPay / {detail.pool.name}
             </div>
           </div>
@@ -75,9 +75,9 @@ export function PayView({ detail }: PayViewProps) {
             title="Copy account details (coming soon)"
             className="rounded-[10px] px-3.5 text-[12px] font-medium disabled:cursor-not-allowed disabled:opacity-90"
             style={{
-              background: 'var(--d2-warm-bg)',
+              background: 'var(--surface-page)',
               border:
-                '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+                '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
             }}
           >
             Copy
@@ -87,9 +87,9 @@ export function PayView({ detail }: PayViewProps) {
 
       <section
         aria-labelledby="pay-step-2"
-        className="rounded-[14px] bg-d2-cream p-4"
+        className="rounded-[14px] bg-surface-card p-4"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <h2 id="pay-step-2" className="kicker-mono mb-2 text-[10px]">
@@ -98,9 +98,9 @@ export function PayView({ detail }: PayViewProps) {
         <div
           className="flex items-center gap-2.5 rounded-[10px] p-3"
           style={{
-            background: 'var(--d2-warm-bg)',
+            background: 'var(--surface-page)',
             border:
-              '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <span
@@ -111,10 +111,10 @@ export function PayView({ detail }: PayViewProps) {
             <MessageSquare size={18} />
           </span>
           <div className="min-w-0 flex-1">
-            <div className="text-[13px] font-medium text-d2-ink">
+            <div className="text-[13px] font-medium text-ink">
               {detail.pool.name} · group chat
             </div>
-            <div className="font-mono text-[11px] text-d2-ink/55">
+            <div className="font-mono text-[11px] text-ink/55">
               bot matches by your phone number
             </div>
           </div>
@@ -125,8 +125,8 @@ export function PayView({ detail }: PayViewProps) {
             title="Coming soon"
             className="rounded-[10px] px-3.5 py-2 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-90"
             style={{
-              background: 'var(--d2-ink)',
-              color: 'var(--d2-warm-bg)',
+              background: 'var(--ink)',
+              color: 'var(--surface-page)',
             }}
           >
             Open WhatsApp
@@ -136,9 +136,9 @@ export function PayView({ detail }: PayViewProps) {
 
       <section
         aria-labelledby="pay-step-3"
-        className="rounded-[14px] bg-d2-cream p-4"
+        className="rounded-[14px] bg-surface-card p-4"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <h2 id="pay-step-3" className="kicker-mono mb-2 text-[10px]">
@@ -148,16 +148,16 @@ export function PayView({ detail }: PayViewProps) {
           <span
             className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
             style={{
-              background: 'var(--ajo-outstanding-subtle)',
-              color: 'var(--ajo-outstanding)',
+              background: 'var(--status-pending-subtle)',
+              color: 'var(--status-pending)',
             }}
             aria-hidden="true"
           >
             <Clock size={14} />
           </span>
           <div className="min-w-0 text-[13px]">
-            <div className="font-medium text-d2-ink">Pending review</div>
-            <div className="text-d2-ink/55">
+            <div className="font-medium text-ink">Pending review</div>
+            <div className="text-ink/55">
               An admin will confirm your payment within a few hours. You{"'"}ll
               get a notification in Inbox and a reply in the WhatsApp thread.
             </div>
@@ -165,7 +165,7 @@ export function PayView({ detail }: PayViewProps) {
         </div>
       </section>
 
-      <p className="kicker-mono mt-2 px-2 text-[10px] tracking-[0.04em] normal-case text-d2-ink/45">
+      <p className="kicker-mono mt-2 px-2 text-[10px] tracking-[0.04em] normal-case text-ink/45">
         poolpay never touches your money · transfers go bank-to-bank · receipts
         are verified by admin, not by OCR
       </p>

--- a/components/member/pool-card.tsx
+++ b/components/member/pool-card.tsx
@@ -20,30 +20,30 @@ export function PoolCard({ pool }: PoolCardProps) {
     <Link
       href={`/pools/${pool.id}`}
       aria-label={`Open ${pool.name}`}
-      className="block rounded-[14px] bg-d2-cream p-4 transition-colors hover:bg-d2-warm-bg/40"
+      className="block rounded-[14px] bg-surface-card p-4 transition-colors hover:bg-surface-page/40"
       style={{
-        border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
     >
       <div className="flex items-center gap-2.5">
         <PoolSwatch glyph={pool.initial} swatch={pool.swatch} />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold tracking-tight text-d2-ink">
+          <div className="truncate text-sm font-semibold tracking-tight text-ink">
             {pool.name}
           </div>
-          <div className="truncate text-[11px] text-d2-ink/55">
+          <div className="truncate text-[11px] text-ink/55">
             {pool.subtitle}
           </div>
         </div>
         <ChevronRight
           size={16}
           aria-hidden="true"
-          className="text-d2-ink/40"
+          className="text-ink/40"
         />
       </div>
-      <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-d2-ink/[0.08]">
+      <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-ink/[0.08]">
         <div
-          className="h-full rounded-full bg-d2-accent"
+          className="h-full rounded-full bg-accent-primary"
           style={{ width: `${pool.progressPct}%` }}
           role="progressbar"
           aria-valuenow={pool.progressPct}
@@ -52,9 +52,9 @@ export function PoolCard({ pool }: PoolCardProps) {
           aria-label={`${pool.name} progress`}
         />
       </div>
-      <div className="mt-2.5 flex items-center justify-between text-[11px] text-d2-ink/55">
+      <div className="mt-2.5 flex items-center justify-between text-[11px] text-ink/55">
         <span>{pool.footnote}</span>
-        <span className="font-mono tabular-nums text-d2-ink/75">
+        <span className="font-mono tabular-nums text-ink/75">
           {pool.amountLabel}
         </span>
       </div>

--- a/components/member/pool-detail-view.tsx
+++ b/components/member/pool-detail-view.tsx
@@ -35,11 +35,11 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
         <p className="kicker-mono text-[10px]">Pools / {detail.pool.name}</p>
         <h1
           id="pool-title"
-          className="mt-1 text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+          className="mt-1 text-[1.5rem] font-semibold tracking-tight text-ink"
         >
           {detail.pool.name}
         </h1>
-        <p className="mt-1 text-[13px] text-d2-ink/55">{detail.metaLine}</p>
+        <p className="mt-1 text-[13px] text-ink/55">{detail.metaLine}</p>
       </header>
       <h1 id="pool-title" className="sr-only md:hidden">
         {detail.pool.name}
@@ -51,7 +51,7 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
         className="rounded-[14px] p-4 text-white md:hidden"
         style={{
           background:
-            'linear-gradient(135deg, var(--d2-accent), var(--pool-swatch-teal))',
+            'linear-gradient(135deg, var(--accent-primary), var(--pool-swatch-teal))',
         }}
       >
         <div className="kicker-mono text-[10px] text-white/85">
@@ -93,17 +93,17 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
       {/* Desktop summary card */}
       <section
         aria-label="Cycle progress"
-        className="hidden grid-cols-[auto_1fr_auto] items-center gap-6 rounded-[14px] bg-d2-cream p-5 md:grid"
+        className="hidden grid-cols-[auto_1fr_auto] items-center gap-6 rounded-[14px] bg-surface-card p-5 md:grid"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <div>
           <div className="kicker-mono text-[10px]">Your payout</div>
-          <div className="mt-0.5 font-mono text-[1.5rem] font-semibold tracking-tight tabular-nums text-d2-ink">
+          <div className="mt-0.5 font-mono text-[1.5rem] font-semibold tracking-tight tabular-nums text-ink">
             {detail.cycle.payoutLabel}
           </div>
-          <div className="text-[12px] text-d2-ink/55">
+          <div className="text-[12px] text-ink/55">
             recipient · {detail.cycle.recipient.name}
           </div>
         </div>
@@ -116,18 +116,18 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
                 style={{
                   background:
                     cell.state === 'closed'
-                      ? 'var(--d2-accent)'
+                      ? 'var(--accent-primary)'
                       : cell.state === 'open'
-                        ? 'var(--ajo-outstanding)'
-                        : 'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+                        ? 'var(--status-pending)'
+                        : 'color-mix(in oklch, var(--ink) 8%, transparent)',
                   border:
-                    cell.state === 'open' ? '2px solid var(--d2-ink)' : 'none',
+                    cell.state === 'open' ? '2px solid var(--ink)' : 'none',
                 }}
                 aria-hidden="true"
               />
             ))}
           </div>
-          <div className="flex justify-between font-mono text-[11px] text-d2-ink/55">
+          <div className="flex justify-between font-mono text-[11px] text-ink/55">
             <span>
               {closedCount} closed · cycle {detail.cycle.index} open
             </span>
@@ -136,7 +136,7 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
         </div>
         <Link
           href={`/pools/${detail.pool.id}/pay`}
-          className="rounded-[10px] bg-d2-accent px-4 py-2.5 text-[14px] font-semibold text-white transition-opacity hover:opacity-90"
+          className="rounded-[10px] bg-accent-primary px-4 py-2.5 text-[14px] font-semibold text-white transition-opacity hover:opacity-90"
         >
           Pay this week
         </Link>
@@ -145,24 +145,24 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
       {/* Mobile owe card */}
       <section
         aria-label="You owe this cycle"
-        className="rounded-[14px] bg-d2-cream p-4 md:hidden"
+        className="rounded-[14px] bg-surface-card p-4 md:hidden"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <div className="flex items-center justify-between">
           <div>
-            <div className="text-[11px] text-d2-ink/55">You owe this cycle</div>
+            <div className="text-[11px] text-ink/55">You owe this cycle</div>
             <div className="font-mono text-[20px] font-semibold tabular-nums">
               {detail.cycle.contributionLabel}
             </div>
-            <div className="text-[11px]" style={{ color: 'var(--ajo-outstanding-fg)' }}>
+            <div className="text-[11px]" style={{ color: 'var(--status-pending-fg)' }}>
               cycle {detail.cycle.index}
             </div>
           </div>
           <Link
             href={`/pools/${detail.pool.id}/pay`}
-            className="rounded-[10px] bg-d2-ink px-4 py-2.5 text-[13px] font-semibold text-d2-warm-bg"
+            className="rounded-[10px] bg-ink px-4 py-2.5 text-[13px] font-semibold text-surface-page"
           >
             Pay now
           </Link>
@@ -173,9 +173,9 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
       <div className="grid grid-cols-1 gap-4 md:grid-cols-[1.3fr_1fr]">
         <section
           aria-labelledby="pool-members-title"
-          className="rounded-[14px] bg-d2-cream"
+          className="rounded-[14px] bg-surface-card"
           style={{
-            border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="flex items-center justify-between px-4 py-3">
@@ -203,9 +203,9 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
 
         <section
           aria-labelledby="pool-activity-title"
-          className="rounded-[14px] bg-d2-cream p-4"
+          className="rounded-[14px] bg-surface-card p-4"
           style={{
-            border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <h2
@@ -224,13 +224,13 @@ export function PoolDetailView({ detail }: PoolDetailViewProps) {
                   className="inline-flex h-[22px] w-[22px] items-center justify-center rounded-md"
                   style={{
                     background:
-                      'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                      'color-mix(in oklch, var(--ink) 6%, transparent)',
                   }}
                 >
                   <row.icon size={12} aria-hidden="true" />
                 </span>
                 <span className="flex-1">{row.title}</span>
-                <span className="font-mono text-[11px] text-d2-ink/50">
+                <span className="font-mono text-[11px] text-ink/50">
                   {row.when}
                 </span>
               </li>

--- a/components/member/pool-swatch.tsx
+++ b/components/member/pool-swatch.tsx
@@ -1,10 +1,10 @@
 import { cn } from '@/lib/utils';
 
 const SWATCH_BACKGROUNDS: Record<'a' | 'b' | 'c' | 'd', string> = {
-  a: 'linear-gradient(135deg, var(--d2-accent), var(--pool-swatch-teal))',
-  b: 'linear-gradient(135deg, var(--d2-coral), var(--pool-swatch-coral-deep))',
-  c: 'linear-gradient(135deg, var(--d2-lav), var(--pool-swatch-lav-deep))',
-  d: 'linear-gradient(135deg, var(--pool-swatch-aqua), var(--d2-accent))',
+  a: 'linear-gradient(135deg, var(--accent-primary), var(--pool-swatch-teal))',
+  b: 'linear-gradient(135deg, var(--accent-coral), var(--pool-swatch-coral-deep))',
+  c: 'linear-gradient(135deg, var(--accent-lavender), var(--pool-swatch-lav-deep))',
+  d: 'linear-gradient(135deg, var(--pool-swatch-aqua), var(--accent-primary))',
 };
 
 export interface PoolSwatchProps {

--- a/components/member/profile-view.tsx
+++ b/components/member/profile-view.tsx
@@ -48,11 +48,11 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
         <p className="kicker-mono text-[10px]">Settings</p>
         <h1
           id="profile-title"
-          className="mt-1 text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+          className="mt-1 text-[1.5rem] font-semibold tracking-tight text-ink"
         >
           Profile {"&"} security
         </h1>
-        <p className="mt-1 text-[13px] text-d2-ink/55">
+        <p className="mt-1 text-[13px] text-ink/55">
           Your account · {email || 'not set'}
         </p>
       </header>
@@ -63,30 +63,30 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
       {/* Mobile identity card */}
       <section
         aria-label="Identity"
-        className="flex flex-col items-center rounded-[14px] bg-d2-cream p-4 text-center md:hidden"
+        className="flex flex-col items-center rounded-[14px] bg-surface-card p-4 text-center md:hidden"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <span
           className="inline-flex h-16 w-16 items-center justify-center rounded-full text-[24px] font-bold text-white"
           style={{
             background:
-              'linear-gradient(135deg, var(--d2-coral), var(--d2-lav))',
+              'linear-gradient(135deg, var(--accent-coral), var(--accent-lavender))',
           }}
           aria-hidden="true"
         >
           {initial}
         </span>
-        <div className="mt-2.5 text-[17px] font-semibold text-d2-ink">
+        <div className="mt-2.5 text-[17px] font-semibold text-ink">
           {displayName}
         </div>
-        <div className="text-[11px] text-d2-ink/55">{email}</div>
+        <div className="text-[11px] text-ink/55">{email}</div>
         <span
           className="mt-1 rounded px-2 py-px font-mono text-[10px]"
           style={{
-            background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-            color: 'color-mix(in oklch, var(--d2-ink) 65%, transparent)',
+            background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
+            color: 'color-mix(in oklch, var(--ink) 65%, transparent)',
           }}
         >
           {role}
@@ -95,9 +95,9 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
 
       <section
         aria-labelledby="profile-section-title"
-        className="rounded-[14px] bg-d2-cream p-4"
+        className="rounded-[14px] bg-surface-card p-4"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <h2 id="profile-section-title" className="kicker-mono mb-2 text-[10px]">
@@ -109,7 +109,7 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
             className="inline-flex items-center justify-center rounded-full text-[18px] font-bold text-white"
             style={{
               background:
-                'linear-gradient(135deg, var(--d2-coral), var(--d2-lav))',
+                'linear-gradient(135deg, var(--accent-coral), var(--accent-lavender))',
               width: 52,
               height: 52,
             }}
@@ -118,10 +118,10 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
             {initial}
           </span>
           <div>
-            <div className="text-[16px] font-semibold text-d2-ink">
+            <div className="text-[16px] font-semibold text-ink">
               {displayName}
             </div>
-            <div className="text-[13px] text-d2-ink/55">
+            <div className="text-[13px] text-ink/55">
               {email}
               <span className="px-2">·</span>
               {role}
@@ -137,27 +137,27 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
                 i > 0
                   ? {
                       borderTop:
-                        '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                        '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
                     }
                   : undefined
               }
             >
               <span className="kicker-mono text-[10px]">{field.label}</span>
               <div className="min-w-0">
-                <div className="truncate text-d2-ink">{field.value}</div>
+                <div className="truncate text-ink">{field.value}</div>
                 {field.note && (
-                  <div className="text-[11px] text-d2-ink/50">{field.note}</div>
+                  <div className="text-[11px] text-ink/50">{field.note}</div>
                 )}
               </div>
               {field.editHref ? (
                 <Link
                   href={field.editHref}
-                  className="text-[12px] font-medium text-d2-accent"
+                  className="text-[12px] font-medium text-accent-primary"
                 >
                   Edit
                 </Link>
               ) : (
-                <span className="text-[11px] text-d2-ink/40">read-only</span>
+                <span className="text-[11px] text-ink/40">read-only</span>
               )}
             </li>
           ))}
@@ -166,9 +166,9 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
 
       <section
         aria-labelledby="profile-security-title"
-        className="rounded-[14px] bg-d2-cream p-4"
+        className="rounded-[14px] bg-surface-card p-4"
         style={{
-          border: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          border: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <h2 id="profile-security-title" className="kicker-mono mb-2 text-[10px]">
@@ -177,10 +177,10 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
         <ul className="flex flex-col">
           <li className="grid grid-cols-[1fr_auto] items-center gap-3 py-2.5">
             <div>
-              <div className="text-[14px] font-medium text-d2-ink">
+              <div className="text-[14px] font-medium text-ink">
                 Change password
               </div>
-              <div className="text-[12px] text-d2-ink/55">
+              <div className="text-[12px] text-ink/55">
                 Rotate your sign-in password.
               </div>
             </div>
@@ -188,8 +188,8 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
               href="/account/change-password"
               className="rounded-[10px] px-3 py-1.5 text-[13px] font-medium"
               style={{
-                background: 'var(--d2-ink)',
-                color: 'var(--d2-warm-bg)',
+                background: 'var(--ink)',
+                color: 'var(--surface-page)',
               }}
             >
               Change
@@ -199,14 +199,14 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
             className="grid grid-cols-[1fr_auto] items-center gap-3 py-2.5"
             style={{
               borderTop:
-                '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
             }}
           >
             <div>
-              <div className="text-[14px] font-medium text-d2-ink">
+              <div className="text-[14px] font-medium text-ink">
                 Active sessions
               </div>
-              <div className="text-[12px] text-d2-ink/55">
+              <div className="text-[12px] text-ink/55">
                 Review devices currently signed in.
               </div>
             </div>
@@ -220,7 +220,7 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
               style={{
                 background: 'transparent',
                 border:
-                  '1px solid color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+                  '1px solid color-mix(in oklch, var(--ink) 12%, transparent)',
               }}
             >
               Manage
@@ -230,7 +230,7 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
             className="grid grid-cols-[1fr_auto] items-center gap-3 py-2.5"
             style={{
               borderTop:
-                '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
             }}
           >
             <div>
@@ -240,7 +240,7 @@ export function ProfileView({ displayName, email, role }: ProfileViewProps) {
               >
                 Sign out everywhere
               </div>
-              <div className="text-[12px] text-d2-ink/55">
+              <div className="text-[12px] text-ink/55">
                 Ends sessions on all devices · live JWT dies within 15 min.
               </div>
             </div>

--- a/components/super/add-admin-trigger.tsx
+++ b/components/super/add-admin-trigger.tsx
@@ -21,7 +21,7 @@ export function AddAdminTrigger() {
       type="button"
       onClick={openModal}
       className="inline-flex items-center gap-1.5 rounded-[10px] px-3.5 py-1.5 text-[13px] font-medium"
-      style={{ background: 'var(--d2-ink)', color: 'var(--d2-warm-bg)' }}
+      style={{ background: 'var(--ink)', color: 'var(--surface-page)' }}
     >
       <Plus size={13} aria-hidden="true" />
       Add admin

--- a/components/super/desktop-only-banner.tsx
+++ b/components/super/desktop-only-banner.tsx
@@ -32,7 +32,7 @@ export function DesktopOnlyBanner() {
       >
         Super-admin tools are desktop-only
       </h1>
-      <p className="text-sm text-d2-ink/75">
+      <p className="text-sm text-ink/75">
         These screens manage tenants across the system. Reach for them on a wider screen
         (≥ 768px) so the cross-group tables stay readable.
       </p>

--- a/components/super/empty-admins.tsx
+++ b/components/super/empty-admins.tsx
@@ -26,7 +26,7 @@ export function EmptyAdmins() {
         <button
           type="button"
           onClick={openModal}
-          className="rounded-[10px] bg-d2-ink px-4 py-2.5 text-[13.5px] font-semibold text-d2-warm-bg"
+          className="rounded-[10px] bg-ink px-4 py-2.5 text-[13.5px] font-semibold text-surface-page"
         >
           Add first admin
         </button>

--- a/components/super/modal-add-admin.tsx
+++ b/components/super/modal-add-admin.tsx
@@ -189,27 +189,27 @@ export function ModalAddAdmin({ groupOptions }: ModalAddAdminProps) {
       aria-labelledby={titleId}
       onMouseDown={handleBackdropMouseDown}
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      style={{ background: 'color-mix(in oklch, var(--d2-ink) 35%, transparent)' }}
+      style={{ background: 'color-mix(in oklch, var(--ink) 35%, transparent)' }}
     >
       <div
-        className="flex w-full max-w-[560px] flex-col overflow-hidden rounded-2xl border bg-d2-warm-bg"
+        className="flex w-full max-w-[560px] flex-col overflow-hidden rounded-2xl border bg-surface-page"
         style={{
-          borderColor: 'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+          borderColor: 'color-mix(in oklch, var(--ink) 12%, transparent)',
           boxShadow:
-            '0 30px 80px -20px color-mix(in oklch, var(--d2-ink) 35%, transparent), 0 4px 12px color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+            '0 30px 80px -20px color-mix(in oklch, var(--ink) 35%, transparent), 0 4px 12px color-mix(in oklch, var(--ink) 8%, transparent)',
         }}
       >
         <header
           className="flex items-start justify-between gap-3 px-5 py-4"
           style={{
-            borderBottom: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderBottom: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div>
             <h2 id={titleId} className="text-[17px] font-semibold">
               Add admin
             </h2>
-            <p className="mt-0.5 text-[12px] text-d2-ink/60">
+            <p className="mt-0.5 text-[12px] text-ink/60">
               {step === 'revealed'
                 ? 'Copy the temp password. It will not appear again.'
                 : 'Create the account and grant groups in one step.'}
@@ -227,7 +227,7 @@ export function ModalAddAdmin({ groupOptions }: ModalAddAdminProps) {
             <X
               size={16}
               aria-hidden="true"
-              style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+              style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
             />
           </button>
         </header>
@@ -268,14 +268,14 @@ export function ModalAddAdmin({ groupOptions }: ModalAddAdminProps) {
             )}
 
             <footer
-              className="flex items-center justify-between gap-3 bg-d2-cream px-5 py-3.5"
+              className="flex items-center justify-between gap-3 bg-surface-card px-5 py-3.5"
               style={{
-                borderTop: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+                borderTop: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
               }}
             >
               <span
                 className="font-mono text-[11px]"
-                style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+                style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
               >
                 no email sent · deliver creds out-of-band
               </span>
@@ -283,7 +283,7 @@ export function ModalAddAdmin({ groupOptions }: ModalAddAdminProps) {
                 <button
                   type="button"
                   onClick={closeModal}
-                  className="rounded-[10px] bg-transparent px-3.5 py-2 text-[13px] font-medium hover:bg-d2-ink/[5%]"
+                  className="rounded-[10px] bg-transparent px-3.5 py-2 text-[13px] font-medium hover:bg-ink/[5%]"
                 >
                   Cancel
                 </button>
@@ -291,7 +291,7 @@ export function ModalAddAdmin({ groupOptions }: ModalAddAdminProps) {
                   type="submit"
                   disabled={!canSubmit}
                   className="inline-flex items-center gap-1.5 rounded-[10px] px-4 py-2 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-60"
-                  style={{ background: 'var(--d2-ink)', color: 'var(--d2-warm-bg)' }}
+                  style={{ background: 'var(--ink)', color: 'var(--surface-page)' }}
                 >
                   <UserPlus size={13} aria-hidden="true" />
                   {isSubmitting ? 'Creating…' : 'Create & grant · reveal temp password'}
@@ -364,20 +364,20 @@ function FormBody({
       <div className="md:col-span-2">
         <div
           className="font-mono text-[10px] uppercase tracking-[0.08em]"
-          style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+          style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
         >
           Grant groups
           <span
             className="ml-1 normal-case tracking-normal"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 50%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 50%, transparent)' }}
           >
             · admin can confirm receipts in these
           </span>
         </div>
         <div
-          className="mt-1.5 flex min-h-[48px] flex-wrap gap-1.5 rounded-[10px] border bg-d2-cream p-3"
+          className="mt-1.5 flex min-h-[48px] flex-wrap gap-1.5 rounded-[10px] border bg-surface-card p-3"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           {groupOptions.map((g) => {
@@ -392,13 +392,13 @@ function FormBody({
                 className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[12px] font-medium transition-colors disabled:opacity-60"
                 style={{
                   background: active
-                    ? 'var(--d2-accent-soft)'
-                    : 'color-mix(in oklch, var(--d2-ink) 5%, transparent)',
+                    ? 'var(--accent-primary-soft)'
+                    : 'color-mix(in oklch, var(--ink) 5%, transparent)',
                   color: active
-                    ? 'var(--d2-accent)'
-                    : 'color-mix(in oklch, var(--d2-ink) 70%, transparent)',
+                    ? 'var(--accent-primary)'
+                    : 'color-mix(in oklch, var(--ink) 70%, transparent)',
                   borderColor: active
-                    ? 'color-mix(in oklch, var(--d2-accent) 30%, transparent)'
+                    ? 'color-mix(in oklch, var(--accent-primary) 30%, transparent)'
                     : 'transparent',
                 }}
               >
@@ -467,7 +467,7 @@ function Field({
       <label
         htmlFor={id}
         className="font-mono text-[10px] uppercase tracking-[0.08em]"
-        style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+        style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
       >
         {label}
         {required && <span aria-hidden="true"> *</span>}
@@ -481,12 +481,12 @@ function Field({
         disabled={disabled}
         required={required}
         onChange={onChange ? (e) => onChange(e.target.value) : undefined}
-        className="mt-1 w-full rounded-[10px] border bg-d2-cream px-3 py-2 text-[14px] disabled:cursor-not-allowed disabled:opacity-70"
+        className="mt-1 w-full rounded-[10px] border bg-surface-card px-3 py-2 text-[14px] disabled:cursor-not-allowed disabled:opacity-70"
         style={{
           background: muted
-            ? 'color-mix(in oklch, var(--d2-ink) 5%, transparent)'
-            : 'var(--d2-cream)',
-          borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            ? 'color-mix(in oklch, var(--ink) 5%, transparent)'
+            : 'var(--surface-card)',
+          borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           fontFamily: mono ? 'var(--font-mono)' : undefined,
         }}
       />
@@ -553,12 +553,12 @@ function RevealedPanel({
         <div>
           <span
             className="font-mono text-[10px] uppercase tracking-[0.08em]"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
           >
             Email
           </span>
-          <div className="mt-1 rounded-[10px] border bg-d2-cream px-3 py-2 font-mono text-[14px]"
-            style={{ borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)' }}
+          <div className="mt-1 rounded-[10px] border bg-surface-card px-3 py-2 font-mono text-[14px]"
+            style={{ borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)' }}
           >
             {revealed.email}
           </div>
@@ -567,7 +567,7 @@ function RevealedPanel({
         <div>
           <span
             className="font-mono text-[10px] uppercase tracking-[0.08em]"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
           >
             Temp password
           </span>
@@ -576,14 +576,14 @@ function RevealedPanel({
               readOnly
               aria-label="Temporary password (one-time reveal)"
               value={revealed.tempPassword}
-              className="flex-1 rounded-[10px] border bg-d2-cream px-3 py-2 font-mono text-[14px]"
-              style={{ borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)' }}
+              className="flex-1 rounded-[10px] border bg-surface-card px-3 py-2 font-mono text-[14px]"
+              style={{ borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)' }}
             />
             <button
               type="button"
               onClick={handleCopy}
               className="inline-flex items-center gap-1.5 rounded-[10px] px-3 py-2 text-[13px] font-medium"
-              style={{ background: 'var(--d2-ink)', color: 'var(--d2-warm-bg)' }}
+              style={{ background: 'var(--ink)', color: 'var(--surface-page)' }}
             >
               {copyState === 'copied' ? (
                 <>
@@ -613,7 +613,7 @@ function RevealedPanel({
           <div>
             <span
               className="font-mono text-[10px] uppercase tracking-[0.08em]"
-              style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+              style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
             >
               Granted on
             </span>
@@ -630,16 +630,16 @@ function RevealedPanel({
             onChange={(e) => {
               if (e.target.checked) onAcknowledge();
             }}
-            className="h-4 w-4 cursor-pointer accent-d2-ink"
+            className="h-4 w-4 cursor-pointer accent-ink"
           />
           I have copied the password
         </label>
       </div>
 
       <footer
-        className="flex justify-end bg-d2-cream px-5 py-3.5"
+        className="flex justify-end bg-surface-card px-5 py-3.5"
         style={{
-          borderTop: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          borderTop: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <button
@@ -647,7 +647,7 @@ function RevealedPanel({
           onClick={onClose}
           disabled={!acknowledged}
           className="rounded-[10px] px-4 py-2 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-60"
-          style={{ background: 'var(--d2-ink)', color: 'var(--d2-warm-bg)' }}
+          style={{ background: 'var(--ink)', color: 'var(--surface-page)' }}
         >
           Done
         </button>

--- a/components/super/modal-create-pool.tsx
+++ b/components/super/modal-create-pool.tsx
@@ -56,10 +56,10 @@ export function ModalCreatePool({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-[10px] border bg-transparent px-3.5 py-2 text-[13px] font-medium text-d2-ink"
+            className="rounded-[10px] border bg-transparent px-3.5 py-2 text-[13px] font-medium text-ink"
             style={{
               borderColor:
-                'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+                'color-mix(in oklch, var(--ink) 12%, transparent)',
             }}
           >
             Cancel
@@ -68,8 +68,8 @@ export function ModalCreatePool({
             type="button"
             onClick={onConfirm}
             disabled={pending}
-            className="rounded-[10px] px-3.5 py-2 text-[13px] font-semibold text-d2-warm-bg disabled:cursor-not-allowed disabled:opacity-60"
-            style={{ background: 'var(--d2-ink)' }}
+            className="rounded-[10px] px-3.5 py-2 text-[13px] font-semibold text-surface-page disabled:cursor-not-allowed disabled:opacity-60"
+            style={{ background: 'var(--ink)' }}
           >
             {pending ? 'Creating…' : 'Create pool · then assign admin'}
           </button>
@@ -140,16 +140,16 @@ function Field({
   return (
     <div>
       <div className="mb-1.5 flex items-baseline justify-between">
-        <span className="text-[12px] font-medium text-d2-ink">{label}</span>
+        <span className="text-[12px] font-medium text-ink">{label}</span>
         {hint && (
-          <span className="font-mono text-[10px] text-d2-ink/55">{hint}</span>
+          <span className="font-mono text-[10px] text-ink/55">{hint}</span>
         )}
       </div>
       <div
-        className="flex items-center gap-2 rounded-[10px] border bg-d2-cream px-3 py-2"
+        className="flex items-center gap-2 rounded-[10px] border bg-surface-card px-3 py-2"
         style={{
           borderColor:
-            'color-mix(in oklch, var(--d2-ink) 12%, transparent)',
+            'color-mix(in oklch, var(--ink) 12%, transparent)',
         }}
       >
         {icon && (
@@ -158,7 +158,7 @@ function Field({
             aria-hidden="true"
             style={{
               color:
-                'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+                'color-mix(in oklch, var(--ink) 55%, transparent)',
             }}
           />
         )}
@@ -166,7 +166,7 @@ function Field({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="flex-1 bg-transparent text-[13px] outline-none placeholder:text-d2-ink/40"
+          className="flex-1 bg-transparent text-[13px] outline-none placeholder:text-ink/40"
         />
       </div>
     </div>

--- a/components/super/status-pill.tsx
+++ b/components/super/status-pill.tsx
@@ -16,32 +16,32 @@ interface ToneStyle {
 
 const TONE_STYLES: Record<StatusPillTone, ToneStyle> = {
   paid: {
-    background: 'var(--ajo-paid-subtle)',
-    color: 'var(--ajo-paid)',
+    background: 'var(--status-paid-subtle)',
+    color: 'var(--status-paid)',
   },
   pending: {
-    background: 'var(--ajo-outstanding-subtle)',
-    color: 'var(--ajo-outstanding-fg)',
+    background: 'var(--status-pending-subtle)',
+    color: 'var(--status-pending-fg)',
   },
   out: {
     background: 'color-mix(in oklch, var(--destructive) 12%, transparent)',
     color: 'var(--destructive)',
   },
   muted: {
-    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-    color: 'color-mix(in oklch, var(--d2-ink) 70%, transparent)',
+    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
+    color: 'color-mix(in oklch, var(--ink) 70%, transparent)',
   },
   inactive: {
-    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-    color: 'color-mix(in oklch, var(--d2-ink) 60%, transparent)',
+    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
+    color: 'color-mix(in oklch, var(--ink) 60%, transparent)',
   },
   system: {
     background: 'var(--accent-violet-subtle)',
     color: 'var(--accent-violet)',
   },
   drift: {
-    background: 'var(--ajo-outstanding-subtle)',
-    color: 'var(--ajo-outstanding-fg)',
+    background: 'var(--status-pending-subtle)',
+    color: 'var(--status-pending-fg)',
   },
 };
 

--- a/components/super/sys-admins-cards.tsx
+++ b/components/super/sys-admins-cards.tsx
@@ -15,7 +15,7 @@ export function SysAdminsCards({ rows }: SysAdminsCardsProps) {
         <li
           key={row.userId}
           data-tone={row.active ? 'paid' : 'inactive'}
-          className="status-row rounded-[14px] border bg-card p-4"
+          className="status-row rounded-[14px] border bg-d2-cream p-4"
           style={{
             borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
           }}

--- a/components/super/sys-admins-cards.tsx
+++ b/components/super/sys-admins-cards.tsx
@@ -15,9 +15,9 @@ export function SysAdminsCards({ rows }: SysAdminsCardsProps) {
         <li
           key={row.userId}
           data-tone={row.active ? 'paid' : 'inactive'}
-          className="status-row rounded-[14px] border bg-d2-cream p-4"
+          className="status-row rounded-[14px] border bg-surface-card p-4"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="flex items-start gap-3">
@@ -26,8 +26,8 @@ export function SysAdminsCards({ rows }: SysAdminsCardsProps) {
               className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-full text-[13px] font-semibold text-white"
               style={{
                 background: row.active
-                  ? 'var(--d2-coral)'
-                  : 'color-mix(in oklch, var(--d2-ink) 18%, transparent)',
+                  ? 'var(--accent-coral)'
+                  : 'color-mix(in oklch, var(--ink) 18%, transparent)',
               }}
             >
               {row.initial}
@@ -39,11 +39,11 @@ export function SysAdminsCards({ rows }: SysAdminsCardsProps) {
                   {row.active ? 'active' : 'inactive'}
                 </StatusPill>
               </div>
-              <div className="font-mono text-[11px] text-d2-ink/55">{row.email}</div>
+              <div className="font-mono text-[11px] text-ink/55">{row.email}</div>
               <div className="mt-1 font-mono text-[12px]">{row.phoneE164}</div>
               <div className="mt-2 flex flex-wrap gap-1">
                 {row.grantedGroupNames.length === 0 ? (
-                  <span className="text-[12px] italic text-d2-ink/50">no grants</span>
+                  <span className="text-[12px] italic text-ink/50">no grants</span>
                 ) : (
                   row.grantedGroupNames.map((g) => (
                     <StatusPill key={g} tone="muted" mono={false}>

--- a/components/super/sys-admins-table.tsx
+++ b/components/super/sys-admins-table.tsx
@@ -17,7 +17,7 @@ const GRID =
 export function SysAdminsTable({ rows }: SysAdminsTableProps) {
   return (
     <div
-      className="overflow-hidden rounded-[14px] border bg-card"
+      className="overflow-hidden rounded-[14px] border bg-d2-cream"
       style={{
         borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
       }}

--- a/components/super/sys-admins-table.tsx
+++ b/components/super/sys-admins-table.tsx
@@ -17,18 +17,18 @@ const GRID =
 export function SysAdminsTable({ rows }: SysAdminsTableProps) {
   return (
     <div
-      className="overflow-hidden rounded-[14px] border bg-d2-cream"
+      className="overflow-hidden rounded-[14px] border bg-surface-card"
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
     >
       <div
         role="row"
         className={`${GRID} kicker-mono py-2.5 text-[10px]`}
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
-          borderBottom: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
-          color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
+          borderBottom: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
+          color: 'color-mix(in oklch, var(--ink) 55%, transparent)',
         }}
       >
         <span>Admin</span>
@@ -50,7 +50,7 @@ export function SysAdminsTable({ rows }: SysAdminsTableProps) {
               style={{
                 borderBottom: isLast
                   ? 'none'
-                  : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                  : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
               }}
             >
               <div className="flex min-w-0 items-center gap-2.5">
@@ -59,23 +59,23 @@ export function SysAdminsTable({ rows }: SysAdminsTableProps) {
                   className="inline-flex h-[30px] w-[30px] items-center justify-center rounded-full text-[12px] font-semibold text-white"
                   style={{
                     background: row.active
-                      ? 'var(--d2-coral)'
-                      : 'color-mix(in oklch, var(--d2-ink) 18%, transparent)',
+                      ? 'var(--accent-coral)'
+                      : 'color-mix(in oklch, var(--ink) 18%, transparent)',
                   }}
                 >
                   {row.initial}
                 </span>
                 <div className="min-w-0">
                   <div className="truncate font-medium">{row.name}</div>
-                  <div className="font-mono text-[11px] text-d2-ink/55">{row.email}</div>
+                  <div className="font-mono text-[11px] text-ink/55">{row.email}</div>
                 </div>
               </div>
-              <span className="truncate font-mono text-[12px] text-d2-ink/70">
+              <span className="truncate font-mono text-[12px] text-ink/70">
                 {row.phoneE164}
               </span>
               <div className="flex flex-wrap gap-1">
                 {row.grantedGroupNames.length === 0 ? (
-                  <span className="text-[12px] italic text-d2-ink/50">no grants</span>
+                  <span className="text-[12px] italic text-ink/50">no grants</span>
                 ) : (
                   row.grantedGroupNames.map((g) => (
                     <StatusPill key={g} tone="muted" mono={false}>
@@ -86,7 +86,7 @@ export function SysAdminsTable({ rows }: SysAdminsTableProps) {
               </div>
               <span
                 className="font-mono text-[12px]"
-                style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+                style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
               >
                 {row.lastSeenLabel}
               </span>
@@ -101,7 +101,7 @@ export function SysAdminsTable({ rows }: SysAdminsTableProps) {
                 aria-label={`Manage ${row.name} (coming soon)`}
                 className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
                 style={{
-                  background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                  background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
                 }}
               >
                 Manage

--- a/components/super/sys-admins-view.tsx
+++ b/components/super/sys-admins-view.tsx
@@ -40,13 +40,13 @@ export function SysAdminsView({
           <div className="flex flex-wrap items-center gap-2">
             <h1
               id="sys-admins-title"
-              className="text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+              className="text-[1.5rem] font-semibold tracking-tight text-ink"
             >
               Admins
             </h1>
             <SuperChip />
           </div>
-          <p className="text-[13px] text-d2-ink/55">{subLine}</p>
+          <p className="text-[13px] text-ink/55">{subLine}</p>
         </div>
         <AddAdminTrigger />
       </header>
@@ -83,7 +83,7 @@ export function SysAdminsView({
         </>
       )}
 
-      <p className="font-mono text-[11px] text-d2-ink/45">
+      <p className="font-mono text-[11px] text-ink/45">
         admins are scoped to the groups you grant them · revoking all grants does NOT delete
         the account
       </p>

--- a/components/super/sys-group-detail-view.tsx
+++ b/components/super/sys-group-detail-view.tsx
@@ -56,7 +56,7 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
         {/* Group record */}
         <section
           aria-labelledby="sys-group-record"
-          className="flex flex-col gap-2.5 rounded-[14px] border bg-card p-5"
+          className="flex flex-col gap-2.5 rounded-[14px] border bg-d2-cream p-5"
           style={{
             borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
           }}
@@ -104,7 +104,7 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
         {/* Assignments + Danger */}
         <section
           aria-label="Group assignments"
-          className="flex flex-col gap-2.5 rounded-[14px] border bg-card p-5"
+          className="flex flex-col gap-2.5 rounded-[14px] border bg-d2-cream p-5"
           style={{
             borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
           }}
@@ -249,7 +249,7 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
       {/* Audit trail */}
       <section
         aria-labelledby="sys-group-audit"
-        className="rounded-[14px] border bg-card p-4"
+        className="rounded-[14px] border bg-d2-cream p-4"
         style={{
           borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
         }}

--- a/components/super/sys-group-detail-view.tsx
+++ b/components/super/sys-group-detail-view.tsx
@@ -27,11 +27,11 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
           <div>
             <h1
               id="sys-group-detail-title"
-              className="text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+              className="text-[1.5rem] font-semibold tracking-tight text-ink"
             >
               {detail.poolName}
             </h1>
-            <p className="font-mono text-[12px] text-d2-ink/55">{detail.subLabel}</p>
+            <p className="font-mono text-[12px] text-ink/55">{detail.subLabel}</p>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -44,7 +44,7 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
             aria-label="Open as admin (coming soon)"
             className="rounded-[10px] px-3 py-1.5 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-70"
             style={{
-              background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+              background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
             }}
           >
             Open as admin
@@ -56,9 +56,9 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
         {/* Group record */}
         <section
           aria-labelledby="sys-group-record"
-          className="flex flex-col gap-2.5 rounded-[14px] border bg-d2-cream p-5"
+          className="flex flex-col gap-2.5 rounded-[14px] border bg-surface-card p-5"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <h2
@@ -76,14 +76,14 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
                   i > 0
                     ? {
                         borderTop:
-                          '1px solid color-mix(in oklch, var(--d2-ink) 5%, transparent)',
+                          '1px solid color-mix(in oklch, var(--ink) 5%, transparent)',
                       }
                     : undefined
                 }
               >
                 <dt
                   className="font-mono text-[12px]"
-                  style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+                  style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
                 >
                   {row.kicker}
                 </dt>
@@ -104,17 +104,17 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
         {/* Assignments + Danger */}
         <section
           aria-label="Group assignments"
-          className="flex flex-col gap-2.5 rounded-[14px] border bg-d2-cream p-5"
+          className="flex flex-col gap-2.5 rounded-[14px] border bg-surface-card p-5"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <h2 className="kicker-mono mb-1 text-[10px]">Assignments</h2>
           {/* Admin on duty */}
           <div
-            className="rounded-[10px] border bg-d2-warm-bg p-3"
+            className="rounded-[10px] border bg-surface-page p-3"
             style={{
-              borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
             }}
           >
             <div className="kicker-mono mb-1 text-[11px]">Admin on duty</div>
@@ -123,13 +123,13 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
                 <span
                   aria-hidden="true"
                   className="inline-flex h-[30px] w-[30px] items-center justify-center rounded-full text-[13px] font-semibold text-white"
-                  style={{ background: 'var(--d2-coral)' }}
+                  style={{ background: 'var(--accent-coral)' }}
                 >
                   {detail.admin.initial}
                 </span>
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm font-medium">{detail.admin.name}</div>
-                  <div className="font-mono text-[11px] text-d2-ink/55">
+                  <div className="font-mono text-[11px] text-ink/55">
                     {detail.admin.email} · {detail.admin.groupCount}{' '}
                     {detail.admin.groupCount === 1 ? 'group' : 'groups'}
                   </div>
@@ -142,7 +142,7 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
                   aria-label="Reassign admin (coming soon)"
                   className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
                   style={{
-                    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
                   }}
                 >
                   Reassign
@@ -157,9 +157,9 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
 
           {/* WhatsApp */}
           <div
-            className="rounded-[10px] border bg-d2-warm-bg p-3"
+            className="rounded-[10px] border bg-surface-page p-3"
             style={{
-              borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
             }}
           >
             <div className="kicker-mono mb-1 text-[11px]">WhatsApp</div>
@@ -169,7 +169,7 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
                 className="inline-block h-2 w-2 rounded-full"
                 style={{
                   background: detail.whatsapp.linked
-                    ? 'var(--ajo-paid)'
+                    ? 'var(--status-paid)'
                     : 'var(--destructive)',
                 }}
               />
@@ -179,7 +179,7 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
                     ? `Linked · ${detail.whatsapp.chatName ?? detail.poolName}`
                     : 'Unlinked · WhatsApp bot not paired'}
                 </div>
-                <div className="font-mono text-[11px] text-d2-ink/55">
+                <div className="font-mono text-[11px] text-ink/55">
                   {detail.whatsapp.linked
                     ? `wa_group_id · ${detail.whatsapp.waGroupId} · bot ${detail.whatsapp.botActive ? 'active' : 'idle'}`
                     : 'add the bot to a WhatsApp chat to pair'}
@@ -193,7 +193,7 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
                 aria-label={detail.whatsapp.linked ? 'Unlink WhatsApp (coming soon)' : 'Link WhatsApp (coming soon)'}
                 className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
                 style={{
-                  background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                  background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
                 }}
               >
                 {detail.whatsapp.linked ? 'Unlink' : 'Link'}
@@ -249,9 +249,9 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
       {/* Audit trail */}
       <section
         aria-labelledby="sys-group-audit"
-        className="rounded-[14px] border bg-d2-cream p-4"
+        className="rounded-[14px] border bg-surface-card p-4"
         style={{
-          borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+          borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
         }}
       >
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
@@ -274,26 +274,26 @@ export function SysGroupDetailView({ detail }: SysGroupDetailViewProps) {
                 i > 0
                   ? {
                       borderTop:
-                        '1px solid color-mix(in oklch, var(--d2-ink) 5%, transparent)',
+                        '1px solid color-mix(in oklch, var(--ink) 5%, transparent)',
                     }
                   : undefined
               }
             >
               <span
                 className="font-mono text-[11px]"
-                style={{ color: 'color-mix(in oklch, var(--d2-ink) 50%, transparent)' }}
+                style={{ color: 'color-mix(in oklch, var(--ink) 50%, transparent)' }}
               >
                 {row.whenLabel}
               </span>
               <span
                 className="font-mono text-[12px]"
                 style={{
-                  color: row.isMachine ? 'var(--accent-violet)' : 'var(--d2-ink)',
+                  color: row.isMachine ? 'var(--accent-violet)' : 'var(--ink)',
                 }}
               >
                 {row.who}
               </span>
-              <span style={{ color: 'color-mix(in oklch, var(--d2-ink) 75%, transparent)' }}>
+              <span style={{ color: 'color-mix(in oklch, var(--ink) 75%, transparent)' }}>
                 {row.action}
               </span>
             </li>

--- a/components/super/sys-groups-cards.tsx
+++ b/components/super/sys-groups-cards.tsx
@@ -26,20 +26,20 @@ export function SysGroupsCards({ rows }: SysGroupsCardsProps) {
           <li
             key={row.poolId}
             data-tone={row.tone}
-            className="status-row rounded-[14px] border bg-d2-cream"
+            className="status-row rounded-[14px] border bg-surface-card"
             style={{
-              borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
             }}
           >
             <Link
               href={`/sys/groups/${row.poolId}`}
-              className="flex flex-col gap-3 p-4 hover:bg-d2-ink/[3%]"
+              className="flex flex-col gap-3 p-4 hover:bg-ink/[3%]"
             >
               <div className="flex items-center gap-3">
                 <PoolGlyph initial={row.poolInitial} swatch={row.poolSwatch} size="sm" />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm font-semibold">{row.poolName}</div>
-                  <div className="font-mono text-[11px] text-d2-ink/55">
+                  <div className="font-mono text-[11px] text-ink/55">
                     {row.currency} · {row.cyclesLabel} · {row.cadence}
                   </div>
                 </div>
@@ -47,11 +47,11 @@ export function SysGroupsCards({ rows }: SysGroupsCardsProps) {
               </div>
               <dl className="grid grid-cols-3 gap-2 text-[12px]">
                 <div>
-                  <dt className="font-mono uppercase tracking-wider text-d2-ink/55">Members</dt>
+                  <dt className="font-mono uppercase tracking-wider text-ink/55">Members</dt>
                   <dd className="font-mono">{row.memberCount}</dd>
                 </div>
                 <div>
-                  <dt className="font-mono uppercase tracking-wider text-d2-ink/55">Admin</dt>
+                  <dt className="font-mono uppercase tracking-wider text-ink/55">Admin</dt>
                   <dd
                     style={{
                       color: isUnassigned ? 'var(--destructive)' : undefined,
@@ -62,7 +62,7 @@ export function SysGroupsCards({ rows }: SysGroupsCardsProps) {
                   </dd>
                 </div>
                 <div>
-                  <dt className="font-mono uppercase tracking-wider text-d2-ink/55">Pending</dt>
+                  <dt className="font-mono uppercase tracking-wider text-ink/55">Pending</dt>
                   <dd className="font-mono">
                     {row.pendingReceiptsCount > 0 ? row.pendingReceiptsCount : '-'}
                   </dd>

--- a/components/super/sys-groups-cards.tsx
+++ b/components/super/sys-groups-cards.tsx
@@ -26,7 +26,7 @@ export function SysGroupsCards({ rows }: SysGroupsCardsProps) {
           <li
             key={row.poolId}
             data-tone={row.tone}
-            className="status-row rounded-[14px] border bg-card"
+            className="status-row rounded-[14px] border bg-d2-cream"
             style={{
               borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
             }}

--- a/components/super/sys-groups-table.tsx
+++ b/components/super/sys-groups-table.tsx
@@ -18,8 +18,8 @@ function waToneFor(status: SystemGroupRow['waStatus']): StatusPillTone {
 }
 
 function healthBarColor(health: number): string {
-  if (health > 85) return 'var(--ajo-paid)';
-  if (health > 60) return 'var(--ajo-outstanding)';
+  if (health > 85) return 'var(--status-paid)';
+  if (health > 60) return 'var(--status-pending)';
   return 'var(--destructive)';
 }
 
@@ -35,18 +35,18 @@ function healthBarColor(health: number): string {
 export function SysGroupsTable({ rows }: SysGroupsTableProps) {
   return (
     <div
-      className="overflow-hidden rounded-[14px] border bg-d2-cream"
+      className="overflow-hidden rounded-[14px] border bg-surface-card"
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
     >
       <div
         role="row"
         className={`${GRID} kicker-mono py-2.5 text-[10px]`}
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
-          borderBottom: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
-          color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
+          borderBottom: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
+          color: 'color-mix(in oklch, var(--ink) 55%, transparent)',
         }}
       >
         <span>Group</span>
@@ -72,7 +72,7 @@ export function SysGroupsTable({ rows }: SysGroupsTableProps) {
               style={{
                 borderBottom: isLast
                   ? 'none'
-                  : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                  : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
               }}
             >
               <Link
@@ -83,16 +83,16 @@ export function SysGroupsTable({ rows }: SysGroupsTableProps) {
                 <PoolGlyph initial={row.poolInitial} swatch={row.poolSwatch} size="sm" />
                 <div className="min-w-0">
                   <div className="truncate font-medium">{row.poolName}</div>
-                  <div className="font-mono text-[11px] text-d2-ink/55">{row.currency}</div>
+                  <div className="font-mono text-[11px] text-ink/55">{row.currency}</div>
                 </div>
               </Link>
               <span className="font-mono text-[12px]">{row.memberCount}</span>
               <span className="font-mono text-[12px]">{row.cyclesLabel}</span>
-              <span className="text-[12px] text-d2-ink/70">{row.cadence}</span>
+              <span className="text-[12px] text-ink/70">{row.cadence}</span>
               <span
                 className="truncate text-[12px]"
                 style={{
-                  color: isUnassigned ? 'var(--destructive)' : 'var(--d2-ink)',
+                  color: isUnassigned ? 'var(--destructive)' : 'var(--ink)',
                   fontStyle: isUnassigned ? 'italic' : 'normal',
                 }}
               >
@@ -104,10 +104,10 @@ export function SysGroupsTable({ rows }: SysGroupsTableProps) {
                 style={{
                   fontWeight: row.pendingReceiptsCount > 2 ? 600 : 400,
                   color: row.pendingReceiptsCount > 2
-                    ? 'var(--ajo-outstanding-fg)'
+                    ? 'var(--status-pending-fg)'
                     : row.pendingReceiptsCount > 0
-                      ? 'var(--d2-ink)'
-                      : 'color-mix(in oklch, var(--d2-ink) 40%, transparent)',
+                      ? 'var(--ink)'
+                      : 'color-mix(in oklch, var(--ink) 40%, transparent)',
                 }}
               >
                 {row.pendingReceiptsCount > 0 ? row.pendingReceiptsCount : '-'}
@@ -116,7 +116,7 @@ export function SysGroupsTable({ rows }: SysGroupsTableProps) {
                 <span
                   className="relative h-[5px] w-[42px] overflow-hidden rounded-[3px]"
                   style={{
-                    background: 'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+                    background: 'color-mix(in oklch, var(--ink) 8%, transparent)',
                   }}
                   aria-hidden="true"
                 >
@@ -127,7 +127,7 @@ export function SysGroupsTable({ rows }: SysGroupsTableProps) {
                 </span>
                 <span
                   className="font-mono text-[11px]"
-                  style={{ color: 'color-mix(in oklch, var(--d2-ink) 60%, transparent)' }}
+                  style={{ color: 'color-mix(in oklch, var(--ink) 60%, transparent)' }}
                 >
                   {row.health}
                 </span>
@@ -135,12 +135,12 @@ export function SysGroupsTable({ rows }: SysGroupsTableProps) {
               <Link
                 href={`/sys/groups/${row.poolId}`}
                 aria-label={`Open ${row.poolName} detail`}
-                className="inline-flex h-6 w-6 items-center justify-center rounded-full hover:bg-d2-ink/10"
+                className="inline-flex h-6 w-6 items-center justify-center rounded-full hover:bg-ink/10"
               >
                 <ChevronRight
                   size={14}
                   aria-hidden="true"
-                  style={{ color: 'color-mix(in oklch, var(--d2-ink) 40%, transparent)' }}
+                  style={{ color: 'color-mix(in oklch, var(--ink) 40%, transparent)' }}
                 />
               </Link>
             </li>

--- a/components/super/sys-groups-table.tsx
+++ b/components/super/sys-groups-table.tsx
@@ -35,7 +35,7 @@ function healthBarColor(health: number): string {
 export function SysGroupsTable({ rows }: SysGroupsTableProps) {
   return (
     <div
-      className="overflow-hidden rounded-[14px] border bg-card"
+      className="overflow-hidden rounded-[14px] border bg-d2-cream"
       style={{
         borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
       }}

--- a/components/super/sys-groups-view.tsx
+++ b/components/super/sys-groups-view.tsx
@@ -32,13 +32,13 @@ export function SysGroupsView({ rows, aggregates }: SysGroupsViewProps) {
           <div className="flex flex-wrap items-center gap-2">
             <h1
               id="sys-groups-title"
-              className="text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+              className="text-[1.5rem] font-semibold tracking-tight text-ink"
             >
               Groups
             </h1>
             <SuperChip />
           </div>
-          <p className="text-[13px] text-d2-ink/55">{subLine}</p>
+          <p className="text-[13px] text-ink/55">{subLine}</p>
         </div>
         <div className="flex items-center gap-2">
           {/* TODO(BE-9): wire the super-view list search endpoint. */}
@@ -47,7 +47,7 @@ export function SysGroupsView({ rows, aggregates }: SysGroupsViewProps) {
               size={13}
               aria-hidden="true"
               className="absolute left-2.5 top-1/2 -translate-y-1/2"
-              style={{ color: 'color-mix(in oklch, var(--d2-ink) 50%, transparent)' }}
+              style={{ color: 'color-mix(in oklch, var(--ink) 50%, transparent)' }}
             />
             <input
               disabled
@@ -56,7 +56,7 @@ export function SysGroupsView({ rows, aggregates }: SysGroupsViewProps) {
               title="Search groups (coming soon)"
               className="w-[180px] rounded-[10px] border-none py-1.5 pl-7 pr-3 text-[13px] disabled:cursor-not-allowed disabled:opacity-70"
               style={{
-                background: 'color-mix(in oklch, var(--d2-ink) 5%, transparent)',
+                background: 'color-mix(in oklch, var(--ink) 5%, transparent)',
               }}
             />
           </div>
@@ -67,7 +67,7 @@ export function SysGroupsView({ rows, aggregates }: SysGroupsViewProps) {
             title="New group (coming soon)"
             aria-label="New group (coming soon)"
             className="inline-flex items-center gap-1.5 rounded-[10px] px-3.5 py-1.5 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-70"
-            style={{ background: 'var(--d2-ink)', color: 'var(--d2-warm-bg)' }}
+            style={{ background: 'var(--ink)', color: 'var(--surface-page)' }}
           >
             <Plus size={13} aria-hidden="true" />
             New group
@@ -82,7 +82,7 @@ export function SysGroupsView({ rows, aggregates }: SysGroupsViewProps) {
         <SysGroupsCards rows={rows} />
       </div>
 
-      <p className="font-mono text-[11px] text-d2-ink/45">
+      <p className="font-mono text-[11px] text-ink/45">
         &ldquo;unassigned&rdquo; + &ldquo;unlinked&rdquo; are orphan states, super-admin should resolve or archive.
       </p>
     </main>

--- a/components/super/sys-receipts-cards.tsx
+++ b/components/super/sys-receipts-cards.tsx
@@ -23,9 +23,9 @@ export function SysReceiptsCards({ rows }: SysReceiptsCardsProps) {
           <li
             key={row.receiptId}
             data-tone={row.tone}
-            className="status-row flex flex-col gap-2 rounded-[14px] border bg-d2-cream p-4"
+            className="status-row flex flex-col gap-2 rounded-[14px] border bg-surface-card p-4"
             style={{
-              borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+              borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
             }}
           >
             <div className="flex items-center justify-between gap-3">
@@ -33,15 +33,15 @@ export function SysReceiptsCards({ rows }: SysReceiptsCardsProps) {
                 <PoolGlyph initial={row.poolInitial} swatch={row.poolSwatch} size="sm" />
                 <div className="min-w-0">
                   <div className="truncate font-medium">{row.poolName}</div>
-                  <div className="font-mono text-[11px] text-d2-ink/55">{row.submittedLabel}</div>
+                  <div className="font-mono text-[11px] text-ink/55">{row.submittedLabel}</div>
                 </div>
               </div>
               <span className="shrink-0 font-mono text-sm font-semibold tabular-nums">{row.amountLabel}</span>
             </div>
             <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-[12px]">
-              <dt className="font-mono uppercase tracking-wider text-d2-ink/55">From</dt>
+              <dt className="font-mono uppercase tracking-wider text-ink/55">From</dt>
               <dd className="text-right">{row.fromName}</dd>
-              <dt className="font-mono uppercase tracking-wider text-d2-ink/55">Admin</dt>
+              <dt className="font-mono uppercase tracking-wider text-ink/55">Admin</dt>
               <dd
                 className="text-right"
                 style={{
@@ -51,11 +51,11 @@ export function SysReceiptsCards({ rows }: SysReceiptsCardsProps) {
               >
                 {row.adminName ?? 'unassigned'}
               </dd>
-              <dt className="font-mono uppercase tracking-wider text-d2-ink/55">Waiting</dt>
+              <dt className="font-mono uppercase tracking-wider text-ink/55">Waiting</dt>
               <dd
                 className="text-right font-mono"
                 style={{
-                  color: row.flag === 'stale' ? 'var(--ajo-outstanding-fg)' : undefined,
+                  color: row.flag === 'stale' ? 'var(--status-pending-fg)' : undefined,
                   fontWeight: row.flag === 'stale' ? 600 : 400,
                 }}
               >

--- a/components/super/sys-receipts-cards.tsx
+++ b/components/super/sys-receipts-cards.tsx
@@ -23,7 +23,7 @@ export function SysReceiptsCards({ rows }: SysReceiptsCardsProps) {
           <li
             key={row.receiptId}
             data-tone={row.tone}
-            className="status-row flex flex-col gap-2 rounded-[14px] border bg-card p-4"
+            className="status-row flex flex-col gap-2 rounded-[14px] border bg-d2-cream p-4"
             style={{
               borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
             }}

--- a/components/super/sys-receipts-signals.tsx
+++ b/components/super/sys-receipts-signals.tsx
@@ -16,7 +16,7 @@ interface Card {
  * the design source, the kicker is mono-uppercase, the value is the
  * 22px serif numeral, and the detail line is the small caption below.
  *
- * `warn` tiles bind to the amber accent (`--ajo-outstanding`); the
+ * `warn` tiles bind to the amber accent (`--status-pending`); the
  * rest stay neutral on the cream surface.
  */
 export function SysReceiptsSignals({ aggregates }: SysReceiptsSignalsProps) {
@@ -61,19 +61,19 @@ export function SysReceiptsSignals({ aggregates }: SysReceiptsSignalsProps) {
       {cards.map((c) => (
         <li
           key={c.kicker}
-          className="flex flex-col gap-0.5 rounded-[14px] border bg-d2-cream px-3.5 py-3"
+          className="flex flex-col gap-0.5 rounded-[14px] border bg-surface-card px-3.5 py-3"
           style={{
             borderColor: c.warn
-              ? 'color-mix(in oklch, var(--ajo-outstanding) 35%, transparent)'
-              : 'color-mix(in oklch, var(--d2-ink) 8%, transparent)',
+              ? 'color-mix(in oklch, var(--status-pending) 35%, transparent)'
+              : 'color-mix(in oklch, var(--ink) 8%, transparent)',
           }}
         >
           <span
             className="font-mono text-[10px] uppercase tracking-[0.06em]"
             style={{
               color: c.warn
-                ? 'var(--ajo-outstanding-fg)'
-                : 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+                ? 'var(--status-pending-fg)'
+                : 'color-mix(in oklch, var(--ink) 55%, transparent)',
             }}
           >
             {c.kicker}
@@ -81,7 +81,7 @@ export function SysReceiptsSignals({ aggregates }: SysReceiptsSignalsProps) {
           <span className="font-mono text-[1.375rem] font-semibold tabular-nums">{c.value}</span>
           <span
             className="text-[11px]"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
           >
             {c.detail}
           </span>

--- a/components/super/sys-receipts-table.tsx
+++ b/components/super/sys-receipts-table.tsx
@@ -23,7 +23,7 @@ const GRID =
 export function SysReceiptsTable({ rows }: SysReceiptsTableProps) {
   return (
     <div
-      className="overflow-hidden rounded-[14px] border bg-card"
+      className="overflow-hidden rounded-[14px] border bg-d2-cream"
       style={{
         borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
       }}

--- a/components/super/sys-receipts-table.tsx
+++ b/components/super/sys-receipts-table.tsx
@@ -23,18 +23,18 @@ const GRID =
 export function SysReceiptsTable({ rows }: SysReceiptsTableProps) {
   return (
     <div
-      className="overflow-hidden rounded-[14px] border bg-d2-cream"
+      className="overflow-hidden rounded-[14px] border bg-surface-card"
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
     >
       <div
         role="row"
         className={`${GRID} kicker-mono py-2.5 text-[10px]`}
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
-          borderBottom: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
-          color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
+          borderBottom: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
+          color: 'color-mix(in oklch, var(--ink) 55%, transparent)',
         }}
       >
         <span aria-hidden="true" />
@@ -59,14 +59,14 @@ export function SysReceiptsTable({ rows }: SysReceiptsTableProps) {
               style={{
                 borderBottom: isLast
                   ? 'none'
-                  : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                  : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
               }}
             >
               <span aria-hidden="true">
                 <input
                   type="checkbox"
                   aria-label={`Select receipt ${row.receiptId}`}
-                  className="h-[15px] w-[15px] cursor-pointer accent-d2-ink"
+                  className="h-[15px] w-[15px] cursor-pointer accent-ink"
                   readOnly
                 />
               </span>
@@ -77,7 +77,7 @@ export function SysReceiptsTable({ rows }: SysReceiptsTableProps) {
               <span
                 className="truncate text-[12px]"
                 style={{
-                  color: isNoAdmin ? 'var(--destructive)' : 'color-mix(in oklch, var(--d2-ink) 70%, transparent)',
+                  color: isNoAdmin ? 'var(--destructive)' : 'color-mix(in oklch, var(--ink) 70%, transparent)',
                   fontStyle: isNoAdmin ? 'italic' : 'normal',
                 }}
               >
@@ -87,7 +87,7 @@ export function SysReceiptsTable({ rows }: SysReceiptsTableProps) {
               <span className="font-mono font-medium">{row.amountLabel}</span>
               <span
                 className="font-mono text-[12px]"
-                style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+                style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
               >
                 {row.submittedLabel}
               </span>
@@ -95,8 +95,8 @@ export function SysReceiptsTable({ rows }: SysReceiptsTableProps) {
                 className="font-mono text-[12px]"
                 style={{
                   color: row.flag === 'stale'
-                    ? 'var(--ajo-outstanding-fg)'
-                    : 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+                    ? 'var(--status-pending-fg)'
+                    : 'color-mix(in oklch, var(--ink) 55%, transparent)',
                   fontWeight: row.flag === 'stale' ? 600 : 400,
                 }}
               >
@@ -111,7 +111,7 @@ export function SysReceiptsTable({ rows }: SysReceiptsTableProps) {
                   aria-label="Reassign receipt (coming soon)"
                   className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
                   style={{
-                    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
                   }}
                 >
                   Reassign
@@ -124,7 +124,7 @@ export function SysReceiptsTable({ rows }: SysReceiptsTableProps) {
                   aria-label="View receipt detail (coming soon)"
                   className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
                   style={{
-                    background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                    background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
                   }}
                 >
                   View

--- a/components/super/sys-receipts-view.tsx
+++ b/components/super/sys-receipts-view.tsx
@@ -36,13 +36,13 @@ export function SysReceiptsView({ rows, aggregates }: SysReceiptsViewProps) {
         <div className="flex flex-wrap items-center gap-2">
           <h1
             id="sys-receipts-title"
-            className="text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+            className="text-[1.5rem] font-semibold tracking-tight text-ink"
           >
             Receipts queue
           </h1>
           <SuperChip>system · all groups</SuperChip>
         </div>
-        <p className="text-[13px] text-d2-ink/55">{subLine}</p>
+        <p className="text-[13px] text-ink/55">{subLine}</p>
       </header>
 
       <SysReceiptsSignals aggregates={aggregates} />
@@ -59,16 +59,16 @@ export function SysReceiptsView({ rows, aggregates }: SysReceiptsViewProps) {
       ) : (
         <div
           role="status"
-          className="rounded-[14px] border bg-d2-cream p-8 text-center text-[13px] text-d2-ink/65"
+          className="rounded-[14px] border bg-surface-card p-8 text-center text-[13px] text-ink/65"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           The system-wide queue is empty. Pool admins handle their own queues today.
         </div>
       )}
 
-      <p className="font-mono text-[11px] text-d2-ink/45">
+      <p className="font-mono text-[11px] text-ink/45">
         super_admin view · does NOT confirm receipts directly, routes stragglers to admins.
         &ldquo;No admin assigned&rdquo; is the only actionable alarm here.
       </p>

--- a/components/super/sys-whatsapp-cards.tsx
+++ b/components/super/sys-whatsapp-cards.tsx
@@ -25,7 +25,7 @@ export function SysWhatsAppCards({ rows }: SysWhatsAppCardsProps) {
         <li
           key={row.poolId}
           data-tone={rowTone(row.status)}
-          className="status-row rounded-[14px] border bg-card p-4"
+          className="status-row rounded-[14px] border bg-d2-cream p-4"
           style={{
             borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
           }}

--- a/components/super/sys-whatsapp-cards.tsx
+++ b/components/super/sys-whatsapp-cards.tsx
@@ -25,9 +25,9 @@ export function SysWhatsAppCards({ rows }: SysWhatsAppCardsProps) {
         <li
           key={row.poolId}
           data-tone={rowTone(row.status)}
-          className="status-row rounded-[14px] border bg-d2-cream p-4"
+          className="status-row rounded-[14px] border bg-surface-card p-4"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="flex items-center justify-between gap-3">
@@ -35,7 +35,7 @@ export function SysWhatsAppCards({ rows }: SysWhatsAppCardsProps) {
               <PoolGlyph initial={row.poolInitial} swatch={row.poolSwatch} size="sm" />
               <div className="min-w-0">
                 <div className="truncate font-medium">{row.poolName}</div>
-                <div className="font-mono text-[11px] text-d2-ink/55">
+                <div className="font-mono text-[11px] text-ink/55">
                   {row.chatName ?? 'not linked'}
                 </div>
               </div>
@@ -44,20 +44,20 @@ export function SysWhatsAppCards({ rows }: SysWhatsAppCardsProps) {
           </div>
           <dl className="mt-3 grid grid-cols-3 gap-2 text-[12px]">
             <div>
-              <dt className="font-mono uppercase tracking-wider text-d2-ink/55">Members</dt>
+              <dt className="font-mono uppercase tracking-wider text-ink/55">Members</dt>
               <dd className="font-mono">{row.rosterLabel}</dd>
             </div>
             <div>
-              <dt className="font-mono uppercase tracking-wider text-d2-ink/55">Matched</dt>
+              <dt className="font-mono uppercase tracking-wider text-ink/55">Matched</dt>
               <dd
                 className="font-mono"
-                style={{ color: row.hasDrift ? 'var(--ajo-outstanding-fg)' : undefined }}
+                style={{ color: row.hasDrift ? 'var(--status-pending-fg)' : undefined }}
               >
                 {row.matchedLabel ?? '-'}
               </dd>
             </div>
             <div>
-              <dt className="font-mono uppercase tracking-wider text-d2-ink/55">Last event</dt>
+              <dt className="font-mono uppercase tracking-wider text-ink/55">Last event</dt>
               <dd className="font-mono">{row.lastEventLabel ?? '-'}</dd>
             </div>
           </dl>

--- a/components/super/sys-whatsapp-table.tsx
+++ b/components/super/sys-whatsapp-table.tsx
@@ -30,18 +30,18 @@ function actionLabel(status: WhatsAppLinkRow['status']): string {
 export function SysWhatsAppTable({ rows }: SysWhatsAppTableProps) {
   return (
     <div
-      className="overflow-hidden rounded-[14px] border bg-d2-cream"
+      className="overflow-hidden rounded-[14px] border bg-surface-card"
       style={{
-        borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
       }}
     >
       <div
         role="row"
         className={`${GRID} kicker-mono py-2.5 text-[10px]`}
         style={{
-          background: 'color-mix(in oklch, var(--d2-ink) 3%, transparent)',
-          borderBottom: '1px solid color-mix(in oklch, var(--d2-ink) 7%, transparent)',
-          color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)',
+          background: 'color-mix(in oklch, var(--ink) 3%, transparent)',
+          borderBottom: '1px solid color-mix(in oklch, var(--ink) 7%, transparent)',
+          color: 'color-mix(in oklch, var(--ink) 55%, transparent)',
         }}
       >
         <span>PoolPay group</span>
@@ -67,7 +67,7 @@ export function SysWhatsAppTable({ rows }: SysWhatsAppTableProps) {
               style={{
                 borderBottom: isLast
                   ? 'none'
-                  : '1px solid color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+                  : '1px solid color-mix(in oklch, var(--ink) 6%, transparent)',
               }}
             >
               <div className="flex min-w-0 items-center gap-2.5">
@@ -78,8 +78,8 @@ export function SysWhatsAppTable({ rows }: SysWhatsAppTableProps) {
                 className="truncate text-[13px]"
                 style={{
                   color: isUnlinked
-                    ? 'color-mix(in oklch, var(--d2-ink) 40%, transparent)'
-                    : 'var(--d2-ink)',
+                    ? 'color-mix(in oklch, var(--ink) 40%, transparent)'
+                    : 'var(--ink)',
                   fontStyle: isUnlinked ? 'italic' : 'normal',
                 }}
               >
@@ -87,7 +87,7 @@ export function SysWhatsAppTable({ rows }: SysWhatsAppTableProps) {
               </span>
               <span
                 className="truncate font-mono text-[12px]"
-                style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+                style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
               >
                 {row.waGroupIdLabel ?? '-'}
               </span>
@@ -96,15 +96,15 @@ export function SysWhatsAppTable({ rows }: SysWhatsAppTableProps) {
                 className="font-mono text-[12px]"
                 style={{
                   color: row.hasDrift
-                    ? 'var(--ajo-outstanding-fg)'
-                    : 'color-mix(in oklch, var(--d2-ink) 70%, transparent)',
+                    ? 'var(--status-pending-fg)'
+                    : 'color-mix(in oklch, var(--ink) 70%, transparent)',
                 }}
               >
                 {row.matchedLabel ?? '-'}
               </span>
               <span
                 className="font-mono text-[12px]"
-                style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+                style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
               >
                 {row.lastEventLabel ?? '-'}
               </span>
@@ -118,9 +118,9 @@ export function SysWhatsAppTable({ rows }: SysWhatsAppTableProps) {
                 className="rounded-lg px-2.5 py-1.5 text-[12px] font-medium disabled:cursor-not-allowed disabled:opacity-60"
                 style={{
                   background: needsLink
-                    ? 'var(--d2-ink)'
-                    : 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
-                  color: needsLink ? 'var(--d2-warm-bg)' : 'var(--d2-ink)',
+                    ? 'var(--ink)'
+                    : 'color-mix(in oklch, var(--ink) 6%, transparent)',
+                  color: needsLink ? 'var(--surface-page)' : 'var(--ink)',
                 }}
               >
                 {actionLabel(row.status)}

--- a/components/super/sys-whatsapp-table.tsx
+++ b/components/super/sys-whatsapp-table.tsx
@@ -30,7 +30,7 @@ function actionLabel(status: WhatsAppLinkRow['status']): string {
 export function SysWhatsAppTable({ rows }: SysWhatsAppTableProps) {
   return (
     <div
-      className="overflow-hidden rounded-[14px] border bg-card"
+      className="overflow-hidden rounded-[14px] border bg-d2-cream"
       style={{
         borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
       }}

--- a/components/super/sys-whatsapp-view.tsx
+++ b/components/super/sys-whatsapp-view.tsx
@@ -61,7 +61,7 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
       <div className="grid grid-cols-1 gap-3.5 lg:grid-cols-[1.6fr_1fr]">
         <section
           aria-labelledby="sys-bot-status"
-          className="rounded-[14px] border bg-card p-4"
+          className="rounded-[14px] border bg-d2-cream p-4"
           style={{
             borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
           }}
@@ -109,7 +109,7 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
 
         <section
           aria-labelledby="sys-bot-how"
-          className="rounded-[14px] border bg-card p-4"
+          className="rounded-[14px] border bg-d2-cream p-4"
           style={{
             borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
           }}

--- a/components/super/sys-whatsapp-view.tsx
+++ b/components/super/sys-whatsapp-view.tsx
@@ -34,13 +34,13 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
           <div className="flex flex-wrap items-center gap-2">
             <h1
               id="sys-whatsapp-title"
-              className="text-[1.5rem] font-semibold tracking-tight text-d2-ink"
+              className="text-[1.5rem] font-semibold tracking-tight text-ink"
             >
               WhatsApp links
             </h1>
             <SuperChip>plumbing</SuperChip>
           </div>
-          <p className="text-[13px] text-d2-ink/55">{subLine}</p>
+          <p className="text-[13px] text-ink/55">{subLine}</p>
         </div>
         {/* TODO(slice 5): wire WhatsApp member re-scan. */}
         <button
@@ -50,7 +50,7 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
           aria-label="Re-scan WhatsApp members (coming soon)"
           className="inline-flex items-center gap-1.5 rounded-[10px] px-3 py-1.5 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-60"
           style={{
-            background: 'color-mix(in oklch, var(--d2-ink) 6%, transparent)',
+            background: 'color-mix(in oklch, var(--ink) 6%, transparent)',
           }}
         >
           <RefreshCw size={13} aria-hidden="true" />
@@ -61,9 +61,9 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
       <div className="grid grid-cols-1 gap-3.5 lg:grid-cols-[1.6fr_1fr]">
         <section
           aria-labelledby="sys-bot-status"
-          className="rounded-[14px] border bg-d2-cream p-4"
+          className="rounded-[14px] border bg-surface-card p-4"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <div className="mb-2.5 flex items-center gap-3">
@@ -78,7 +78,7 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
               <h2 id="sys-bot-status" className="text-[15px] font-semibold">
                 PoolPay bot
               </h2>
-              <p className="text-[12px] text-d2-ink/55">
+              <p className="text-[12px] text-ink/55">
                 {bot.botPhone} · {aggregates.linked} group chats · last event{' '}
                 {rows[0]?.lastEventLabel ?? '-'}
               </p>
@@ -94,10 +94,10 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
               { k: 'Needs admin', v: String(bot.needsAdmin) },
               { k: 'Avg ack time', v: bot.avgAckLabel },
             ].map((s) => (
-              <div key={s.k} className="rounded-lg bg-d2-cream px-2.5 py-2">
+              <div key={s.k} className="rounded-lg bg-surface-card px-2.5 py-2">
                 <div
                   className="font-mono text-[10px] uppercase tracking-[0.06em]"
-                  style={{ color: 'color-mix(in oklch, var(--d2-ink) 55%, transparent)' }}
+                  style={{ color: 'color-mix(in oklch, var(--ink) 55%, transparent)' }}
                 >
                   {s.k}
                 </div>
@@ -109,9 +109,9 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
 
         <section
           aria-labelledby="sys-bot-how"
-          className="rounded-[14px] border bg-d2-cream p-4"
+          className="rounded-[14px] border bg-surface-card p-4"
           style={{
-            borderColor: 'color-mix(in oklch, var(--d2-ink) 7%, transparent)',
+            borderColor: 'color-mix(in oklch, var(--ink) 7%, transparent)',
           }}
         >
           <h2 id="sys-bot-how" className="kicker-mono mb-2 text-[10px]">
@@ -119,7 +119,7 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
           </h2>
           <ol
             className="ml-4 list-decimal space-y-1 text-[13px]"
-            style={{ color: 'color-mix(in oklch, var(--d2-ink) 75%, transparent)' }}
+            style={{ color: 'color-mix(in oklch, var(--ink) 75%, transparent)' }}
           >
             <li>
               Super-admin invites <span className="font-mono text-[12px]">{bot.botPhone}</span>{' '}
@@ -142,7 +142,7 @@ export function SysWhatsAppView({ rows, aggregates, bot }: SysWhatsAppViewProps)
         <SysWhatsAppCards rows={rows} />
       </div>
 
-      <p className="font-mono text-[11px] text-d2-ink/45">
+      <p className="font-mono text-[11px] text-ink/45">
         phone-match drift (e.g. 8/10) means members changed numbers or never joined the chat
         · nudge them
       </p>

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -12,7 +12,7 @@ const alertVariants = cva(
         destructive:
           "border-destructive/25 bg-destructive/10 text-destructive [&>svg]:text-destructive dark:border-destructive/40 dark:bg-destructive/15",
         warning:
-          "border-ajo-outstanding/25 bg-ajo-outstanding-subtle text-ajo-outstanding [&>svg]:text-ajo-outstanding dark:border-ajo-outstanding/40 dark:bg-ajo-outstanding/15 dark:text-ajo-outstanding",
+          "border-status-pending/25 bg-status-pending-subtle text-status-pending [&>svg]:text-status-pending dark:border-status-pending/40 dark:bg-status-pending/15 dark:text-status-pending",
       },
     },
     defaultVariants: {

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -53,17 +53,32 @@ Chart colours are **identical in light and dark** — they were chosen to read w
 | `--chart-4` | `oklch(0.488 0.243 264.376)` | Dark blue |
 | `--chart-5` | `oklch(0.424 0.199 265.638)` | Darkest blue |
 
-### Ajo Accent Tokens
+### Status Tokens
 
-> **Theme-invariant** — these colours do not change between light and dark. They are defined as `--ajo-*` variables in `:root` and then mapped to Tailwind colour utilities via `--color-ajo-*` using `var()`, so they are never overridden by `.dark`. Do not add `.dark` overrides for these unless the contrast requirement genuinely cannot be met without them.
+> **Theme-invariant** — these colours do not change between light and dark. They are defined as `--status-*` variables in `:root` and then mapped to Tailwind colour utilities via `--color-status-*` using `var()`, so they are never overridden by `.dark`. Do not add `.dark` overrides for these unless the contrast requirement genuinely cannot be met without them.
+>
+> The one exception is `--status-pending-fg`, which IS overridden in `.dark` to use a lighter amber so body-copy on the dark cream surface stays legible.
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `--color-ajo-paid` | `var(--ajo-paid)` | Paid status text and icons (`text-ajo-paid`) |
-| `--color-ajo-paid-subtle` | `var(--ajo-paid-subtle)` | Paid status badge background (`bg-ajo-paid-subtle`) |
-| `--color-ajo-outstanding` | `var(--ajo-outstanding)` | Outstanding status text and icons |
-| `--color-ajo-outstanding-subtle` | `var(--ajo-outstanding-subtle)` | Outstanding status badge background |
-| `--color-ajo-active` | `var(--ajo-active)` | Active cycle indicator (matches paid) |
+| `--color-status-paid` | `var(--status-paid)` | Paid / settled status text and icons (`text-status-paid`, `fill-status-paid`) |
+| `--color-status-paid-subtle` | `var(--status-paid-subtle)` | Paid status badge background (`bg-status-paid-subtle`) |
+| `--color-status-pending` | `var(--status-pending)` | Pending / warning status text and icons |
+| `--color-status-pending-subtle` | `var(--status-pending-subtle)` | Pending status badge background |
+| `--status-pending-fg` | `oklch(0.5 0.14 70)` light, `oklch(0.78 0.17 70)` dark | Darker text-on-cream variant for body copy where the chip foreground is too light |
+| `--color-status-active` | `var(--status-active)` | In-flight cycle indicator (shares the paid hue) |
+
+### Brand Surface Tokens
+
+| Token | Light | Dark | Usage |
+|-------|-------|------|-------|
+| `--surface-page` | `oklch(0.98 0.01 75)` | `oklch(0.16 0.02 260)` | Warm cream page background (`bg-surface-page`) |
+| `--surface-card` | `oklch(0.97 0.012 75)` | `oklch(0.19 0.018 260)` | Card / panel background (`bg-surface-card`) |
+| `--ink` | `oklch(0.18 0.02 260)` | `oklch(0.97 0.01 75)` | Primary text / foreground (`text-ink`, `border-ink`) |
+| `--accent-primary` | `oklch(0.62 0.14 160)` | (same) | Brand green-teal, primary CTA accent |
+| `--accent-primary-soft` | `oklch(0.62 0.14 160 / 14%)` | (same) | 14% tint, chip backgrounds |
+| `--accent-coral` | `oklch(0.72 0.13 38)` | (same) | Warm accent, pool-swatch gradients |
+| `--accent-lavender` | `oklch(0.76 0.08 310)` | (same) | Cool accent, gradients |
 
 ### Sidebar Tokens
 
@@ -176,7 +191,7 @@ const buttonVariants = cva('...base classes...', {
       default: '...',
       outline: '...',
       // Add your variant here:
-      brand: 'bg-ajo-paid text-white hover:bg-ajo-paid/90',
+      brand: 'bg-status-paid text-white hover:bg-status-paid/90',
     },
   },
 });

--- a/docs/slice-1-screenshots.md
+++ b/docs/slice-1-screenshots.md
@@ -94,7 +94,7 @@ The four new stub routes added in slice 1:
 - `/offline`
 
 These confirm the editorial layouts render and the dark `#0a0a0a` panel +
-ajo-paid kicker land correctly.
+status-paid kicker land correctly.
 
 ## What to look for
 
@@ -104,11 +104,11 @@ A pass requires:
   super_admin: +System section with 3 items).
 - Active route is highlighted (dark ink fill, warm-bg text).
 - Topbar shows the route-derived title (e.g. "Home", "Administration").
-- Active-pool card on member sidebar shows the d2-cream surface + balance.
+- Active-pool card on member sidebar shows the surface-card surface + balance.
 - Dark mode: warm-bg flips to deep blue-ink, cream flips to a darker
   blue-ink — verify there's no Tailwind-default blue or hex bleed.
 - `/admin/receipts` link surfaces the pending-count badge in
-  `--ajo-outstanding` (gold) only when count > 0 (slice 5 wires the actual
+  `--status-pending` (gold) only when count > 0 (slice 5 wires the actual
   count; today the badge is hidden because we pass `undefined`).
 
 ## Known gaps for the reviewer's eye

--- a/docs/slice-2-screenshots.md
+++ b/docs/slice-2-screenshots.md
@@ -98,7 +98,7 @@ A pass requires:
 - **Desktop (1440px):** full chrome with active-pool card in sidebar,
   Quick-pay CTA on `/home` and `/pools/:id` topbars, breadcrumb above
   the title for nested routes.
-- **Dark theme:** `--d2-warm-bg` flips to deep blue-ink, `--d2-cream`
+- **Dark theme:** `--surface-page` flips to deep blue-ink, `--surface-card`
   flips to a darker blue-ink, status pills retain semantic tone.
 - **Pay flow:** desktop renders a max-width 560px column inside the
   cream panel; mobile is full-bleed with the bottom tab bar suppressed.

--- a/tests/unit/sidebar-theme-toggle.test.tsx
+++ b/tests/unit/sidebar-theme-toggle.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const setTheme = vi.fn();
+let resolvedTheme: string | undefined = 'light';
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme, setTheme }),
+}));
+
+import { SidebarThemeToggle } from '@/components/layout/sidebar-theme-toggle';
+
+afterEach(() => {
+  cleanup();
+  setTheme.mockReset();
+  resolvedTheme = 'light';
+});
+
+describe('SidebarThemeToggle', () => {
+  it('renders a moon icon and calls setTheme("dark") when current is light', async () => {
+    resolvedTheme = 'light';
+    render(<SidebarThemeToggle />);
+    const button = await screen.findByRole('button', { name: 'Switch to dark theme' });
+    await userEvent.click(button);
+    expect(setTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('renders a sun icon and calls setTheme("light") when current is dark', async () => {
+    resolvedTheme = 'dark';
+    render(<SidebarThemeToggle />);
+    const button = await screen.findByRole('button', { name: 'Switch to light theme' });
+    await userEvent.click(button);
+    expect(setTheme).toHaveBeenCalledWith('light');
+  });
+});

--- a/tests/unit/sidebar-theme-toggle.test.tsx
+++ b/tests/unit/sidebar-theme-toggle.test.tsx
@@ -21,17 +21,19 @@ afterEach(() => {
 describe('SidebarThemeToggle', () => {
   it('renders a moon icon and calls setTheme("dark") when current is light', async () => {
     resolvedTheme = 'light';
+    const user = userEvent.setup();
     render(<SidebarThemeToggle />);
     const button = await screen.findByRole('button', { name: 'Switch to dark theme' });
-    await userEvent.click(button);
+    await user.click(button);
     expect(setTheme).toHaveBeenCalledWith('dark');
   });
 
   it('renders a sun icon and calls setTheme("light") when current is dark', async () => {
     resolvedTheme = 'dark';
+    const user = userEvent.setup();
     render(<SidebarThemeToggle />);
     const button = await screen.findByRole('button', { name: 'Switch to light theme' });
-    await userEvent.click(button);
+    await user.click(button);
     expect(setTheme).toHaveBeenCalledWith('light');
   });
 });

--- a/tests/unit/skeleton-block.test.tsx
+++ b/tests/unit/skeleton-block.test.tsx
@@ -33,9 +33,9 @@ describe('SkeletonBlock', () => {
     expect(span?.style.borderRadius).toBe('999px');
   });
 
-  it('keeps the d2-shimmer animation set on the inline style', () => {
+  it('keeps the surface-shimmer animation set on the inline style', () => {
     const { container } = render(<SkeletonBlock />);
     const span = container.querySelector('span');
-    expect(span?.style.animation).toContain('d2-shimmer');
+    expect(span?.style.animation).toContain('surface-shimmer');
   });
 });

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -78,26 +78,26 @@ test.describe('Visual, light mode', () => {
     expect(width).toBe(`${percent}%`);
   });
 
-  test('"Paid" badge (ajo-paid-subtle) has a visible background', async ({ page }) => {
-    const badge = page.locator('[class*="ajo-paid-subtle"]').first();
+  test('"Paid" badge (status-paid-subtle) has a visible background', async ({ page }) => {
+    const badge = page.locator('[class*="status-paid-subtle"]').first();
     const badgeVisible = await badge.isVisible().catch(() => false);
     if (!badgeVisible) test.skip();
-    const bg = await computedBg(page, '[class*="ajo-paid-subtle"]');
+    const bg = await computedBg(page, '[class*="status-paid-subtle"]');
     expect(bg).not.toBe('rgba(0, 0, 0, 0)');
     expect(bg).not.toBe('transparent');
   });
 
-  test('"Outstanding" badge (ajo-outstanding-subtle) has a visible background', async ({ page }) => {
-    const badge = page.locator('[class*="ajo-outstanding-subtle"]').first();
+  test('"Outstanding" badge (status-pending-subtle) has a visible background', async ({ page }) => {
+    const badge = page.locator('[class*="status-pending-subtle"]').first();
     const badgeVisible = await badge.isVisible().catch(() => false);
     if (!badgeVisible) test.skip();
-    const bg = await computedBg(page, '[class*="ajo-outstanding-subtle"]');
+    const bg = await computedBg(page, '[class*="status-pending-subtle"]');
     expect(bg).not.toBe('rgba(0, 0, 0, 0)');
     expect(bg).not.toBe('transparent');
   });
 
   test('"Active" badge uses same paid colour token', async ({ page }) => {
-    const activeBadge = page.locator('[class*="ajo-paid-subtle"]').filter({ hasText: 'Active' }).first();
+    const activeBadge = page.locator('[class*="status-paid-subtle"]').filter({ hasText: 'Active' }).first();
     const badgeVisible = await activeBadge.isVisible().catch(() => false);
     if (!badgeVisible) test.skip();
     const bg = await activeBadge.evaluate((el) => window.getComputedStyle(el).backgroundColor);
@@ -156,19 +156,19 @@ test.describe('Visual, dark mode', () => {
   });
 
   test('"Paid" badge has a visible background in dark mode', async ({ page }) => {
-    const badge = page.locator('[class*="ajo-paid-subtle"]').first();
+    const badge = page.locator('[class*="status-paid-subtle"]').first();
     const badgeVisible = await badge.isVisible().catch(() => false);
     if (!badgeVisible) test.skip();
-    const bg = await computedBg(page, '[class*="ajo-paid-subtle"]');
+    const bg = await computedBg(page, '[class*="status-paid-subtle"]');
     expect(bg).not.toBe('rgba(0, 0, 0, 0)');
     expect(bg).not.toBe('transparent');
   });
 
   test('"Outstanding" badge has a visible background in dark mode', async ({ page }) => {
-    const badge = page.locator('[class*="ajo-outstanding-subtle"]').first();
+    const badge = page.locator('[class*="status-pending-subtle"]').first();
     const badgeVisible = await badge.isVisible().catch(() => false);
     if (!badgeVisible) test.skip();
-    const bg = await computedBg(page, '[class*="ajo-outstanding-subtle"]');
+    const bg = await computedBg(page, '[class*="status-pending-subtle"]');
     expect(bg).not.toBe('rgba(0, 0, 0, 0)');
     expect(bg).not.toBe('transparent');
   });


### PR DESCRIPTION
## Summary

A design-fidelity audit of the redesign on top of `feat/poolpay-redesign-reapply` against the canonical handoff at `Downloads/design_handoff_poolpay_app/` found two real deltas. Token equality was clean (zero `oklch(...)` mismatches), gradient inventory matched (every chrome gradient the handoff specifies already exists), and per-surface comparison flagged only these two.

This stacked PR addresses both, plus restores the theme toggle (which the mockups omitted but the implementation needs), and renames the color tokens to semantic names so the variables describe what they're for. Base is `feat/poolpay-redesign-reapply` so the diff stays focused; rebase onto `main` once reapply merges.

### Fix 1: receipts queue left-edge gradient

`components/admin/receipts-queue-table.tsx` defined a `TONE_BG` map and applied it as inline `background:` on each row, which both overrode the canonical `.status-row` left-edge gradient wash from `app/globals.css` AND meant the row never received the `status-row` className. Removed the constant + inline style, added `status-row` to each row, kept `data-tone={row.tone}` so the global selectors trigger.

### Fix 2: super-admin background brand consistency

Super-admin tables and panels used Tailwind's `bg-card` (white in light, cool blue-black in dark). Member and admin views use the warm cream / deep navy surface that matches the handoff for all three roles. Swapped the class on panel/table backgrounds across:

- `sys-admins-table.tsx`, `sys-admins-cards.tsx`
- `sys-receipts-table.tsx`, `sys-receipts-cards.tsx`
- `sys-groups-cards.tsx`
- `sys-whatsapp-table.tsx`, `sys-whatsapp-cards.tsx`
- `sys-whatsapp-view.tsx` (two panels)
- `sys-group-detail-view.tsx` (three panels)

Inline summary cards intentionally on a different token (e.g. the warm-bg in Assignments) were left alone.

### Fix 3: restore theme toggle in sidebar user foot

The redesign mockups omitted the theme toggle, but the app still ships a `ThemeProvider` (next-themes) and the legacy `ThemeToggle` was orphaned when the old `AppNav` was retired. Added a sidebar-styled toggle (`components/layout/sidebar-theme-toggle.tsx`) immediately to the left of the sign-out button in the user-foot block. Visual styling matches the adjacent sign-out icon button (h-7 w-7, same hover and color tokens) so the two read as a sibling pair.

Cycles light and dark only. System mode is still honoured on first paint via `next-themes` defaults but is not exposed as a third click target, since a dropdown would visually clash with the adjacent icon button. The standalone three-mode `ThemeToggle` at `components/dashboard/theme-toggle.tsx` remains available for a future Settings page.

Hydration safety uses `useSyncExternalStore` (server snapshot `false`, client snapshot `true`) instead of `useState` + `useEffect`, matching the pattern adopted for `SysMobileGuard` and satisfying `react-hooks/set-state-in-effect`.

### Fix 4: rename color tokens to semantic names

The design-token namespace previously used names lifted from internal design-canvas iterations (`--ajo-paid`, `--d2-cream`, `bg-d2-ink`, etc) which carried no meaning to a human reader. Renamed the entire namespace so each variable describes what it represents, not which iteration of the design canvas it came from. The rendered colors are byte-identical; this is purely a naming sweep.

Status palette:
- `--ajo-paid` to `--status-paid` (and the `-subtle` variant)
- `--ajo-outstanding` to `--status-pending` (and the `-subtle` and `-fg` variants)
- `--ajo-active` to `--status-active`

Brand surface palette:
- `--d2-warm-bg` to `--surface-page`
- `--d2-cream` to `--surface-card`
- `--d2-ink` to `--ink`
- `--d2-accent` to `--accent-primary` (and the `-soft` variant)
- `--d2-coral` to `--accent-coral`
- `--d2-lav` to `--accent-lavender`

Tailwind class equivalents follow the same mapping (`bg-d2-cream` to `bg-surface-card`, `text-d2-ink` to `text-ink`, `bg-ajo-paid` to `bg-status-paid`, `accent-d2-ink` to `accent-ink`, etc). The `d2-shimmer` keyframe is renamed to `surface-shimmer` for the same consistency reason.

Each token in `app/globals.css` now carries a one-line docstring describing what it represents and where it shows up, so future readers do not need to grep components to understand what a value drives.

The rename also surfaced a latent type error in the round-12 `setTimeout` cleanup commit (a34d9ff): the four sites used `window.setTimeout` (returns `number` per DOM lib) but typed the Set as `Set<ReturnType<typeof setTimeout>>` which TS resolves to `NodeJS.Timeout`. Vitest does not run `tsc`, which is why this slipped through; Turbopack's tsc step in `next build` caught it. Dropped the `window.` prefix on the four call sites so the types align.

### Out of scope

- Sign-in right-column dark frame (deferred to FE-4 per project memory)
- The minor unjustified gradient in `components/dashboard/member-payment-row.tsx` (audit flagged for dead-code investigation, not in this PR)
- A Settings page exposure of the full three-mode theme dropdown
- The handoff itself still uses the old `--ajo-*` and `--d2-*` token names; this PR diverges from the handoff naming on purpose, since the handoff's choice was an internal design-canvas convention, not a brand requirement

## Test plan

- [x] `yarn lint` clean
- [x] `yarn test --run` 496 of 496 passing (+2 new for `SidebarThemeToggle`)
- [x] `yarn build` clean (Turbopack production build)
- [ ] Visual smoke on `/admin/receipts` desktop: receipts rows show the left-edge gradient wash by tone
- [ ] Visual smoke on `/sys/receipts`, `/sys/groups`, `/sys/admins`, `/sys/whatsapp` desktop in light AND dark: panel backgrounds read warm cream (light) / deep navy (dark), matching member and admin
- [ ] Visual smoke on `/sys/groups/[poolId]` panels (overview, members, settings) same as above
- [ ] Click the moon/sun icon in the sidebar user foot: theme cycles light to dark and back, icon and aria-label update accordingly, no hydration warning in the console
- [ ] After the rename, all surfaces still render with no missing-color regressions (compare against the dev server before this commit)
