### PR TITLE
[FIX] - Drop legacy "Ajo" prefix from metadata description strings

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,17 +31,17 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: "PoolPay",
-  description: "Ajo savings group management dashboard",
+  description: "Savings group management dashboard",
   openGraph: {
     title: "PoolPay",
-    description: "Ajo savings group management dashboard",
+    description: "Savings group management dashboard",
     siteName: "PoolPay",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "PoolPay",
-    description: "Ajo savings group management dashboard",
+    description: "Savings group management dashboard",
   },
 };
 

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -4,7 +4,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "PoolPay",
     short_name: "PoolPay",
-    description: "Ajo savings group management dashboard",
+    description: "Savings group management dashboard",
     start_url: "/",
     display: "standalone",
     // sRGB hex of the rendered light-mode `--background` token in


### PR DESCRIPTION
## Summary

- Strip the leading `Ajo ` from every `description` string in `app/layout.tsx` (root, OpenGraph, Twitter) and `app/manifest.ts`.
- The pre-rebrand product name was still the leading word in Google search snippets, every social-link unfurl card, and the Android install prompt.
- All four strings now read `Savings group management dashboard`. Title, brand assets, and substantive user-facing copy untouched.

## Why now

Audit of the Digital Brain vault surfaced that "Ajo" still ships on the metadata/install surface — the highest-visibility leakage point outside the app shell itself. Body and surface copy (signin, signup, member empty-state) deliberately retains "ajo" as a localisation gloss for the Nigerian audience, so they are intentionally excluded from this PR.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm test` green (no test asserts on the old description string — pre-checked)
- [ ] Open `/` in dev, View Page Source, confirm `<meta name="description">`, `og:description`, `twitter:description` all read `Savings group management dashboard`
- [ ] Curl `/manifest.webmanifest` and confirm the `description` field
- [ ] Optional: Facebook Sharing Debugger / Twitter Card Validator on a preview URL once deployed