### PR TITLE
[REFACTOR] - Extract hashToSwatch helper to dedupe swatch-picking logic

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,6 +22,18 @@ export function formatPhone(phone: string): string {
   return `+${digits}`;
 }
 
+/**
+ * Deterministically pick a swatch from `swatches` based on a string id, so
+ * the same id always maps to the same slot across surfaces (member + admin
+ * + super views need to agree on a pool's accent colour). A sum-of-codepoints
+ * hash is enough, collisions are aesthetic only.
+ */
+export function hashToSwatch<T>(id: string, swatches: readonly T[]): T {
+  let sum = 0;
+  for (let i = 0; i < id.length; i++) sum += id.charCodeAt(i);
+  return swatches[sum % swatches.length];
+}
+
 export function padZero(n: number): string {
   return String(n).padStart(2, '0');
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -28,7 +28,7 @@ export function formatPhone(phone: string): string {
  * + super views need to agree on a pool's accent colour). A sum-of-codepoints
  * hash is enough, collisions are aesthetic only.
  */
-export function hashToSwatch<T>(id: string, swatches: readonly T[]): T {
+export function hashToSwatch<T>(id: string, swatches: readonly [T, ...T[]]): T {
   let sum = 0;
   for (let i = 0; i < id.length; i++) sum += id.charCodeAt(i);
   return swatches[sum % swatches.length];

--- a/lib/view-models/admin.ts
+++ b/lib/view-models/admin.ts
@@ -22,7 +22,7 @@ import type {
   Receipt,
   ReceiptStatus,
 } from '@/lib/types';
-import { formatNgn } from '@/lib/utils';
+import { formatNgn, hashToSwatch } from '@/lib/utils';
 
 // ─── Shared swatch helpers ─────────────────────────────────────────────────
 
@@ -35,9 +35,7 @@ export type PoolSwatchSlot = (typeof SWATCHES)[number];
  * `view-models/member.ts` so member + admin views agree).
  */
 export function pickPoolSwatch(id: string): PoolSwatchSlot {
-  let sum = 0;
-  for (let i = 0; i < id.length; i++) sum += id.charCodeAt(i);
-  return SWATCHES[sum % SWATCHES.length];
+  return hashToSwatch(id, SWATCHES);
 }
 
 function uppercaseFirst(name: string): string {

--- a/lib/view-models/member.ts
+++ b/lib/view-models/member.ts
@@ -25,6 +25,7 @@ import {
   deriveCycleSummary,
   formatNgn,
   getMemberPaymentStatuses,
+  hashToSwatch,
 } from '@/lib/utils';
 
 // ─── PoolSummary, used on /home pool cards ────────────────────────────────
@@ -127,18 +128,6 @@ export interface PoolDetail {
 // ─── Derivation helpers ────────────────────────────────────────────────────
 
 const SWATCHES = ['a', 'b', 'c', 'd'] as const;
-type Swatch = (typeof SWATCHES)[number];
-
-/**
- * Pick a swatch deterministically from the pool id so the same pool always
- * renders with the same accent color. A simple sum-of-codepoints hash is
- * enough, collisions are aesthetic only.
- */
-function pickSwatch(id: string): Swatch {
-  let sum = 0;
-  for (let i = 0; i < id.length; i++) sum += id.charCodeAt(i);
-  return SWATCHES[sum % SWATCHES.length];
-}
 
 /**
  * Express a frequency from `Cycle.cycleNumber` cadence as the design's
@@ -218,7 +207,7 @@ export function toPoolSummary({
     id: group.id,
     name: group.name,
     initial: uppercaseFirst(group.name),
-    swatch: pickSwatch(group.id),
+    swatch: hashToSwatch(group.id, SWATCHES),
     subtitle,
     progressPct,
     amountLabel,


### PR DESCRIPTION
## Summary

Two view-model modules duplicated a byte-identical hash-to-swatch algorithm:

- `lib/view-models/member.ts` had a private `pickSwatch` function
- `lib/view-models/admin.ts` had an exported `pickPoolSwatch` function (re-exported via `view-models/super.ts`)

Both used `sum-of-codepoints % SWATCHES.length` to deterministically pick a swatch slot from a string id. The only legitimate difference was the swatch-slot type per role.

This PR extracts the algorithm into a generic `hashToSwatch<T>(id, swatches)` helper in `lib/utils.ts`. Each module keeps its own typed `SWATCHES` constant and now calls the shared helper. Public exports are preserved: `pickPoolSwatch` keeps its name and signature so the `view-models/super.ts` re-export and existing consumers continue to type-check.

## Why now

Surfaced by `/graphify` analysis post-PR #68 at confidence 0.95 — the highest semantic-similarity edge in the codebase. If either branch had drifted (e.g. switched to a stronger hash for better distribution), member and admin views would have silently rendered different glyph colours for the same pool id, breaking visual coherence between roles.

## Files changed

- `lib/utils.ts` — adds `hashToSwatch<T>(id: string, swatches: readonly T[]): T`
- `lib/view-models/admin.ts` — `pickPoolSwatch` becomes a one-line delegate
- `lib/view-models/member.ts` — deletes local `pickSwatch` (and now-unused `Swatch` type alias), call site uses `hashToSwatch(id, SWATCHES)`

## Test plan

- [x] `npx vitest run` — 50/50 test files, 496/496 tests pass (matches main baseline)
- [x] `grep -n "for (let i = 0; i < id.length; i++) sum +=" lib/` returns one hit, in `lib/utils.ts` (the new canonical home)
- [x] `grep "function pickSwatch" lib/` returns no matches
- [x] Public exports of `pickPoolSwatch` preserved — `view-models/super.ts` re-export and `lib/preview/super-fixtures.ts` consumers unchanged