### PR TITLE
[CONFIG] - Gitignore graphify-out knowledge graph artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ next-env.d.ts
 # brain-sync marker (personal sync state)
 .brain-sync
 
+# graphify output — knowledge graph build artifacts stay local
+graphify-out/
+
 # Visual + reference assets live in Obsidian vault, not the repo
 docs/screenshots/
 docs/design-handoff/


### PR DESCRIPTION
## Summary

- Adds `graphify-out/` to `.gitignore` so the knowledge graph build artifacts (graph.json, GRAPH_REPORT.md, graph.html, cache, cost tracker) stay local to the developer's machine.

## Context

Ran `/graphify` on `main` post-#68-merge to audit cross-tier coupling and surface refactor candidates. The output dir (~12 MB of graph data + HTML viz) is intentionally local-only: it's a build artifact derived from the source, not source itself, and gets regenerated on demand via `graphify` CLI.

## Test plan

- [ ] `git status` is clean after `graphify` runs
- [ ] No graphify artifacts appear in `git diff` / `gh pr view --json files` after a rebuild