### PR TITLE
[REFACTOR] - Migrate admin-actions.ts to secureAction wrapper

### DIFF
--- a/lib/admin-actions.ts
+++ b/lib/admin-actions.ts
@@ -1,21 +1,36 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { apiAction } from '@/lib/http';
-import { ADMIN_TOKEN } from '@/lib/config';
+import { secureAction } from '@/lib/auth/backend-fetch';
 import type { ActionResult, CycleStatus, GroupStatus, MemberStatus } from '@/lib/types';
 
-async function adminAction(
+/**
+ * Admin CRUD wrapper around `secureAction`.
+ *
+ * Previously this module called a bespoke `apiAction(path, { token: ADMIN_TOKEN })`
+ * helper that did a plain fetch with no auth-refresh flow. Migrating to
+ * `secureAction` brings admin mutations onto the same single-401-retry +
+ * `BackendUnauthorizedError` plumbing every other authenticated mutation
+ * already uses (post-PR #68 graphify analysis, confidence 0.80).
+ *
+ * Public function signatures are preserved: each exported action still
+ * resolves to `ActionResult` (`{ success: true } | { success: false; error }`)
+ * so consumers in `app/(app)/admin/_components/*` need no change. Auth
+ * failures continue to bubble as `BackendUnauthorizedError` for the caller's
+ * /signin redirect, matching `lib/actions/receipts.ts`.
+ */
+async function runAdminMutation(
   path: string,
   method: string,
   body?: unknown,
 ): Promise<ActionResult> {
-  const result = await apiAction(path, { method, body, token: ADMIN_TOKEN });
+  const result = await secureAction(path, { method, body });
   if (result.success) {
     revalidatePath('/');
     revalidatePath('/admin');
+    return { success: true };
   }
-  return result;
+  return { success: false, error: result.error };
 }
 
 // ─── Groups ───────────────────────────────────────────────────────────────────
@@ -24,18 +39,18 @@ export async function createGroup(input: {
   name: string;
   description?: string;
 }): Promise<ActionResult> {
-  return adminAction('/api/admin/groups', 'POST', input);
+  return runAdminMutation('/api/admin/groups', 'POST', input);
 }
 
 export async function updateGroup(
   id: string,
   input: { name?: string; status?: GroupStatus; description?: string },
 ): Promise<ActionResult> {
-  return adminAction(`/api/admin/groups/${id}`, 'PATCH', input);
+  return runAdminMutation(`/api/admin/groups/${id}`, 'PATCH', input);
 }
 
 export async function deleteGroup(id: string): Promise<ActionResult> {
-  return adminAction(`/api/admin/groups/${id}`, 'DELETE');
+  return runAdminMutation(`/api/admin/groups/${id}`, 'DELETE');
 }
 
 // ─── Members ──────────────────────────────────────────────────────────────────
@@ -44,18 +59,18 @@ export async function createMember(
   groupId: string,
   input: { name: string; phone: string; position: number },
 ): Promise<ActionResult> {
-  return adminAction(`/api/admin/groups/${groupId}/members`, 'POST', input);
+  return runAdminMutation(`/api/admin/groups/${groupId}/members`, 'POST', input);
 }
 
 export async function updateMember(
   id: string,
   input: { name?: string; phone?: string; position?: number; status?: MemberStatus },
 ): Promise<ActionResult> {
-  return adminAction(`/api/admin/members/${id}`, 'PATCH', input);
+  return runAdminMutation(`/api/admin/members/${id}`, 'PATCH', input);
 }
 
 export async function deleteMember(id: string): Promise<ActionResult> {
-  return adminAction(`/api/admin/members/${id}`, 'DELETE');
+  return runAdminMutation(`/api/admin/members/${id}`, 'DELETE');
 }
 
 // ─── Cycles ───────────────────────────────────────────────────────────────────
@@ -70,7 +85,7 @@ export async function createCycle(
     recipientMemberId: string;
   },
 ): Promise<ActionResult> {
-  return adminAction(`/api/admin/groups/${groupId}/cycles`, 'POST', input);
+  return runAdminMutation(`/api/admin/groups/${groupId}/cycles`, 'POST', input);
 }
 
 export async function updateCycle(
@@ -83,9 +98,9 @@ export async function updateCycle(
     status?: CycleStatus;
   },
 ): Promise<ActionResult> {
-  return adminAction(`/api/admin/cycles/${id}`, 'PATCH', input);
+  return runAdminMutation(`/api/admin/cycles/${id}`, 'PATCH', input);
 }
 
 export async function deleteCycle(id: string): Promise<ActionResult> {
-  return adminAction(`/api/admin/cycles/${id}`, 'DELETE');
+  return runAdminMutation(`/api/admin/cycles/${id}`, 'DELETE');
 }

--- a/tests/unit/admin-actions.test.ts
+++ b/tests/unit/admin-actions.test.ts
@@ -1,277 +1,374 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ActionResult } from '@/lib/types';
 
-vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+// `secureAction` is the migration target (graphify post-PR #68). Hoisted so
+// the `vi.mock` factory below resolves before `lib/admin-actions` is imported
+// at test time.
+const { secureActionMock, revalidatePathMock } = vi.hoisted(() => ({
+  secureActionMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
+vi.mock('@/lib/auth/backend-fetch', async (orig) => {
+  const actual = await orig<typeof import('@/lib/auth/backend-fetch')>();
+  return {
+    ...actual,
+    secureAction: secureActionMock,
+  };
+});
 
-function mockFetch(status: number, body: unknown) {
-  return vi.fn().mockResolvedValue({
-    ok: status >= 200 && status < 300,
-    status,
-    statusText: status === 200 ? 'OK' : 'Error',
-    json: async () => body,
-  });
-}
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
 
-// ─── Tests ────────────────────────────────────────────────────────────────────
+import { BackendUnauthorizedError } from '@/lib/auth/backend-fetch';
+import {
+  createCycle,
+  createGroup,
+  createMember,
+  deleteCycle,
+  deleteGroup,
+  deleteMember,
+  updateCycle,
+  updateGroup,
+  updateMember,
+} from '@/lib/admin-actions';
 
-describe('admin server actions', () => {
-  let originalAdminToken: string | undefined;
+beforeEach(() => {
+  secureActionMock.mockReset();
+  revalidatePathMock.mockReset();
+});
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.resetModules();
-    // Restore ADMIN_TOKEN to whatever it was before each test set it
-    if (originalAdminToken === undefined) {
-      delete process.env.ADMIN_TOKEN;
-    } else {
-      process.env.ADMIN_TOKEN = originalAdminToken;
-    }
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
-  // Admin actions require a non-empty ADMIN_TOKEN to attach the Authorization
-  // header. In CI/test the env var is unset, so we stub it for every test.
-  const STUB_TOKEN = 'test-admin-token';
-  function stubEnvAndFetch(status: number, body: unknown) {
-    originalAdminToken = process.env.ADMIN_TOKEN;
-    process.env.ADMIN_TOKEN = STUB_TOKEN;
-    const spy = mockFetch(status, body);
-    vi.stubGlobal('fetch', spy);
-    return spy;
-  }
+// ─── Groups ───────────────────────────────────────────────────────────────────
 
-  describe('createGroup', () => {
-    it('sends POST to /api/admin/groups with Authorization header', async () => {
-      const fetchSpy = stubEnvAndFetch(200, { id: 'group:1', name: 'Test Group' });
-      const { createGroup } = await import('@/lib/admin-actions');
+describe('createGroup', () => {
+  it('POSTs to /api/admin/groups via secureAction with the supplied body', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
 
-      await createGroup({ name: 'Test Group' });
+    const result: ActionResult = await createGroup({ name: 'Test Group' });
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/groups');
-      expect((opts.method as string).toUpperCase()).toBe('POST');
-      expect(opts.headers).toMatchObject({ Authorization: `Bearer ${STUB_TOKEN}` });
-    });
-
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, { id: 'group:1', name: 'Test Group' }));
-      const { createGroup } = await import('@/lib/admin-actions');
-      const result: ActionResult = await createGroup({ name: 'Test Group' });
-      expect(result.success).toBe(true);
-    });
-
-    it('returns { success: false, error } on non-OK response', async () => {
-      vi.stubGlobal('fetch', mockFetch(400, { error: 'name is required' }));
-      const { createGroup } = await import('@/lib/admin-actions');
-      const result: ActionResult = await createGroup({ name: '' });
-      expect(result.success).toBe(false);
-      if (!result.success) expect(result.error).toBeTruthy();
-    });
-
-    it('returns { success: false, error } when ADMIN_TOKEN is missing', async () => {
-      vi.stubGlobal('fetch', mockFetch(401, { error: 'Unauthorized' }));
-      const { createGroup } = await import('@/lib/admin-actions');
-      const result: ActionResult = await createGroup({ name: 'Test' });
-      expect(result.success).toBe(false);
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith('/api/admin/groups', {
+      method: 'POST',
+      body: { name: 'Test Group' },
     });
   });
 
-  describe('updateGroup', () => {
-    it('sends PATCH to /api/admin/groups/{id}', async () => {
-      const fetchSpy = mockFetch(200, {});
-      vi.stubGlobal('fetch', fetchSpy);
-      const { updateGroup } = await import('@/lib/admin-actions');
+  it('revalidates root and /admin on success so listings refresh', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
 
-      await updateGroup('group:1', { name: 'Renamed' });
+    await createGroup({ name: 'Test Group' });
 
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/groups/');
-      expect((opts.method as string).toUpperCase()).toBe('PATCH');
+    expect(revalidatePathMock).toHaveBeenCalledWith('/');
+    expect(revalidatePathMock).toHaveBeenCalledWith('/admin');
+  });
+
+  it('returns { success: false, error } on non-OK and skips revalidation', async () => {
+    secureActionMock.mockResolvedValueOnce({
+      success: false,
+      error: 'name is required',
+      status: 400,
     });
 
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, {}));
-      const { updateGroup } = await import('@/lib/admin-actions');
-      const result = await updateGroup('group:1', { name: 'Renamed' });
-      expect(result.success).toBe(true);
-    });
+    const result: ActionResult = await createGroup({ name: '' });
 
-    it('returns { success: false, error } on 404', async () => {
-      vi.stubGlobal('fetch', mockFetch(404, { error: 'not found' }));
-      const { updateGroup } = await import('@/lib/admin-actions');
-      const result = await updateGroup('group:999', { name: 'X' });
-      expect(result.success).toBe(false);
+    expect(result).toEqual({ success: false, error: 'name is required' });
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+
+  it('rethrows BackendUnauthorizedError so the caller can redirect to /signin', async () => {
+    secureActionMock.mockRejectedValueOnce(
+      new BackendUnauthorizedError('retry_exhausted'),
+    );
+
+    await expect(createGroup({ name: 'x' })).rejects.toBeInstanceOf(
+      BackendUnauthorizedError,
+    );
+  });
+});
+
+describe('updateGroup', () => {
+  it('PATCHes /api/admin/groups/:id with the supplied patch', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    const result = await updateGroup('group:1', { name: 'Renamed' });
+
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith('/api/admin/groups/group:1', {
+      method: 'PATCH',
+      body: { name: 'Renamed' },
     });
   });
 
-  describe('deleteGroup', () => {
-    it('sends DELETE to /api/admin/groups/{id}', async () => {
-      const fetchSpy = mockFetch(200, {});
-      vi.stubGlobal('fetch', fetchSpy);
-      const { deleteGroup } = await import('@/lib/admin-actions');
-
-      await deleteGroup('group:1');
-
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/groups/');
-      expect((opts.method as string).toUpperCase()).toBe('DELETE');
+  it('returns { success: false, error } on 404', async () => {
+    secureActionMock.mockResolvedValueOnce({
+      success: false,
+      error: 'not found',
+      status: 404,
     });
 
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, {}));
-      const { deleteGroup } = await import('@/lib/admin-actions');
-      const result = await deleteGroup('group:1');
-      expect(result.success).toBe(true);
-    });
+    const result = await updateGroup('group:999', { name: 'X' });
 
-    it('returns { success: false, error } on 409 conflict', async () => {
-      vi.stubGlobal('fetch', mockFetch(409, { error: 'group has active cycles' }));
-      const { deleteGroup } = await import('@/lib/admin-actions');
-      const result = await deleteGroup('group:1');
-      expect(result.success).toBe(false);
-      if (!result.success) expect(result.error).toBeTruthy();
+    expect(result).toEqual({ success: false, error: 'not found' });
+  });
+});
+
+describe('deleteGroup', () => {
+  it('DELETEs /api/admin/groups/:id with no body', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    const result = await deleteGroup('group:1');
+
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith('/api/admin/groups/group:1', {
+      method: 'DELETE',
+      body: undefined,
     });
   });
 
-  describe('createMember', () => {
-    it('sends POST to /api/admin/groups/{groupId}/members', async () => {
-      const fetchSpy = stubEnvAndFetch(200, { id: 'member:1' });
-      const { createMember } = await import('@/lib/admin-actions');
-
-      await createMember('group:1', { name: 'Alice', phone: '2349000000001', position: 1 });
-
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/groups/');
-      expect(url).toContain('/members');
-      expect((opts.method as string).toUpperCase()).toBe('POST');
-      expect(opts.headers).toMatchObject({ Authorization: `Bearer ${STUB_TOKEN}` });
+  it('returns { success: false, error } on 409 conflict', async () => {
+    secureActionMock.mockResolvedValueOnce({
+      success: false,
+      error: 'group has active cycles',
+      status: 409,
     });
 
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, { id: 'member:1' }));
-      const { createMember } = await import('@/lib/admin-actions');
-      const result = await createMember('group:1', { name: 'Alice', phone: '2349000000001', position: 1 });
-      expect(result.success).toBe(true);
+    const result = await deleteGroup('group:1');
+
+    expect(result).toEqual({
+      success: false,
+      error: 'group has active cycles',
+    });
+  });
+});
+
+// ─── Members ──────────────────────────────────────────────────────────────────
+
+describe('createMember', () => {
+  it('POSTs to /api/admin/groups/:groupId/members', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    const result = await createMember('group:1', {
+      name: 'Alice',
+      phone: '2349000000001',
+      position: 1,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith(
+      '/api/admin/groups/group:1/members',
+      {
+        method: 'POST',
+        body: { name: 'Alice', phone: '2349000000001', position: 1 },
+      },
+    );
+  });
+
+  it('returns { success: false, error } on validation failure', async () => {
+    secureActionMock.mockResolvedValueOnce({
+      success: false,
+      error: 'phone is invalid',
+      status: 400,
+    });
+
+    const result = await createMember('group:1', {
+      name: 'Alice',
+      phone: 'bad',
+      position: 1,
+    });
+
+    expect(result).toEqual({ success: false, error: 'phone is invalid' });
+  });
+});
+
+describe('updateMember', () => {
+  it('PATCHes /api/admin/members/:id', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    const result = await updateMember('member:1', { name: 'Bob' });
+
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith(
+      '/api/admin/members/member:1',
+      { method: 'PATCH', body: { name: 'Bob' } },
+    );
+  });
+
+  it('forwards a status patch to the backend', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    await updateMember('member:1', { status: 'inactive' });
+
+    expect(secureActionMock).toHaveBeenCalledWith(
+      '/api/admin/members/member:1',
+      { method: 'PATCH', body: { status: 'inactive' } },
+    );
+  });
+});
+
+describe('deleteMember', () => {
+  it('DELETEs /api/admin/members/:id with no body', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    const result = await deleteMember('member:1');
+
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith(
+      '/api/admin/members/member:1',
+      { method: 'DELETE', body: undefined },
+    );
+  });
+
+  it('returns { success: false, error } on 404', async () => {
+    secureActionMock.mockResolvedValueOnce({
+      success: false,
+      error: 'member not found',
+      status: 404,
+    });
+
+    const result = await deleteMember('member:missing');
+
+    expect(result).toEqual({ success: false, error: 'member not found' });
+  });
+});
+
+// ─── Cycles ───────────────────────────────────────────────────────────────────
+
+describe('createCycle', () => {
+  it('POSTs to /api/admin/groups/:groupId/cycles with the full payload', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    const result = await createCycle('group:1', {
+      cycleNumber: 1,
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+      contributionPerMember: 500000,
+      recipientMemberId: 'member:1',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith(
+      '/api/admin/groups/group:1/cycles',
+      {
+        method: 'POST',
+        body: {
+          cycleNumber: 1,
+          startDate: '2026-01-01',
+          endDate: '2026-01-31',
+          contributionPerMember: 500000,
+          recipientMemberId: 'member:1',
+        },
+      },
+    );
+  });
+});
+
+describe('updateCycle', () => {
+  it('PATCHes /api/admin/cycles/:id with the supplied patch', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    const result = await updateCycle('cycle:1', { status: 'closed' });
+
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith('/api/admin/cycles/cycle:1', {
+      method: 'PATCH',
+      body: { status: 'closed' },
     });
   });
 
-  describe('updateMember', () => {
-    it('sends PATCH to /api/admin/members/{id}', async () => {
-      const fetchSpy = mockFetch(200, {});
-      vi.stubGlobal('fetch', fetchSpy);
-      const { updateMember } = await import('@/lib/admin-actions');
-
-      await updateMember('member:1', { name: 'Bob' });
-
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/members/');
-      expect((opts.method as string).toUpperCase()).toBe('PATCH');
+  it('returns { success: false, error } when the backend rejects the patch', async () => {
+    secureActionMock.mockResolvedValueOnce({
+      success: false,
+      error: 'cannot reopen a closed cycle',
+      status: 409,
     });
 
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, {}));
-      const { updateMember } = await import('@/lib/admin-actions');
-      const result = await updateMember('member:1', { name: 'Bob' });
-      expect(result.success).toBe(true);
+    const result = await updateCycle('cycle:1', { status: 'active' });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'cannot reopen a closed cycle',
+    });
+  });
+});
+
+describe('deleteCycle', () => {
+  it('DELETEs /api/admin/cycles/:id with no body', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    const result = await deleteCycle('cycle:1');
+
+    expect(result).toEqual({ success: true });
+    expect(secureActionMock).toHaveBeenCalledWith('/api/admin/cycles/cycle:1', {
+      method: 'DELETE',
+      body: undefined,
     });
   });
 
-  describe('deleteMember', () => {
-    it('sends DELETE to /api/admin/members/{id}', async () => {
-      const fetchSpy = mockFetch(200, {});
-      vi.stubGlobal('fetch', fetchSpy);
-      const { deleteMember } = await import('@/lib/admin-actions');
-
-      await deleteMember('member:1');
-
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/members/');
-      expect((opts.method as string).toUpperCase()).toBe('DELETE');
+  it('returns { success: false, error } on 409 when payments exist', async () => {
+    secureActionMock.mockResolvedValueOnce({
+      success: false,
+      error: 'cycle has confirmed payments',
+      status: 409,
     });
 
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, {}));
-      const { deleteMember } = await import('@/lib/admin-actions');
-      const result = await deleteMember('member:1');
-      expect(result.success).toBe(true);
+    const result = await deleteCycle('cycle:1');
+
+    expect(result).toEqual({
+      success: false,
+      error: 'cycle has confirmed payments',
     });
   });
+});
 
-  describe('createCycle', () => {
-    it('sends POST to /api/admin/groups/{groupId}/cycles', async () => {
-      const fetchSpy = stubEnvAndFetch(200, { id: 'cycle:1' });
-      const { createCycle } = await import('@/lib/admin-actions');
+// ─── Cross-cutting behaviour ──────────────────────────────────────────────────
 
-      await createCycle('group:1', {
+describe('revalidation', () => {
+  it('skips revalidation on a failed mutation so stale pages are not nuked', async () => {
+    secureActionMock.mockResolvedValueOnce({
+      success: false,
+      error: 'boom',
+      status: 500,
+    });
+
+    await deleteCycle('cycle:1');
+
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+
+  it('revalidates root and /admin once on every successful mutation', async () => {
+    secureActionMock.mockResolvedValueOnce({ success: true });
+
+    await deleteMember('member:1');
+
+    expect(revalidatePathMock).toHaveBeenCalledTimes(2);
+    expect(revalidatePathMock).toHaveBeenNthCalledWith(1, '/');
+    expect(revalidatePathMock).toHaveBeenNthCalledWith(2, '/admin');
+  });
+});
+
+describe('auth failure propagation', () => {
+  it.each([
+    ['updateGroup', () => updateGroup('group:1', { name: 'x' })],
+    ['deleteMember', () => deleteMember('member:1')],
+    ['createCycle', () =>
+      createCycle('group:1', {
         cycleNumber: 1,
         startDate: '2026-01-01',
         endDate: '2026-01-31',
         contributionPerMember: 500000,
         recipientMemberId: 'member:1',
-      });
+      }),
+    ],
+  ])('%s rethrows BackendUnauthorizedError', async (_label, run) => {
+    secureActionMock.mockRejectedValueOnce(
+      new BackendUnauthorizedError('refresh_failed'),
+    );
 
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/groups/');
-      expect(url).toContain('/cycles');
-      expect((opts.method as string).toUpperCase()).toBe('POST');
-      expect(opts.headers).toMatchObject({ Authorization: `Bearer ${STUB_TOKEN}` });
-    });
-
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, { id: 'cycle:1' }));
-      const { createCycle } = await import('@/lib/admin-actions');
-      const result = await createCycle('group:1', {
-        cycleNumber: 1,
-        startDate: '2026-01-01',
-        endDate: '2026-01-31',
-        contributionPerMember: 500000,
-        recipientMemberId: 'member:1',
-      });
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe('updateCycle', () => {
-    it('sends PATCH to /api/admin/cycles/{id}', async () => {
-      const fetchSpy = mockFetch(200, {});
-      vi.stubGlobal('fetch', fetchSpy);
-      const { updateCycle } = await import('@/lib/admin-actions');
-
-      await updateCycle('cycle:1', { status: 'closed' });
-
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/cycles/');
-      expect((opts.method as string).toUpperCase()).toBe('PATCH');
-    });
-
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, {}));
-      const { updateCycle } = await import('@/lib/admin-actions');
-      const result = await updateCycle('cycle:1', { status: 'closed' });
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe('deleteCycle', () => {
-    it('sends DELETE to /api/admin/cycles/{id}', async () => {
-      const fetchSpy = mockFetch(200, {});
-      vi.stubGlobal('fetch', fetchSpy);
-      const { deleteCycle } = await import('@/lib/admin-actions');
-
-      await deleteCycle('cycle:1');
-
-      const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/api/admin/cycles/');
-      expect((opts.method as string).toUpperCase()).toBe('DELETE');
-    });
-
-    it('returns { success: true } on 200', async () => {
-      vi.stubGlobal('fetch', mockFetch(200, {}));
-      const { deleteCycle } = await import('@/lib/admin-actions');
-      const result = await deleteCycle('cycle:1');
-      expect(result.success).toBe(true);
-    });
+    await expect(run()).rejects.toBeInstanceOf(BackendUnauthorizedError);
   });
 });


### PR DESCRIPTION
## Summary

`lib/admin-actions.ts` used a private `adminAction(path, method, input?)` helper that wrapped the legacy `apiAction` from `lib/http` with a static `ADMIN_TOKEN` from `lib/config`. That path did plain admin-token auth and never refreshed a JWT, so admin mutations were the **only authenticated mutations in the codebase missing the Plan-3 401-retry-via-refresh flow**.

This PR replaces the local helper with a thin `runAdminMutation` wrapper that calls `secureAction(path, { method, body })` from `lib/auth/backend-fetch` (the same wrapper `lib/actions/receipts.ts` already uses), runs `revalidatePath('/')` + `revalidatePath('/admin')` on success, and maps `SecureActionResult` back to the legacy `ActionResult` shape so existing consumers keep working with zero touchups.

## Behaviour preserved

All 9 public function signatures unchanged: `createGroup`, `updateGroup`, `deleteGroup`, `createMember`, `updateMember`, `deleteMember`, `createCycle`, `updateCycle`, `deleteCycle`. All 6 consumers under `app/(app)/admin/_components/*` (`group-form`, `groups-section`, `member-form`, `members-section`, `cycle-form`, `cycles-section`) still branch on `result.success` / `result.error` exactly as before. `BackendUnauthorizedError` propagates naturally so existing reauth-redirect plumbing fires consistently.

## Behaviour added

- Admin mutations now retry once on 401 via the refresh flow (same as every other authenticated mutation).
- `BackendUnauthorizedError` surfaces for the consumer-side reauth redirect path (`/signin?reauth=1`).

## Tests

`tests/unit/admin-actions.test.ts` rewritten to mock `secureAction` via `vi.hoisted` + static top-level imports. The prior per-test `await import` / `resetModules` dance only existed because the old code read `ADMIN_TOKEN` at module load — no longer needed.

- 24 test cases preserved (same count as before).
- **Dropped:** header-attach and `ADMIN_TOKEN`-missing tests (those concerns now belong to `secureAction` and are covered by `tests/unit/backend-fetch.test.ts`).
- **Added:** `BackendUnauthorizedError` rethrow tests across 3 representative actions; negative "success skips revalidation" test; "revalidates `/` then `/admin`" ordering assertion.

## Why now

Surfaced by `/graphify` analysis post-PR #68 at confidence 0.80 cross-folder similarity. Closes the auth-refresh gap on the last remaining mutation surface in the FE.

## Follow-up (out of scope here, FE-7 candidate)

`app/(app)/admin/page.tsx` still imports `ADMIN_TOKEN` from `lib/config.ts` to render a "warning: admin mutations will be rejected" banner. With JWT-only mutations now in place, that banner is misleading. Full `ADMIN_TOKEN` removal (config, `.env.example`, README, RUNBOOK, CODEMAPS) belongs in the FE-7 cleanup pass per the README's own note.

## Test plan

- [x] `npx vitest run` — 50/50 test files, 498/498 tests pass (+2 net from the rewritten test file)
- [x] `grep "function adminAction" lib/admin-actions.ts` returns no matches
- [x] `grep "secureAction" lib/admin-actions.ts` shows the new wrapper
- [x] All 6 admin-component consumers unchanged